### PR TITLE
v3.0.2: quality, coverage & honesty pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## [3.0.2] - 2026-05-26
+
+### Removed
+
+- `search_papers` `has_results` filter and `get_paper` `include_results` parameter. These exposed the
+  `paper_results` benchmark-extraction table, which is abstract-only (~10% corpus coverage) and not
+  reliable enough to surface. The structured-extraction filters (`dataset`, `method_name`,
+  `method_category`, `task`, `task_category`, `contribution_type`) and `verbose` are unaffected — they
+  read columns on the papers table, not `paper_results`. Server-side data is left dormant (reversible).
+
+### Fixed
+
+- `get_paper` now actually forwards `fields` and `verbose` to the API — field selection / the verbose
+  28-field shape were previously declared but silently ignored on the default JSON path.
+- `get_paper` `arxiv_ids` is now capped at 50 in the schema (matches the documented batch limit).
+- `init` wizard uses `path.dirname` instead of manual `/`-slicing, fixing config-dir creation on Windows.
+
+### Added
+
+- Request timeout on all API calls (default 30s, override with `SF_API_TIMEOUT_MS`). A stalled backend
+  now returns a clear "timed out" error instead of hanging the tool call indefinitely.
+
+### Changed
+
+- Corpus size corrected to **600,000+** across the README, package description, and tool descriptions
+  (was inconsistently 512k / 560k).
+- Rate-limit table corrected: `get_paper` 60→**30/min** (the default batch path), `get_field_orientation`
+  5→**20/min**. README parameter tables fixed for `get_paper`, `co_author_graph`, and `get_field_orientation`.
+- Removed stale references to retired tools (`discover_authors`, `search_by_method`, and the post-install
+  `check_connection` hint).
+
+### Internal
+
+- Replaced the string-grep "tests" with a real behavioral suite (tool registry, HTTP client, and tool
+  handlers exercised with a mocked `fetch`). Test runner switched to `tsx` so it runs on Node 18/20/22
+  (the previous `--experimental-strip-types` flag is 22.6+ only, which had left CI red).
+- Bumped `@modelcontextprotocol/sdk` to `^1.29`; `npm audit` is clean. Added a `prepublishOnly` guard
+  (`build && test`) and a `bugs` URL.
+
 ## [3.0.1] - 2026-05-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Scholar Feed MCP Server
 
-Search 560,000+ CS/AI/ML research papers with LLM-powered novelty analysis from Claude Code, Cursor, or any MCP client.
+Search 600,000+ CS/AI/ML research papers with LLM-powered novelty analysis from Claude Code, Cursor, or any MCP client.
 
 [Scholar Feed](https://www.scholarfeed.org) indexes arXiv papers daily and ranks them using a multi-signal scoring system (recency, citation velocity, institutional reputation, code availability). Each paper has an LLM-generated summary and novelty score.
 
@@ -131,8 +131,8 @@ To add an API key, add `"env": { "SF_API_KEY": "sf_your_key_here" }` to the conf
 
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
-| `search_papers` | Semantic + keyword search with filters. Also does similar-paper discovery, citation-scoped search, and trending. | `q`, `category`, `novelty_min`, `days`, `sort`, `anchor_paper_id`, `scope_to_citations_of`, `mode`, `method_category`, `task`, `dataset`, `contribution_type`, `task_category`, `has_results`, `cursor`, `limit` |
-| `get_paper` | Get full paper details by arXiv ID. Also handles batch lookup and BibTeX export. | `arxiv_id`, `arxiv_ids`, `format`, `fields` |
+| `search_papers` | Semantic + keyword search with filters. Also does similar-paper discovery, citation-scoped search, and trending. | `q`, `category`, `novelty_min`, `days`, `sort`, `anchor_paper_id`, `scope_to_citations_of`, `mode`, `method_category`, `task`, `dataset`, `contribution_type`, `task_category`, `cursor`, `limit` |
+| `get_paper` | Get full paper details by arXiv ID. Also handles batch lookup and BibTeX export. | `arxiv_ids`, `format`, `fields`, `verbose` |
 | `get_citations` | Citation graph (outgoing refs or incoming citations) | `arxiv_id`, `direction`, `limit`, `fields` |
 | `fetch_fulltext` | Extract results/experiments from LaTeX source | `arxiv_id` |
 
@@ -141,7 +141,7 @@ To add an API key, add `"env": { "SF_API_KEY": "sf_your_key_here" }` to the conf
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
 | `find_author` | Find researchers by topic/name query, or retrieve a profile by ID. | `q`, `id`, `field`, `limit` |
-| `co_author_graph` | Co-authorship neighborhood for an author | `author_id`, `limit` |
+| `co_author_graph` | Co-authorship neighborhood for an author | `author_ids`, `window_years` |
 
 ### Embeddings
 
@@ -153,7 +153,7 @@ To add an API key, add `"env": { "SF_API_KEY": "sf_your_key_here" }` to the conf
 
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
-| `get_field_orientation` | Cheap retrieval orientation for a research area — top papers, subfields, open problems. No Pro quota. | `topic` |
+| `get_field_orientation` | Cheap retrieval orientation for a research area — top papers, subfields, open problems. No Pro quota. | `topic`, `limit` |
 
 ## Novelty Score
 
@@ -173,13 +173,13 @@ Use `novelty_min: 0.5` in `search_papers` to filter for genuinely novel work.
 | Endpoint | Limit |
 |----------|-------|
 | `search_papers` | 30/min |
-| `get_paper` | 60/min |
+| `get_paper` | 30/min |
 | `get_citations` | 30/min |
 | `fetch_fulltext` | 10/min |
 | `find_author` | 20/min |
 | `co_author_graph` | 20/min |
 | `embed_text` | 30/min |
-| `get_field_orientation` | 5/min |
+| `get_field_orientation` | 20/min |
 
 Responses include `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "scholar-feed-mcp",
-  "version": "1.3.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scholar-feed-mcp",
-      "version": "1.3.1",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.27.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^3.24.0"
       },
       "bin": {
@@ -18,6 +18,7 @@
       "devDependencies": {
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
+        "tsx": "^4.22.3",
         "typescript": "^5.5.0"
       },
       "engines": {
@@ -467,9 +468,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -518,9 +519,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -1399,12 +1400,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1423,9 +1424,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -1605,9 +1606,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1656,9 +1657,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1912,9 +1913,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -1936,9 +1937,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2036,9 +2037,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -2484,6 +2485,509 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/type-is": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scholar-feed-mcp",
-  "version": "3.0.1",
-  "description": "MCP server for Scholar Feed — search 512k+ CS/AI papers with LLM-powered analysis",
+  "version": "3.0.2",
+  "description": "MCP server for Scholar Feed — search 600,000+ CS/AI/ML papers with LLM-powered analysis",
   "type": "module",
   "license": "MIT",
   "author": "Scholar Feed <hello@scholarfeed.org>",
@@ -9,6 +9,9 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/YGao2005/scholar-feed-mcp"
+  },
+  "bugs": {
+    "url": "https://github.com/YGao2005/scholar-feed-mcp/issues"
   },
   "keywords": [
     "mcp",
@@ -30,15 +33,17 @@
     "build": "tsup src/index.ts --format esm --dts --clean --out-dir build",
     "dev": "tsup src/index.ts --format esm --watch --out-dir build",
     "typecheck": "tsc --noEmit",
-    "test": "node --test --experimental-strip-types src/__tests__/tools.test.ts"
+    "test": "node --import tsx --test src/__tests__/*.test.ts",
+    "prepublishOnly": "npm run build && npm test"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
     "tsup": "^8.0.0",
+    "tsx": "^4.22.3",
     "typescript": "^5.5.0"
   },
   "engines": {

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1,0 +1,124 @@
+/**
+ * HTTP client tests — exercise the real client with a mocked global fetch.
+ * Config is read at call time, so each test sets env and restores it after.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { client } from "../client.js";
+import { stubFetch, headerOf, type CapturedRequest } from "./helpers.js";
+
+const ENV_KEYS = ["SF_API_KEY", "SF_API_BASE_URL", "SF_API_TIMEOUT_MS"];
+
+function snapshotEnv(): Record<string, string | undefined> {
+  const snap: Record<string, string | undefined> = {};
+  for (const k of ENV_KEYS) snap[k] = process.env[k];
+  return snap;
+}
+
+function restoreEnv(snap: Record<string, string | undefined>): void {
+  for (const k of ENV_KEYS) {
+    const v = snap[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+}
+
+const TEST_BASE = "https://example.test/api/v1";
+
+/** Run fn with a stubbed fetch + clean env, always restoring after. */
+async function withStub(
+  opts: Parameters<typeof stubFetch>[0],
+  env: Record<string, string | undefined>,
+  fn: (calls: CapturedRequest[]) => Promise<void>
+): Promise<void> {
+  const snap = snapshotEnv();
+  for (const k of ENV_KEYS) delete process.env[k];
+  process.env.SF_API_BASE_URL = TEST_BASE;
+  for (const [k, v] of Object.entries(env)) {
+    if (v !== undefined) process.env[k] = v;
+  }
+  const f = stubFetch(opts);
+  try {
+    await fn(f.calls);
+  } finally {
+    f.restore();
+    restoreEnv(snap);
+  }
+}
+
+describe("client auth headers", () => {
+  it("attaches a Bearer header when SF_API_KEY is set", async () => {
+    await withStub({}, { SF_API_KEY: "sf_test_key" }, async (calls) => {
+      await client.get("/public/health");
+      assert.strictEqual(headerOf(calls[0], "Authorization"), "Bearer sf_test_key");
+    });
+  });
+
+  it("omits the Authorization header when no key is set", async () => {
+    await withStub({}, {}, async (calls) => {
+      await client.get("/public/health");
+      assert.strictEqual(headerOf(calls[0], "Authorization"), undefined);
+    });
+  });
+});
+
+describe("client URL building", () => {
+  it("honors SF_API_BASE_URL and appends flat query params", async () => {
+    await withStub({}, {}, async (calls) => {
+      await client.get("/public/papers/search", { q: "rag", limit: "5" });
+      const url = new URL(calls[0].url);
+      assert.strictEqual(url.origin + url.pathname, `${TEST_BASE}/public/papers/search`);
+      assert.strictEqual(url.searchParams.get("q"), "rag");
+      assert.strictEqual(url.searchParams.get("limit"), "5");
+    });
+  });
+
+  it("getWithParams emits repeated array params", async () => {
+    await withStub({}, {}, async (calls) => {
+      const search = new URLSearchParams();
+      search.append("arxiv_ids[]", "A");
+      search.append("arxiv_ids[]", "B");
+      search.set("verbose", "true");
+      await client.getWithParams("/public/papers", search);
+      const url = new URL(calls[0].url);
+      assert.deepStrictEqual(url.searchParams.getAll("arxiv_ids[]"), ["A", "B"]);
+      assert.strictEqual(url.searchParams.get("verbose"), "true");
+    });
+  });
+});
+
+describe("client error mapping", () => {
+  it("maps 401 to an actionable auth message", async () => {
+    await withStub({ status: 401, body: "unauthorized" }, {}, async () => {
+      await assert.rejects(client.get("/x"), /Authentication failed/);
+    });
+  });
+
+  it("maps 429 to a rate-limit message", async () => {
+    await withStub({ status: 429, body: "slow down" }, {}, async () => {
+      await assert.rejects(client.get("/x"), /Rate limit exceeded/);
+    });
+  });
+
+  it("hides the response body on other errors (no internal leak)", async () => {
+    await withStub({ status: 500, body: "SECRET_INTERNAL_TRACE" }, {}, async () => {
+      await assert.rejects(client.get("/x"), (err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        assert.match(msg, /HTTP 500/);
+        assert.doesNotMatch(msg, /SECRET_INTERNAL_TRACE/);
+        return true;
+      });
+    });
+  });
+});
+
+describe("client timeout", () => {
+  it("maps an aborted/timed-out fetch to a clear message", async () => {
+    const timeoutErr = new Error("aborted");
+    timeoutErr.name = "TimeoutError";
+    await withStub({ throwError: timeoutErr }, {}, async () => {
+      await assert.rejects(client.get("/x"), /timed out/i);
+    });
+  });
+});

--- a/src/__tests__/handlers.test.ts
+++ b/src/__tests__/handlers.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tool-handler tests — register the real tools on a fake server, invoke the
+ * captured handlers with a mocked fetch, and assert the outgoing request.
+ * These cover the high-branch tools and guard the v3.0.2 param removals.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { registerAllTools } from "../tools/index.js";
+import {
+  makeFakeServer,
+  stubFetch,
+  type ToolHandler,
+  type CapturedRequest,
+} from "./helpers.js";
+
+const TEST_BASE = "https://example.test/api/v1";
+const ENV_KEYS = ["SF_API_KEY", "SF_API_BASE_URL", "SF_API_TIMEOUT_MS"];
+
+function buildTools(): Map<string, { inputSchema: Record<string, unknown>; handler: ToolHandler }> {
+  const { server, tools } = makeFakeServer();
+  registerAllTools(server);
+  const map = new Map<string, { inputSchema: Record<string, unknown>; handler: ToolHandler }>();
+  for (const [name, def] of tools) {
+    map.set(name, { inputSchema: def.inputSchema, handler: def.handler });
+  }
+  return map;
+}
+
+const TOOLS = buildTools();
+
+function handlerFor(name: string): ToolHandler {
+  const t = TOOLS.get(name);
+  if (!t) throw new Error(`tool not registered: ${name}`);
+  return t.handler;
+}
+
+function schemaFor(name: string): Record<string, unknown> {
+  const t = TOOLS.get(name);
+  if (!t) throw new Error(`tool not registered: ${name}`);
+  return t.inputSchema;
+}
+
+/** Invoke a handler with a stubbed fetch + clean env; return captured requests + result. */
+async function invoke(
+  name: string,
+  args: Record<string, unknown>,
+  opts?: Parameters<typeof stubFetch>[0]
+): Promise<{ calls: CapturedRequest[]; url: URL | undefined; result: Awaited<ReturnType<ToolHandler>> }> {
+  const snap: Record<string, string | undefined> = {};
+  for (const k of ENV_KEYS) {
+    snap[k] = process.env[k];
+    delete process.env[k];
+  }
+  process.env.SF_API_BASE_URL = TEST_BASE;
+  const f = stubFetch(opts);
+  try {
+    const result = await handlerFor(name)(args);
+    const url = f.calls.length > 0 ? new URL(f.calls[0].url) : undefined;
+    return { calls: f.calls, url, result };
+  } finally {
+    f.restore();
+    for (const k of ENV_KEYS) {
+      const v = snap[k];
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+describe("search_papers handler", () => {
+  it("defaults mode to semantic", async () => {
+    const { url } = await invoke("search_papers", { q: "test", page: 1, limit: 20 });
+    assert.ok(url);
+    assert.ok(url.pathname.endsWith("/public/papers/search"));
+    assert.strictEqual(url.searchParams.get("mode"), "semantic");
+    assert.strictEqual(url.searchParams.get("q"), "test");
+  });
+
+  it("passes sort=trending through", async () => {
+    const { url } = await invoke("search_papers", { q: "x", sort: "trending", page: 1, limit: 20 });
+    assert.strictEqual(url?.searchParams.get("sort"), "trending");
+  });
+
+  it("anchor mode forwards anchor_paper_id", async () => {
+    const { url } = await invoke("search_papers", { anchor_paper_id: "2407.15831", page: 1, limit: 20 });
+    assert.strictEqual(url?.searchParams.get("anchor_paper_id"), "2407.15831");
+  });
+
+  it("no longer exposes has_results in its schema", () => {
+    assert.ok(!("has_results" in schemaFor("search_papers")));
+  });
+});
+
+describe("get_paper handler", () => {
+  it("batch fetch uses repeated arxiv_ids[] and never sends include_results", async () => {
+    const { url } = await invoke("get_paper", { arxiv_ids: ["A", "B"] });
+    assert.ok(url);
+    assert.ok(url.pathname.endsWith("/public/papers"));
+    assert.deepStrictEqual(url.searchParams.getAll("arxiv_ids[]"), ["A", "B"]);
+    assert.strictEqual(url.searchParams.has("include_results"), false);
+  });
+
+  it("forwards verbose and fields (previously inert)", async () => {
+    const verbose = await invoke("get_paper", { arxiv_ids: ["A"], verbose: true });
+    assert.strictEqual(verbose.url?.searchParams.get("verbose"), "true");
+
+    const fields = await invoke("get_paper", { arxiv_ids: ["A"], fields: "arxiv_id,title" });
+    assert.strictEqual(fields.url?.searchParams.get("fields"), "arxiv_id,title");
+  });
+
+  it("bibtex mode hits the single-paper route and returns the bib string", async () => {
+    const { url, result } = await invoke(
+      "get_paper",
+      { arxiv_ids: ["A", "B"], format: "bibtex" },
+      { json: { bibtex: "@article{x}", count: 1, not_found: [] } }
+    );
+    assert.ok(url?.pathname.endsWith("/public/papers/A"));
+    assert.strictEqual(url?.searchParams.get("format"), "bibtex");
+    assert.strictEqual(result.content[0].text, "@article{x}");
+  });
+
+  it("schema drops include_results but keeps fields and verbose", () => {
+    const schema = schemaFor("get_paper");
+    assert.ok(!("include_results" in schema));
+    assert.ok("verbose" in schema);
+    assert.ok("fields" in schema);
+  });
+});
+
+describe("find_author handler", () => {
+  it("rejects when neither q nor id is provided", async () => {
+    const { result } = await invoke("find_author", {});
+    assert.strictEqual(result.isError, true);
+  });
+
+  it("rejects when both q and id are provided", async () => {
+    const { result } = await invoke("find_author", { q: "x", id: 5 });
+    assert.strictEqual(result.isError, true);
+  });
+
+  it("q-mode hits /authors/discover", async () => {
+    const { url } = await invoke("find_author", { q: "efficient transformers", limit: 20 });
+    assert.ok(url?.pathname.endsWith("/public/authors/discover"));
+    assert.strictEqual(url?.searchParams.get("q"), "efficient transformers");
+  });
+
+  it("id-mode hits /authors/{id}", async () => {
+    const { url } = await invoke("find_author", { id: 42 });
+    assert.ok(url?.pathname.endsWith("/public/authors/42"));
+  });
+});

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -1,0 +1,92 @@
+/**
+ * Test helpers — a fake McpServer that captures tool registrations, and a
+ * fetch stub for asserting outgoing requests. No external test dependencies;
+ * this file is not a test itself (the runner only picks up *.test.ts).
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export type ToolResult = {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+};
+
+export type ToolHandler = (args: Record<string, unknown>) => Promise<ToolResult>;
+
+export interface CapturedTool {
+  description: string;
+  inputSchema: Record<string, unknown>;
+  handler: ToolHandler;
+}
+
+/**
+ * A minimal McpServer double that records registerTool(name, def, handler).
+ * Cast to McpServer so the real register functions accept it; at runtime only
+ * registerTool is exercised.
+ */
+export function makeFakeServer(): {
+  server: McpServer;
+  tools: Map<string, CapturedTool>;
+} {
+  const tools = new Map<string, CapturedTool>();
+  const fake = {
+    registerTool(
+      name: string,
+      def: { description: string; inputSchema: Record<string, unknown> },
+      handler: ToolHandler
+    ): void {
+      tools.set(name, {
+        description: def.description,
+        inputSchema: def.inputSchema,
+        handler,
+      });
+    },
+  };
+  return { server: fake as unknown as McpServer, tools };
+}
+
+export interface CapturedRequest {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+/**
+ * Replace globalThis.fetch with a stub that records every request and returns
+ * a canned response (or throws). Call restore() when done.
+ */
+export function stubFetch(opts?: {
+  status?: number;
+  json?: unknown;
+  body?: string;
+  throwError?: Error;
+}): { calls: CapturedRequest[]; restore: () => void } {
+  const calls: CapturedRequest[] = [];
+  const original = globalThis.fetch;
+  const status = opts?.status ?? 200;
+  const payload = opts?.body ?? JSON.stringify(opts?.json ?? { ok: true });
+
+  globalThis.fetch = (async (
+    input: string | URL | Request,
+    init?: RequestInit
+  ): Promise<Response> => {
+    calls.push({ url: String(input), init });
+    if (opts?.throwError) throw opts.throwError;
+    return new Response(payload, {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+/** Read a header value off a captured request's plain-object headers. */
+export function headerOf(req: CapturedRequest, name: string): string | undefined {
+  const headers = (req.init?.headers ?? {}) as Record<string, string>;
+  return headers[name];
+}

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -1,8 +1,9 @@
 /**
- * Basic tests for Scholar Feed MCP server.
+ * Tool-registry + packaging tests.
  *
- * These tests verify tool registration and client module structure
- * without hitting the live API (no SF_API_KEY required).
+ * Unlike the old string-grep suite, the registry test actually runs
+ * registerAllTools() against a fake server and asserts the exact v3 surface,
+ * so it can't silently drift when tools are added/removed.
  */
 
 import { describe, it } from "node:test";
@@ -10,12 +11,44 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { registerAllTools } from "../tools/index.js";
+import { makeFakeServer } from "./helpers.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkgPath = resolve(__dirname, "../../package.json");
 
+/** The exact v3 tool surface. Changing the surface must update this list. */
+const EXPECTED_TOOLS = [
+  "search_papers",
+  "get_paper",
+  "get_citations",
+  "fetch_fulltext",
+  "find_author",
+  "co_author_graph",
+  "embed_text",
+  "get_field_orientation",
+];
+
+/** Active tool source files that must never use console.log (corrupts stdio). */
+const ACTIVE_TOOL_FILES = [
+  "search",
+  "get_paper",
+  "citations",
+  "fulltext",
+  "find_author",
+  "co_author_graph",
+  "embed_text",
+  "get_field_orientation",
+];
+
 describe("package.json", () => {
-  const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+    name: string;
+    license: string;
+    bin: Record<string, string>;
+    engines: { node: string };
+    files: string[];
+  };
 
   it("has correct name", () => {
     assert.strictEqual(pkg.name, "scholar-feed-mcp");
@@ -38,72 +71,42 @@ describe("package.json", () => {
   });
 });
 
-describe("tool files", () => {
-  const toolDir = resolve(__dirname, "../tools");
-  const barrelPath = resolve(toolDir, "index.ts");
-  const barrel = readFileSync(barrelPath, "utf-8");
-
-  // Extract tool module names from the barrel imports
-  const importPattern = /from\s+"\.\/(\w+)\.js"/g;
-  const toolModules: string[] = [];
-  let match: RegExpExecArray | null;
-  while ((match = importPattern.exec(barrel)) !== null) {
-    toolModules.push(match[1]);
-  }
-
-  it("has 15 tool modules registered", () => {
-    assert.strictEqual(toolModules.length, 15);
+describe("tool registry", () => {
+  it("registers exactly the 8 v3 tools", () => {
+    const { server, tools } = makeFakeServer();
+    registerAllTools(server);
+    assert.deepStrictEqual(
+      [...tools.keys()].sort(),
+      [...EXPECTED_TOOLS].sort()
+    );
   });
 
-  it("each tool file exists and exports a register function", async () => {
-    for (const mod of toolModules) {
-      const filePath = resolve(toolDir, `${mod}.ts`);
-      const content = readFileSync(filePath, "utf-8");
-      assert.ok(
-        content.includes("export function register"),
-        `${mod}.ts must export a register function`
-      );
-    }
-  });
-
-  it("all tool files use console.error, not console.log", () => {
-    // Match console.log( at start of line or after whitespace — skip mentions in comments
-    const callPattern = /^\s*console\.log\(/m;
-    for (const mod of toolModules) {
-      const filePath = resolve(toolDir, `${mod}.ts`);
-      const content = readFileSync(filePath, "utf-8");
-      assert.ok(
-        !callPattern.test(content),
-        `${mod}.ts must not use console.log (corrupts JSON-RPC stdio)`
+  it("every registered tool has a non-empty description and an input schema", () => {
+    const { server, tools } = makeFakeServer();
+    registerAllTools(server);
+    for (const [name, def] of tools) {
+      assert.ok(def.description.length > 0, `${name} must have a description`);
+      assert.strictEqual(
+        typeof def.inputSchema,
+        "object",
+        `${name} must have an inputSchema`
       );
     }
   });
 });
 
-describe("client module", () => {
-  const clientPath = resolve(__dirname, "../client.ts");
-  const content = readFileSync(clientPath, "utf-8");
+describe("stdio hygiene", () => {
+  const toolDir = resolve(__dirname, "../tools");
+  // Match console.log( at line start or after whitespace — skip comment mentions.
+  const callPattern = /^\s*console\.log\(/m;
 
-  it("reads API key from SF_API_KEY env var", () => {
-    assert.ok(content.includes('process.env.SF_API_KEY'));
-  });
-
-  it("supports SF_API_BASE_URL override", () => {
-    assert.ok(content.includes('process.env.SF_API_BASE_URL'));
-  });
-
-  it("uses Bearer auth header when key is present", () => {
-    assert.ok(content.includes('Bearer'));
-  });
-
-  it("makes API key optional", () => {
-    assert.ok(content.includes('?? null'), "API key should default to null when not set");
-    assert.ok(!content.includes('process.exit(1)'), "Should not exit when API key is missing");
-  });
-
-  it("does not use console.log in code", () => {
-    // Match console.log( at start of line or after whitespace — skip mentions in comments
-    const callPattern = /^\s*console\.log\(/m;
-    assert.ok(!callPattern.test(content));
-  });
+  for (const mod of ACTIVE_TOOL_FILES) {
+    it(`${mod}.ts uses console.error, not console.log`, () => {
+      const content = readFileSync(resolve(toolDir, `${mod}.ts`), "utf-8");
+      assert.ok(
+        !callPattern.test(content),
+        `${mod}.ts must not use console.log (corrupts JSON-RPC stdio)`
+      );
+    });
+  }
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,55 +4,65 @@
  * SF_API_KEY is optional. Without it, requests are anonymous with lower
  * rate limits (100 calls/day). With a key, limits are 1,000 calls/day per account.
  *
+ * Config (SF_API_KEY, SF_API_BASE_URL, SF_API_TIMEOUT_MS) is read at call time,
+ * so importing this module has no side effects — that keeps the unit tests honest
+ * and lets each test set env per case.
+ *
  * CRITICAL: All logging uses console.error() — never console.log().
  * console.log() on stdout would corrupt the JSON-RPC stdio transport.
  */
 
-const apiKey = process.env.SF_API_KEY ?? null;
+const DEFAULT_BASE_URL = "https://api.scholarfeed.org/api/v1";
+const DEFAULT_TIMEOUT_MS = 30_000;
 
-if (!apiKey) {
-  console.error(
-    "Scholar Feed MCP: running without API key (anonymous mode, 100 calls/day).\n" +
-    "For higher limits, set SF_API_KEY in your MCP config.\n" +
-    "Get a free key at https://www.scholarfeed.org/settings"
-  );
+function getBaseUrl(): string {
+  return process.env.SF_API_BASE_URL ?? DEFAULT_BASE_URL;
 }
 
-const baseUrl =
-  process.env.SF_API_BASE_URL ??
-  "https://api.scholarfeed.org/api/v1";
+function getApiKey(): string | null {
+  return process.env.SF_API_KEY ?? null;
+}
+
+function getTimeoutMs(): number {
+  const raw = process.env.SF_API_TIMEOUT_MS;
+  if (!raw) return DEFAULT_TIMEOUT_MS;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_TIMEOUT_MS;
+}
+
+function authHeaders(): Record<string, string> {
+  const key = getApiKey();
+  return key ? { Authorization: `Bearer ${key}` } : {};
+}
 
 class ScholarFeedClient {
-  private readonly apiKey: string | null;
-  private readonly baseUrl: string;
-
-  constructor(apiKey: string | null, baseUrl: string) {
-    this.apiKey = apiKey;
-    this.baseUrl = baseUrl;
-  }
-
-  private get authHeaders(): Record<string, string> {
-    if (this.apiKey) {
-      return { Authorization: `Bearer ${this.apiKey}` };
-    }
-    return {};
+  /**
+   * GET with flat query params. Throws Error on non-2xx response or timeout.
+   */
+  async get<T>(path: string, params?: Record<string, string>): Promise<T> {
+    const search =
+      params && Object.keys(params).length > 0
+        ? new URLSearchParams(params)
+        : undefined;
+    return this.getWithParams<T>(path, search);
   }
 
   /**
-   * Make a GET request to the Scholar Feed API.
-   * Throws Error on non-2xx response.
+   * GET allowing repeated / array-valued query params
+   * (e.g. ?arxiv_ids[]=A&arxiv_ids[]=B). Shares auth, timeout, and error
+   * handling with get() — callers that need repeated params build a
+   * URLSearchParams and pass it here instead of re-implementing fetch.
    */
-  async get<T>(path: string, params?: Record<string, string>): Promise<T> {
-    let url = `${this.baseUrl}${path}`;
-    if (params && Object.keys(params).length > 0) {
-      const qs = new URLSearchParams(params).toString();
-      url = `${url}?${qs}`;
+  async getWithParams<T>(path: string, search?: URLSearchParams): Promise<T> {
+    let url = `${getBaseUrl()}${path}`;
+    if (search && [...search].length > 0) {
+      url = `${url}?${search.toString()}`;
     }
 
-    const response = await fetch(url, {
+    const response = await this.fetchWithTimeout(url, {
       method: "GET",
       headers: {
-        ...this.authHeaders,
+        ...authHeaders(),
         Accept: "application/json",
       },
     });
@@ -66,13 +76,13 @@ class ScholarFeedClient {
 
   /**
    * Make a POST request to the Scholar Feed API.
-   * Throws Error on non-2xx response.
+   * Throws Error on non-2xx response or timeout.
    */
   async post<T>(path: string, body: unknown): Promise<T> {
-    const response = await fetch(`${this.baseUrl}${path}`, {
+    const response = await this.fetchWithTimeout(`${getBaseUrl()}${path}`, {
       method: "POST",
       headers: {
-        ...this.authHeaders,
+        ...authHeaders(),
         "Content-Type": "application/json",
       },
       body: JSON.stringify(body),
@@ -86,28 +96,33 @@ class ScholarFeedClient {
   }
 
   /**
-   * Make a POST request that returns the raw Response for
-   * SSE streaming.
-   *
-   * Sets Accept: text/event-stream header.
+   * fetch() wrapper that enforces a request timeout via AbortSignal.timeout.
+   * An unbounded fetch can hang a tool call forever if the backend stalls;
+   * the timeout turns that into a clear, actionable error instead.
    */
-  async fetchSSE(path: string, body: unknown, signal?: AbortSignal): Promise<Response> {
-    const response = await fetch(`${this.baseUrl}${path}`, {
-      method: "POST",
-      headers: {
-        ...this.authHeaders,
-        "Content-Type": "application/json",
-        Accept: "text/event-stream",
-      },
-      body: JSON.stringify(body),
-      signal,
-    });
-
-    if (!response.ok) {
-      await this.throwApiError(response);
+  private async fetchWithTimeout(
+    url: string,
+    init: RequestInit
+  ): Promise<Response> {
+    const timeoutMs = getTimeoutMs();
+    try {
+      return await fetch(url, {
+        ...init,
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+    } catch (err) {
+      // AbortSignal.timeout fires a "TimeoutError"; a manual abort is "AbortError".
+      if (
+        err instanceof Error &&
+        (err.name === "TimeoutError" || err.name === "AbortError")
+      ) {
+        throw new Error(
+          `Request timed out after ${Math.round(timeoutMs / 1000)}s — the Scholar Feed API did not respond. ` +
+            "Raise the limit with SF_API_TIMEOUT_MS if needed."
+        );
+      }
+      throw err;
     }
-
-    return response;
   }
 
   /**
@@ -122,14 +137,14 @@ class ScholarFeedClient {
       case 401:
         throw new Error(
           "Authentication failed: your SF_API_KEY is invalid or has been revoked. " +
-          "Check your key at https://www.scholarfeed.org/settings"
+            "Check your key at https://www.scholarfeed.org/settings"
         );
       case 403:
         throw new Error("Access denied. You may need a valid API key for this endpoint.");
       case 429:
         throw new Error(
           "Rate limit exceeded. Add an API key for higher limits — " +
-          "get one free at https://www.scholarfeed.org/settings"
+            "get one free at https://www.scholarfeed.org/settings"
         );
       default:
         // Truncate body to avoid leaking internal details to LLM
@@ -138,4 +153,4 @@ class ScholarFeedClient {
   }
 }
 
-export const client = new ScholarFeedClient(apiKey, baseUrl);
+export const client = new ScholarFeedClient();

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,13 @@ const server = new McpServer({
 registerAllTools(server);
 
 async function main(): Promise<void> {
+  if (!process.env.SF_API_KEY) {
+    console.error(
+      "Scholar Feed MCP: running without API key (anonymous mode, 100 calls/day).\n" +
+        "For higher limits (1,000/day per account), set SF_API_KEY in your MCP config.\n" +
+        "Get a free key at https://www.scholarfeed.org/settings"
+    );
+  }
   const transport = new StdioServerTransport();
   await server.connect(transport);
   console.error("Scholar Feed MCP server running on stdio");

--- a/src/init.ts
+++ b/src/init.ts
@@ -11,7 +11,7 @@
 import { createInterface } from "readline";
 import { execSync } from "child_process";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
-import { join } from "path";
+import { join, dirname } from "path";
 import { homedir, platform } from "os";
 
 const rl = createInterface({ input: process.stdin, output: process.stderr });
@@ -67,7 +67,7 @@ function mergeJsonConfig(filePath: string, serverConfig: Record<string, unknown>
   servers["scholar-feed"] = serverConfig;
   existing.mcpServers = servers;
 
-  const dir = filePath.substring(0, filePath.lastIndexOf("/"));
+  const dir = dirname(filePath);
   if (dir && !existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }
@@ -121,7 +121,7 @@ export async function runInit(): Promise<void> {
           `claude mcp add scholar-feed${envFlag} -- npx -y scholar-feed-mcp`,
           { stdio: "inherit" }
         );
-        console.error("  Added to Claude Code. Use 'check_connection' tool to verify.");
+        console.error("  Added to Claude Code. Restart it, then ask it to search for papers to verify.");
       } catch {
         console.error("  'claude' CLI not found. Install Claude Code first: https://docs.anthropic.com/claude-code");
         const envFlag = apiKey ? ` -e SF_API_KEY=${apiKey}` : "";

--- a/src/tools/co_author_graph.ts
+++ b/src/tools/co_author_graph.ts
@@ -21,7 +21,7 @@ export function register(server: McpServer): void {
           .min(1)
           .max(25)
           .describe(
-            "Author IDs to query (1-25). Get author IDs via the discover_authors / find_author tool."
+            "Author IDs to query (1-25). Get author IDs via the find_author tool."
           ),
         window_years: z
           .number()

--- a/src/tools/find_author.ts
+++ b/src/tools/find_author.ts
@@ -87,7 +87,7 @@ export function register(server: McpServer): void {
         } else {
           // id-mode: direct profile lookup
           const result = await client.get<unknown>(
-            `/public/authors/${id}`
+            `/public/authors/${encodeURIComponent(String(id))}`
           );
           return {
             content: [

--- a/src/tools/get_paper.ts
+++ b/src/tools/get_paper.ts
@@ -8,7 +8,7 @@
  *     POST /papers/batch was retired in plan 02)
  *
  * Endpoints:
- *   GET /public/papers?arxiv_ids[]=...          (batch, all formats except bibtex)
+ *   GET /public/papers?arxiv_ids[]=...          (batch, json — repeated query params)
  *   GET /public/papers/{arxiv_id}?format=bibtex (single bibtex)
  */
 
@@ -16,40 +16,17 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { client } from "../client.js";
 
-// Replicate base URL resolution from client.ts so we can build URLs manually
-// for the batch case (repeated arxiv_ids[] params, not supported by flat
-// Record<string,string> params in client.get).
-const _baseUrl =
-  process.env.SF_API_BASE_URL ?? "https://api.scholarfeed.org/api/v1";
-const _apiKey = process.env.SF_API_KEY ?? null;
-
-async function batchFetch(arxivIds: string[]): Promise<unknown> {
-  // Build URL with repeated ?arxiv_ids[]=A&arxiv_ids[]=B params
-  const qs = new URLSearchParams();
-  for (const id of arxivIds) {
-    qs.append("arxiv_ids[]", id);
-  }
-  const url = `${_baseUrl}/public/papers?${qs.toString()}`;
-  const headers: Record<string, string> = { Accept: "application/json" };
-  if (_apiKey) headers["Authorization"] = `Bearer ${_apiKey}`;
-
-  const response = await fetch(url, { method: "GET", headers });
-  if (!response.ok) {
-    throw new Error(`API request failed (HTTP ${response.status})`);
-  }
-  return response.json();
-}
-
 export function register(server: McpServer): void {
   server.registerTool(
     "get_paper",
     {
       description:
-        "Get full details for one or more papers by arXiv ID. Pass a single-element array for one paper; pass multiple IDs to batch-fetch up to 50 papers in one call (replaces the removed batch_lookup tool). Pass format='bibtex' to get a .bib citation entry (replaces the removed export_bibtex tool — bibtex is single-paper only; for multi-paper bibtex, call repeatedly). Default returns a lean 12-field shape (arxiv_id, title, authors, year, categories, has_code, github_url, citation_count, venue_name, llm_summary, llm_significance, llm_novelty_score). Pass verbose=true for the full 28-field shape with structured extraction (method_name, contribution_type, task_category, datasets, baselines) and institution_tags. Use fields='abstract' to include the abstract, or fetch_fulltext with sections='all' for the full paper.",
+        "Get full details for one or more papers by arXiv ID. Pass a single-element array for one paper; pass multiple IDs to batch-fetch up to 50 papers in one call (replaces the removed batch_lookup tool). Pass format='bibtex' to get a .bib citation entry (replaces the removed export_bibtex tool — bibtex is single-paper only; for multi-paper bibtex, call repeatedly). Default returns a lean 12-field shape (arxiv_id, title, authors, year, categories, has_code, github_url, citation_count, venue_name, llm_summary, llm_significance, llm_novelty_score). Pass verbose=true for the full 28-field shape with structured extraction (method_name, contribution_type, task_category, datasets, baselines) and institution_tags. Use fields='arxiv_id,title,abstract' to select an exact subset, or fetch_fulltext with sections='all' for the full paper.",
       inputSchema: {
         arxiv_ids: z
           .array(z.string().min(1))
           .min(1)
+          .max(50)
           .describe(
             "One or more arXiv IDs. Single-paper lookup uses [id]; batch lookup passes multiple IDs (max 50). Replaces the removed batch_lookup tool. Example: ['2407.15831'] or ['2407.15831', '2402.09906']."
           ),
@@ -71,25 +48,18 @@ export function register(server: McpServer): void {
           .describe(
             "If true, returns the full 28-field paper shape (method/task/dataset extraction, application_domain, baselines, etc.). Default false returns the lean 12-field set. Ignored when `fields` is provided."
           ),
-        include_results: z
-          .boolean()
-          .optional()
-          .default(true)
-          .describe(
-            "Include inline benchmark results from paper_results. Default true. Set false if you only need metadata."
-          ),
       },
     },
-    async ({ arxiv_ids, format, fields, verbose, include_results }) => {
+    async ({ arxiv_ids, format, fields, verbose }) => {
       try {
         // bibtex mode: single-paper, use GET /papers/{id}?format=bibtex
         if (format === "bibtex") {
           const id = arxiv_ids[0];
-          const params: Record<string, string> = { format: "bibtex" };
-          const result = await client.get<{ bibtex: string; count: number; not_found: string[] }>(
-            `/public/papers/${encodeURIComponent(id)}`,
-            params
-          );
+          const result = await client.get<{
+            bibtex: string;
+            count: number;
+            not_found: string[];
+          }>(`/public/papers/${encodeURIComponent(id)}`, { format: "bibtex" });
           // Return the bibtex string directly (the backend wraps it in {bibtex, count, not_found})
           const bibText = result.bibtex ?? JSON.stringify(result, null, 2);
           return {
@@ -97,8 +67,19 @@ export function register(server: McpServer): void {
           };
         }
 
-        // JSON mode (batch or single via collection route)
-        const result = await batchFetch(arxiv_ids);
+        // JSON mode (batch or single): repeated ?arxiv_ids[]=... params routed
+        // through the shared client (auth, timeout, and error handling).
+        const search = new URLSearchParams();
+        for (const id of arxiv_ids) {
+          search.append("arxiv_ids[]", id);
+        }
+        if (fields !== undefined) search.set("fields", fields);
+        if (verbose === true) search.set("verbose", "true");
+
+        const result = await client.getWithParams<unknown>(
+          "/public/papers",
+          search
+        );
 
         return {
           content: [

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -1,5 +1,5 @@
 /**
- * search_papers tool — full-text search across Scholar Feed's 560k+ paper corpus.
+ * search_papers tool — full-text search across Scholar Feed's 600k+ paper corpus.
  *
  * v3: absorbs find_similar (anchor_paper_id), find_citations_about
  * (scope_to_citations_of), and whats_trending (sort='trending') in addition
@@ -17,7 +17,7 @@ export function register(server: McpServer): void {
     "search_papers",
     {
       description:
-        "Search Scholar Feed's 560k+ CS/AI/ML paper corpus. Defaults to semantic (embedding) search — finds conceptually related papers even when the user's wording doesn't match the paper's title/abstract. Pass mode='keyword' for exact-string full-text search. CAVEAT: semantic search often misses old high-citation CANONICAL papers (e.g. foundational anchors like H2O for KV eviction, GRIT for unified embedding+generation) because the ranker prefers recent stylistically-matched papers. If you're hunting the canonical anchor for an area, parse the top-5 result abstracts for baseline mentions ('we compare against X, Y, Z'), then look the most-mentioned name up directly. Returns papers with LLM-generated summaries, novelty scores, and structured extraction data. Default response is a lean 12-field shape (arxiv_id, title, authors, year, categories, has_code, github_url, citation_count, venue_name, llm_summary, llm_significance, llm_novelty_score) — pass verbose=true or fields=... for the full 28-field shape with method/task/dataset extraction. Supports filtering by category, novelty, recency, method, task, dataset, contribution type, and whether papers have benchmark results. v3 ABSORPTIONS: pass sort='trending' to replicate whats_trending; pass anchor_paper_id to replicate find_similar (q is ignored in anchor mode, results carry similarity_score); pass scope_to_citations_of to restrict search to a paper's citation graph (replaces find_citations_about).",
+        "Search Scholar Feed's 600k+ CS/AI/ML paper corpus. Defaults to semantic (embedding) search — finds conceptually related papers even when the user's wording doesn't match the paper's title/abstract. Pass mode='keyword' for exact-string full-text search. CAVEAT: semantic search often misses old high-citation CANONICAL papers (e.g. foundational anchors like H2O for KV eviction, GRIT for unified embedding+generation) because the ranker prefers recent stylistically-matched papers. If you're hunting the canonical anchor for an area, parse the top-5 result abstracts for baseline mentions ('we compare against X, Y, Z'), then look the most-mentioned name up directly. Returns papers with LLM-generated summaries, novelty scores, and structured extraction data. Default response is a lean 12-field shape (arxiv_id, title, authors, year, categories, has_code, github_url, citation_count, venue_name, llm_summary, llm_significance, llm_novelty_score) — pass verbose=true or fields=... for the full 28-field shape with method/task/dataset extraction. Supports filtering by category, novelty, recency, method, task, dataset, and contribution type. v3 ABSORPTIONS: pass sort='trending' to replicate whats_trending; pass anchor_paper_id to replicate find_similar (q is ignored in anchor mode, results carry similarity_score); pass scope_to_citations_of to restrict search to a paper's citation graph (replaces find_citations_about).",
       inputSchema: {
         q: z.string().min(1).optional().describe("Search query keywords. Optional when anchor_paper_id is set (anchor mode ignores q and returns papers similar to the anchor)."),
         sort: z
@@ -65,7 +65,7 @@ export function register(server: McpServer): void {
           .string()
           .optional()
           .describe(
-            "Filter to papers introducing/using a specific named method e.g. 'LoRA', 'YOLO', 'DPO'. Case-insensitive substring match on the extracted method_name field. Replaces the dropped search_by_method tool."
+            "Filter to papers introducing/using a specific named method e.g. 'LoRA', 'YOLO', 'DPO'. Case-insensitive substring match on the extracted method_name field."
           ),
         task: z
           .string()
@@ -109,12 +109,6 @@ export function register(server: McpServer): void {
           ])
           .optional()
           .describe("Filter by broad research area"),
-        has_results: z
-          .boolean()
-          .optional()
-          .describe(
-            "If true, only return papers with quantitative benchmark results in paper_results"
-          ),
         mode: z
           .enum(["keyword", "semantic"])
           .optional()
@@ -169,7 +163,6 @@ export function register(server: McpServer): void {
       dataset,
       contribution_type,
       task_category,
-      has_results,
       mode,
       cursor,
       page,
@@ -199,8 +192,6 @@ export function register(server: McpServer): void {
           params.contribution_type = contribution_type;
         if (task_category !== undefined)
           params.task_category = task_category;
-        if (has_results !== undefined)
-          params.has_results = String(has_results);
         // Default to semantic search — keyword sorts by rank_score (not relevance),
         // which is wrong for natural-language queries (audit 2026-05-14).
         params.mode = mode ?? "semantic";


### PR DESCRIPTION
## Summary
Audit-driven fixes from a 4-agent review (code / tests / docs / packaging). The code was already solid; this closes the gaps that undercut "open-source quality, honest coverage."

## Changes
- **Removed `paper_results` from the MCP surface** — `search_papers.has_results` + `get_paper.include_results` (abstract-only extraction, ~10% coverage, not reliable). Kept the structured-extraction filters (`dataset`/`method_name`/`task`/`contribution_type`) + `verbose`, which read `papers.*` columns, not the `paper_results` table.
- **`get_paper`** — `fields`/`verbose` are now actually forwarded (were declared-but-inert); `.max(50)` cap; routed through a shared `client.getWithParams()`.
- **Client hardening** — request timeout (`AbortSignal.timeout`, `SF_API_TIMEOUT_MS`, default 30s), call-time config, dead `fetchSSE` removed.
- **Real test suite** — 35 behavioral tests (registry, client with mocked fetch, handlers) on a `tsx` runner. The old suite was string-grep theater AND used `--experimental-strip-types` (Node 22.6+ only), so CI had been red on the 18/20 matrix since the v3 cut.
- **Deps/release** — SDK `^1.27`→`^1.29` (`npm audit` clean), `prepublishOnly` guard, `bugs` URL.
- **Docs** — paper count → 600,000+; rate-limit table fixed (`get_paper` 30/min, `get_field_orientation` 20/min); README param tables; stale tool references removed.

## Verification
typecheck clean · 35/35 tests pass · build clean · `npm pack` = lean 6 files · `npm audit` = 0 · live backend contract confirmed (lean 12-field / verbose 28-field, no `paper_results` in either).

## Not in scope (follow-ups)
- `npm publish` of 3.0.2 — manual, after merge
- Backend retirement of the 6 dead benchmark/leaderboard/methods endpoints — separate coordinated Heroku deploy
- Deep security/quality pass (ESLint, SAST, supply-chain) — see handoff doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)