### PR TITLE
Remote Streamable HTTP MCP server + OAuth 2.1 Resource Server (foundation)

### DIFF
--- a/.env.http.example
+++ b/.env.http.example
@@ -1,0 +1,54 @@
+# Remote MCP server (src/server-http.ts) environment.
+# Copy to .env (gitignored) for the deploy target. The stdio npm package does
+# NOT use this file — it reads SF_API_KEY from the MCP client config.
+
+# ---------------------------------------------------------------------------
+# Transport / abuse surface (DNS-rebinding guards)
+# ---------------------------------------------------------------------------
+# Comma-separated EXACT origins a browser host may use (scheme+host+port, NO
+# trailing slash). Loopback (localhost / 127.0.0.1 / [::1]) is always allowed.
+# NEVER use a wildcard. Example: https://claude.ai
+# SF_MCP_ALLOWED_ORIGINS=
+
+# Comma-separated allowed Host header values. REQUIRED on any non-loopback
+# deploy: with this unset, ONLY loopback Hosts are accepted (fail closed) and a
+# public deploy will 403 everything. Set to your public host (and/or tunnel host).
+# Example: mcp.scholarfeed.org
+# SF_MCP_ALLOWED_HOSTS=
+
+# Listen port (default 3000).
+# PORT=3000
+
+# DO NOT set SF_API_KEY here. The remote server derives each request's key from
+# its own Authorization header; a process-level SF_API_KEY is a latent
+# cross-tenant leak and the server REFUSES TO START if it is set.
+
+# ---------------------------------------------------------------------------
+# OAuth Resource Server (M4) — needed only for the OAuth (JWT) path. The sf_-key
+# bearer path and anonymous reads work without any of these.
+# ---------------------------------------------------------------------------
+# Canonical MCP resource URI = the token `aud` the verifier requires AND the
+# `resource` in the RFC 9728 metadata. MUST be a non-empty URL (an empty value
+# is rejected at startup; an empty audience would disable audience validation).
+# SF_MCP_RESOURCE_URI=https://mcp.scholarfeed.org/mcp
+# SF_MCP_AUDIENCE=https://mcp.scholarfeed.org/mcp
+
+# Authorization Server issuer (Supabase: {SUPABASE_URL}/auth/v1). Advertised in
+# the metadata's authorization_servers and used to derive the JWKS URL.
+# SF_OAUTH_ISSUER=
+
+# JWKS source. Defaults to {SF_OAUTH_ISSUER}/.well-known/jwks.json. For Supabase:
+# {SUPABASE_URL}/auth/v1/.well-known/jwks.json
+# SF_OAUTH_JWKS_URL=
+
+# Issuer enforcement. OFF by default (mirrors the backend's enforce_jwt_issuer).
+# GA GATE: set this to true (with SF_OAUTH_ISSUER) BEFORE opening OAuth to real
+# tokens — once the access-token hook stamps the shared MCP `aud`, the issuer is
+# the only remaining project discriminator.
+# SF_OAUTH_ENFORCE_ISSUER=false
+
+# ---------------------------------------------------------------------------
+# Backend proxy target (shared with the stdio client)
+# ---------------------------------------------------------------------------
+# SF_API_BASE_URL=https://api.scholarfeed.org/api/v1
+# SF_API_TIMEOUT_MS=30000

--- a/docs/plans/2026-06-04-remote-mcp-DECISIONS.md
+++ b/docs/plans/2026-06-04-remote-mcp-DECISIONS.md
@@ -1,0 +1,114 @@
+# Remote MCP + OAuth — Locked Build Decisions (Phase 0)
+
+Date: 2026-06-04
+Companion to: `2026-06-04-remote-mcp-oauth-connector-spec.md`
+Status: LOCKED. Build agents read this as ground truth; where it conflicts with the spec, this doc wins (it reflects post-spec verification of the live code).
+
+## Backend reality (verified 2026-06-04 against scholar-feed/backend)
+
+- Backend is **Python FastAPI on Heroku** (`web: uvicorn api.main:app`). DB: Supabase Postgres (asyncpg).
+- Auth (`backend/api/auth.py`): the backend ALREADY validates **Supabase JWT (ES256) via JWKS** at
+  `{SUPABASE_URL}/auth/v1/.well-known/jwks.json`, requires claims `exp/sub/aud`, audience `authenticated`,
+  issuer `{SUPABASE_URL}/auth/v1` (gated by `enforce_jwt_issuer`). HS256 is legacy/gated-off.
+- The public API also accepts **`sf_` API keys** as Bearer tokens (`require_any_auth` / `optional_any_auth`),
+  routing on the `sf_` prefix; `eyJ...` goes to the JWT path. Anonymous (no token) is allowed with lower caps.
+- `api_keys` stores only `key_hash` (SHA-256). **Raw `sf_` keys are NOT recoverable from the DB.**
+
+## Three corrections to the spec (consequences of the above)
+
+1. **Cheapest first rung = API-key bearer passthrough (no OAuth).** Because the backend already accepts an
+   `sf_` Bearer, the remote server can accept the user's pasted `sf_` key as the Bearer and forward it. This is
+   the SAME credential the stdio package uses (the user supplying their own downstream key) — NOT confused-deputy
+   token passthrough. It unlocks a working claude.ai custom connector with zero OAuth. The ALS refactor (below)
+   yields this for free.
+2. **The token->key bridge as the spec wrote it ("SELECT the account's SF_API_KEY") is impossible** — keys are
+   stored hashed. Build the bridge as a typed SEAM (`CredentialResolver`) with a default that fails loud and
+   documents the open backend decision (#8): (a) RS mints a per-user `sf_` key, (b) GoTrue admin act-as-user
+   JWT with `aud=authenticated`, or (c) service credential + `X-SF-User-Id` header. Do NOT fabricate a SELECT.
+3. **The OAuth verifier mirrors `backend/api/auth.py` exactly** (ES256/JWKS, require exp/sub/aud, gated issuer)
+   but validates `aud` against the MCP resource URI, not `authenticated`. The Custom Access Token Hook that
+   stamps that `aud` + `sf_tier` is backend work, OUT OF SCOPE here; the verifier reads its target from env.
+
+## Locked decisions
+
+- **Threading model: AsyncLocalStorage.** `client.ts` reads per-request creds (`apiKey`, `sessionId`) from an ALS
+  store set by the HTTP entry point; falls back to `process.env` when no context (preserves stdio + existing tests).
+  Rationale: only touches `client.ts` + the new HTTP entry; leaves all 25 tool handlers untouched; stateless v1
+  has no server-initiated push so each request->response is fully contained in one async context (the case ALS
+  handles correctly). This supersedes the spec's "explicit getCreds threading" recommendation, which would require
+  rewriting every `client.*` call site across 14 files and collides with the M2 annotation edits.
+- **Transport: stateless Streamable HTTP** (`sessionIdGenerator: undefined`). POST `/mcp`; GET/DELETE -> 405.
+- **Host target: runtime-agnostic core + a Node/Express entry point** as the tested default. Reasoning: the backend
+  is Python, so the Node MCP server MUST be a separate service (one thin HTTPS hop to `api.scholarfeed.org`); it
+  cannot be co-located in FastAPI. Express lets us use the SDK's batteries (`StreamableHTTPServerTransport`,
+  `requireBearerAuth`, the auth metadata `router`) and the existing `node --test` harness. Deploy options, cheapest
+  first: validate $0 via local + Cloudflare-Tunnel/ngrok; $0 standalone via Cloudflare Workers free tier (documented
+  port: `node:crypto` randomUUID -> global `crypto.randomUUID()`); ~$7/mo via a second Heroku dyno (max infra reuse).
+  Keep all OAuth/verifier logic framework-agnostic so the Workers port is a thin entry-point swap.
+- **Authorization Server: Supabase Auth** (already proven in prod via the backend's JWKS verification). The verifier
+  is AS-agnostic via env (`SF_OAUTH_ISSUER`, JWKS URL, `SF_MCP_AUDIENCE`); swapping to WorkOS/Auth0 later changes
+  only config. No M3 spike needed to write the code.
+- **Canonical MCP URI / resource / token aud: `https://mcp.scholarfeed.org/mcp`** (env `SF_MCP_RESOURCE_URI`).
+- **Anonymous coexistence:** `/mcp` serves read/search tools token-free (backend anonymous caps apply); account
+  tools return `401 + WWW-Authenticate: Bearer resource_metadata=...` when called without a valid token/scope.
+
+## In scope for THIS repo / this build
+
+- **M1** — transport + ALS creds: `client.ts` ALS refactor; `src/http/credentials.ts` (ALS store); `src/server-http.ts`
+  (Express, stateless transport, Origin validation, CORS exposing the MCP headers, per-request creds from `sf_` Bearer);
+  `src/index.ts` unchanged (env fallback). HTTP smoke test.
+- **M2** — annotations: `title` + `readOnlyHint` + `destructiveHint` on all 25 `registerTool` configs (hint table in
+  spec §6 M2); programmatic tool-name length check (<= 64) as a test.
+- **M4 (code only, AS-agnostic)** — OAuth Resource Server: `src/http/oauth/verifier.ts` (ES256/JWKS, mirrors auth.py),
+  `src/http/oauth/metadata.ts` (RFC 9728 protected-resource doc + `.well-known` routes), `src/http/oauth/credential-resolver.ts`
+  (the typed bridge SEAM), bearer-auth wiring + anon/auth split in `server-http.ts`. Verifier + metadata + routing tests.
+
+## OUT of scope here (backend / web / ops / operator)
+
+- M3 Supabase AS spike (live-project investigation); the Custom Access Token Hook (`aud`/`sf_tier` stamping).
+- M5 consent UI at `scholarfeed.org/oauth/authorize`; redirect-URI registration; refresh-token rotation config.
+- M6 deployment infra, custom domain, OAuth-endpoint rate limits (backend/AS-side).
+- M7 directory submissions. **GATE (spec §9): do not submit until per-tool-call instrumentation lands** — broad
+  reach is gated on measurement per the `broaden-icp-and-instrumentation` decision. This build is foundation only.
+
+## New dependencies
+
+`express`, `cors` (+ `@types/*`), and `jose` (ES256 JWKS verify via `createRemoteJWKSet` + `jwtVerify`; ESM,
+Web-crypto, works in Node and the eventual Workers runtime). `zod` already present. The npm `bin` build
+(`tsup src/index.ts`) is unchanged — `server-http.ts` is built by the deploy target, not shipped in the package.
+
+## Adversarial review hardening (applied 2026-06-04, post-build)
+
+A 5-lens adversarial pass (ALS threading, token passthrough, secret leakage, JWT rigor, transport abuse)
+confirmed the two highest-stakes properties CLEAN — the user OAuth JWT can never reach the backend
+(confused-deputy), and per-request ALS creds never bleed across tenants / never fall back to a server env
+key on an anonymous request. The following real findings were then fixed:
+
+- **Empty `SF_MCP_AUDIENCE` failed OPEN.** `??` does not catch `""`, and jose treats a falsy audience as
+  "skip" — silently disabling audience binding. The verifier now trims and THROWS on an empty audience.
+- **DNS-rebinding: Host header was unvalidated.** Added an `isHostAllowed` guard (env `SF_MCP_ALLOWED_HOSTS`,
+  loopback-only when unset) alongside the existing Origin guard. Fixed an IPv6 `http://[::1]` Origin
+  false-reject (bracketed hostname).
+- **501 body echoed the resolver's `err.message`.** Now only the vetted secret-free Unconfigured message is
+  echoed; any other resolver throw returns a generic 501 (full detail to stderr) so a future key-minting
+  resolver can't leak a minted key/JWT.
+- **Raw network errors leaked the backend host/IP** via `err.cause`. `client.ts` now sanitizes all
+  non-timeout fetch failures to a generic message (benefits the stdio path too).
+- **OAuth verify-failure logs dumped the unverified decoded JWT** (email/sub via jose `err.payload`). Now
+  logs only the error code/name.
+- **`SF_API_KEY` on the remote process** is a latent leak — the run-directly entry now FAILS FAST if it is set.
+- **`ResolvedCredential.headers`** was silently dropped — the wiring now FAILS LOUD (RequestCreds carries
+  only `apiKey`; models b/c must extend it first).
+
+New tests pin these: the ALS no-leak + concurrency invariant over the wire (`http_credentials.test.ts`),
+the empty-audience throw, and the Origin/Host guard units. Full suite green (228 tests).
+
+## Remote server environment variables (deploy)
+
+See `.env.http.example`. Security-critical:
+- `SF_MCP_ALLOWED_HOSTS` — MUST be set to the public host (e.g. `mcp.scholarfeed.org`) and/or tunnel host on
+  any non-loopback deploy, else the server 403s everything (fail closed).
+- `SF_MCP_ALLOWED_ORIGINS` — exact browser origins (no trailing slash, never a wildcard); loopback always ok.
+- `SF_API_KEY` — MUST be unset on the remote server (it refuses to start otherwise).
+- **GA GATE:** set `SF_OAUTH_ENFORCE_ISSUER=true` + `SF_OAUTH_ISSUER` before opening the OAuth path to real
+  tokens — once the access-token hook stamps the shared MCP `aud`, the issuer is the only project discriminator.

--- a/docs/plans/2026-06-04-remote-mcp-oauth-connector-spec.md
+++ b/docs/plans/2026-06-04-remote-mcp-oauth-connector-spec.md
@@ -1,0 +1,348 @@
+# Remote MCP + OAuth Connector Build Spec
+
+Date: 2026-06-04
+Status: SCOPING (decision-complete, ready for a future BUILD workflow)
+Author: synthesized from 6 parallel research agents + repo verification
+Scope: ship scholar-feed as a remote Streamable HTTP MCP server with OAuth so it can be added as a connector on claude.ai, the Anthropic Connectors Directory, ChatGPT/OpenAI, and other remote-MCP hosts.
+
+HOUSE NOTE: this doc avoids dashes by style. Where research was uncertain, the assumption and its fallback are stated inline.
+
+---
+
+## 1. Goal and strategic rationale
+
+### Goal
+Stand up `https://mcp.scholarfeed.org/mcp`: one spec-compliant remote MCP server (Streamable HTTP transport, MCP spec 2025-11-25) fronted by OAuth 2.1, that reuses the 25 existing tool handlers unchanged and proxies to `api.scholarfeed.org`. The existing stdio npm package stays exactly as-is for local installs; the remote server is an additive second surface.
+
+### Why one build unlocks the whole category
+The MCP ecosystem converged in 2025 on a single wire format. Every major hosted assistant now negotiates Streamable HTTP first and accepts an OAuth 2.1 bearer token:
+
+- claude.ai self-add custom connectors and the Anthropic Connectors Directory (claude.com/docs/connectors)
+- ChatGPT Apps + the OpenAI Responses API (developers.openai.com/api/docs/mcp)
+- Cursor, VS Code / GitHub Copilot, Windsurf / Devin, JetBrains AI, Goose, Perplexity Pro
+
+So the build is: one HTTPS endpoint that speaks POST (client to server JSON-RPC) and GET (server to client SSE), publishes `/.well-known/oauth-protected-resource` (RFC 9728), and validates a bearer token. The per-platform deltas are small and mostly about OAuth client registration (CIMD vs DCR) and submission paperwork, not about the server's core behavior. This is a category unlock, not a per-platform integration: build the server and AS once, then submit to each directory.
+
+### Strategic caveat the operator must hold (see Section 9)
+Per MEMORY (broaden-icp-and-instrumentation), the decision to chase broad web reach is explicitly gated on instrumenting usage first. This spec builds the distribution surface. It does NOT instrument usage. Shipping this before interaction instrumentation lands means traffic arrives un-measured, which is the exact tension flagged in `docs/interaction-instrumentation-backend-spec.md`. Recommendation: land minimal per-tool-call instrumentation on the backend in parallel with M1 to M3 so the directory traffic is legible from day one. Treat this as a hard dependency on the value-prop validation, not a nice-to-have.
+
+---
+
+## 2. Target platforms and requirements matrix
+
+Required = hard gate. Optional = works without it. Uncertain = research could not confirm for June 2026; assumption + fallback noted in the cell or Section 9.
+
+| Platform | Transport | Auth | Tool annotations | Submission / review | Extra requirements |
+|---|---|---|---|---|---|
+| **claude.ai self-add (custom connector)** | Streamable HTTP, required. Old HTTP+SSE deprecated. | OAuth optional. Anonymous bearer (existing SF_API_KEY paste) works. | Not required to function. Helps UX. | None. Paid claude.ai user pastes the URL under Settings > Connectors. | Paid plan only (custom connectors are beta, paid-only). HTTPS. Origin validation. ~150k char result cap, 300s timeout. |
+| **Anthropic Connectors Directory** | Streamable HTTP, required. | OAuth 2.1 + PKCE (S256), required for authenticated listing. CIMD preferred; DCR or Anthropic-held creds accepted. | `title`, `readOnlyHint`, `destructiveHint` REQUIRED on all 25 tools per directory policy. | Formal review via clau.de/mcp-directory-submission. Test account, 3 prompt examples, support channel, branding, public doc. No SLA; escalate to mcp-review@anthropic.com. | Privacy + ToS URLs (already live). Health-data checklist item. IP license grant to Anthropic. Removable at any time. |
+| **OpenAI / ChatGPT Apps** | Streamable HTTP (SSE backwards-compat accepted). | OAuth 2.1 + PKCE + CIMD/DCR, required. Plain API-key bearer is explicitly BLOCKED for the ChatGPT web connector flow. Responses API (programmatic) still accepts a bearer token. | Read-only hint matters: write connectors gated to Business/Enterprise/Edu; Plus/Pro limited to read-only. | OpenAI Platform identity verification, app metadata, screenshots, test prompts, test account. No SLA; do not request expedited review. | Redirect URI `https://chatgpt.com/connector/oauth/{callback_id}`. Apps SDK (proprietary) only needed for native ChatGPT UI. |
+| **Cursor** | Streamable HTTP (`type: http`), required. | OAuth browser flow supported (shipped v1.0, June 2025). | Optional. | None (user adds URL). | None notable. |
+| **VS Code / GitHub Copilot** | `type: http` or `sse`, `url` field. GA in 1.102. | OAuth supported (`oauth.clientId`). | Optional. | Optional: list on the GitHub MCP Registry (mcp-publisher CLI + server.json + mcpName in package.json). | None notable. |
+| **Windsurf / Devin (Cascade)** | Streamable HTTP + SSE + stdio. | OAuth for all transports. Forwards RFC 8707 `resource` param. | Optional. | None. | None notable. |
+| **JetBrains AI** | Streamable HTTP + SSE. | UNCERTAIN: no OAuth mention in official docs as of research date; v2.13.26 (Apr 2026) fixed OAuth bugs. Assume lower maturity; fallback is user-managed config. | Optional. | None. | Treat as best-effort. |
+| **Goose (AAIF / Linux Foundation)** | Streamable HTTP / SSE. | OAuth supported. | Optional. | None. | Apache-2.0 client. |
+| **Perplexity Pro/Max/Enterprise** | Remote MCP supported. | OAuth. | Optional. | None. | LOW priority: Perplexity announced (Mar 2026) a strategic move away from MCP internally; treat as transient. |
+| **Google / Gemini** | SDK-level only (Python/JS), Workspace / Enterprise Agent Platform. | n/a | n/a | No public consumer connector directory analogous to Anthropic/OpenAI. | LOW priority. Out of scope for v1. |
+
+Matrix takeaways:
+- The minimum to be usable on the broadest set of hosts is: Streamable HTTP + Origin validation + HTTPS (Section 6, M1).
+- The minimum to LIST in either directory is: OAuth 2.1 + PKCE + CIMD/DCR + tool annotations + submission paperwork.
+- ChatGPT write-tool exposure is the one hard structural limit (write connectors gated to Business/Enterprise/Edu). Plan to expose read-only tools on the ChatGPT surface first.
+
+---
+
+## 3. Architecture
+
+A single new service (the remote MCP server) acts as an OAuth 2.0 Resource Server (RS). It reuses `registerAllTools()` and the existing tool handlers verbatim, but threads a per-request API key into the HTTP client instead of reading `process.env.SF_API_KEY`. A separate Authorization Server (AS), recommended to be Supabase Auth, issues tokens. The RS validates the token, maps it to a Scholar Feed account, looks up that account's SF_API_KEY server-side, and proxies to `api.scholarfeed.org` with that key. The user's OAuth token is NEVER forwarded to the backend (token passthrough is forbidden by the MCP spec; it is a confused-deputy vector).
+
+### Request flow (text diagram)
+
+```
+  Host (claude.ai / ChatGPT / Cursor / ...)
+        |
+        |  1. POST /mcp  (no token, or expired)
+        v
+  Remote MCP server (Resource Server)  --->  401 + WWW-Authenticate: Bearer
+        |                                       resource_metadata=https://mcp.scholarfeed.org/.well-known/oauth-protected-resource
+        |
+        |  2. Host reads RFC 9728 metadata -> finds authorization_servers -> reads RFC 8414 metadata on the AS
+        v
+  Authorization Server (Supabase Auth)
+        |  3. OAuth 2.1 auth-code + PKCE(S256), resource=https://mcp.scholarfeed.org/mcp
+        |     User logs in (Scholar-Feed-branded consent), AS issues access token
+        |     Custom Access Token Hook stamps: aud, sf_user_id, sf_tier
+        v
+  Host receives access token, retries:
+        |  4. POST /mcp  Authorization: Bearer <access_token>   MCP-Protocol-Version: 2025-11-25
+        v
+  Remote MCP server (Resource Server)
+        |  5. validate token sig (JWKS), validate aud == https://mcp.scholarfeed.org/mcp, extract sf_user_id + sf_tier
+        |  6. look up that account's SF_API_KEY (Supabase SELECT, cached)
+        |  7. registerAllTools handler runs -> client.ts uses the per-request SF_API_KEY
+        v
+  api.scholarfeed.org  (Authorization: Bearer <SF_API_KEY>, X-SF-Session: <per-request id>)
+        |
+        v
+  corpus / library / watches -> JSON back up the chain -> tool result to host
+```
+
+### Stateless vs stateful decision
+DECISION: stateless Streamable HTTP for v1 (`sessionIdGenerator: undefined`). All 25 tools are thin REST proxies; account state lives in Supabase / the backend, not in MCP session RAM. Stateless means no session store, no sticky routing, trivial horizontal scale, and GET/DELETE on `/mcp` return 405. The only thing lost is server-initiated push (for example pushing watch alerts to a connected client), which is not a v1 feature. FALLBACK / future: if watch-alert push is wanted, migrate to stateful with `Mcp-Session-Id` and a Durable Object (Cloudflare) or distributed session store. Note GitHub issue #1658: stateful sessions cannot be reconstructed across process restarts, which is another reason to stay stateless now.
+
+---
+
+## 4. Codebase reuse map
+
+Verified against the repo on 2026-06-04. Line numbers below are current.
+
+### Reusable as-is (no change)
+- `src/tools/*.ts`: all 25 tool handlers. They call `client.get/post/patch/del` and make zero transport assumptions. Confirmed: every module uses `server.registerTool(name, { description, inputSchema }, handler)`.
+- `src/tools/index.ts`: `registerAllTools(server)` (line 57). Transport-agnostic. Runs identically under stdio and Streamable HTTP.
+- `src/tools/_untrusted.ts`: `fencePaperContent` helper. Unchanged.
+- `src/__tests__/*`: `handlers.test.ts`, `write_tools.test.ts`, `helpers.ts`. The handler suite still validates tool logic under the new transport.
+- `scholarfeed.org/privacy-policy` and `/terms-of-service`: already live, satisfy directory requirements.
+- `@modelcontextprotocol/sdk ^1.29.0`: already ships `StreamableHTTPServerTransport` (`@modelcontextprotocol/sdk/server/streamableHttp`), `requireBearerAuth` (`@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth`), `mcpAuthMetadataRouter`, and the `WebStandardStreamableHTTPServerTransport` for Workers/Deno/Bun. NO SDK upgrade needed.
+
+### Modify (small, surgical)
+- `src/client.ts`: the one substantive change. Today `getApiKey()` (line 30) reads `process.env.SF_API_KEY`; `authHeaders()` (line 41) builds the Bearer header; `getSessionId()` (line 56) memoizes one id per process. For multi-tenant remote use, the API key and session id must be PER-REQUEST, not module-global.
+  - Recommended refactor: change `registerAllTools(server)` and each `register(server)` to accept a credential accessor, for example `register(server, getCreds: () => { apiKey: string | null; sessionId: string })`. The stdio entry point passes `() => ({ apiKey: process.env.SF_API_KEY ?? null, sessionId: <process singleton> })`. The HTTP entry point passes a closure that reads the per-request `AuthInfo` (resolved SF_API_KEY) and a fresh per-request session id. This keeps `ScholarFeedClient`'s verb methods unchanged; only header construction reads from the passed creds.
+  - LIGHTER alternative if the refactor footprint must stay tiny: use `AsyncLocalStorage` to stash per-request creds and have `authHeaders()` / `getSessionId()` read from it, falling back to env when there is no active context. This touches only `client.ts` and the HTTP entry point. Tradeoff: implicit context vs explicit threading. RECOMMENDATION: explicit `getCreds` threading; it is more testable and avoids ALS edge cases under the SDK's request handling.
+- `src/index.ts`: leave as the stdio entry point. Optionally add a `serve` subcommand that boots the HTTP server, OR keep the HTTP server as a fully separate entry file (preferred, see below).
+
+### Net-new
+- `src/server-http.ts` (new HTTP entry point): Express (or Hono for Workers) app. Mounts POST `/mcp` (and GET/DELETE returning 405 in stateless mode). Per request: `new McpServer(...)`, `registerAllTools(server, getCreds)`, `new StreamableHTTPServerTransport({ sessionIdGenerator: undefined })`, `await server.connect(transport)`, `await transport.handleRequest(req, res, req.body)`, close on `res.on('close')`. Wires the bearer-auth middleware and CORS. Estimated 200 to 400 LOC.
+- Auth middleware: `requireBearerAuth({ verifier, requiredScopes, resourceMetadataUrl })` with an `OAuthTokenVerifier` implementation that validates the JWT against the Supabase JWKS endpoint, checks `aud`, and returns `AuthInfo { token, clientId, scopes, expiresAt }`. The transport surfaces this to handlers as `ctx.http?.authInfo`.
+- Token-to-key bridge: given the validated token's `sf_user_id` (sub) claim, look up the account's SF_API_KEY and tier from Supabase, with a short in-memory cache. ~100 LOC. Injects the key into the `getCreds` closure for that request.
+- OAuth discovery endpoints: `mcpAuthMetadataRouter({ oauthMetadata, resourceServerUrl })` mounted at app root: serves `/.well-known/oauth-protected-resource[/mcp]` (RFC 9728) and re-advertises the AS metadata. ~static.
+- Tool annotations: add `title`, `readOnlyHint`, `destructiveHint` to all 25 `server.registerTool(...)` config objects (currently NONE have an `annotations` block or a `title`). See Section 5 for the per-tool hint table.
+- CORS config: expose `Mcp-Session-Id`, `Last-Event-ID`, `Mcp-Protocol-Version`, `WWW-Authenticate`. Validate Origin (DNS-rebinding guard).
+- Supabase Custom Access Token Hook: stamps `aud = https://mcp.scholarfeed.org/mcp`, `sf_user_id`, `sf_tier` onto issued tokens. Backend work, not in this repo.
+- OAuth consent UI at `scholarfeed.org/oauth/authorize`: the AS redirects here for the Scholar-Feed-branded consent screen. Backend/web work.
+- Deployment infra: a persistent HTTPS host (Section 7). The npm package cannot serve HTTP.
+- `package.json`: no `bin` change needed. If a second binary is wanted, add a `serve` subcommand; otherwise deploy `src/server-http.ts` directly from the deployment target's build.
+
+### Tool name length check
+Anthropic caps tool names at 64 chars. All 25 current names are well under (longest is `get_foundational_lineage`, 24 chars). PASS, but re-verify programmatically before submission.
+
+---
+
+## 5. OAuth 2.1 design
+
+### Chosen approach: Supabase Auth as the Authorization Server (Option A), RS in the new MCP service
+Rationale: the backend is already Supabase (`axqpptygcrgyxftzaeka`); users, subscriptions, and the `is_pro` computed flag already live there. Supabase shipped a public-beta OAuth 2.1 server in November 2025 (supabase.com/docs/guides/auth/oauth-server) covering auth-code + PKCE, OIDC discovery, DCR, JWKS, and Custom Access Token Hooks. Using it means zero new identity store and zero account-sync. The MCP server only has to be a Resource Server: validate tokens and look up the key. This is the lowest-friction path for this stack.
+
+FALLBACK: if the Supabase beta proves insufficient on either of the two known gaps below, switch the AS to WorkOS (has an MCP-specific guide, preserves the Supabase user DB via "Connect") or Auth0 (GA for MCP auth, May 2026). Both support CIMD and are tested against claude.ai/ChatGPT. The RS code (token validation + key bridge) is unchanged; only the JWKS URL and metadata pointers change. Do NOT roll a custom AS (Option C) unless both managed paths fail; auth is the highest security-responsibility surface.
+
+Two known Supabase gaps to validate in M3 before committing:
+1. `aud` binding via the Custom Access Token Hook. Supabase's default `aud` is `authenticated` (RLS depends on it). Setting `aud = https://mcp.scholarfeed.org/mcp` must not break existing RLS. ASSUMPTION: issue an MCP-scoped token whose `aud` is the MCP URI, distinct from the standard Supabase session token, via the hook. FALLBACK: if the hook cannot cleanly produce an MCP-audience token, validate `aud` against a custom claim the hook CAN set, or move the AS to WorkOS/Auth0.
+2. CIMD support is unconfirmed in the beta; DCR is confirmed. ASSUMPTION for v1: rely on DCR (RFC 7591), which both Anthropic and OpenAI accept. FALLBACK: if a target host requires CIMD, move the AS to WorkOS/Auth0. Track supabase discussion #38022.
+
+### The .well-known endpoints
+- On the RS (`mcp.scholarfeed.org`): `GET /.well-known/oauth-protected-resource` and `/.well-known/oauth-protected-resource/mcp` (RFC 9728), returning `{ resource: "https://mcp.scholarfeed.org/mcp", authorization_servers: ["<supabase issuer>"], scopes_supported: [...] }`. On every unauthenticated request, return `401` with `WWW-Authenticate: Bearer resource_metadata="https://mcp.scholarfeed.org/.well-known/oauth-protected-resource", scope="sf:read"`.
+- On the AS (Supabase): `/.well-known/oauth-authorization-server` (RFC 8414) and/or `/.well-known/openid-configuration`. Note Supabase serves these under a `/auth/v1` path prefix, so the standard-path probe may miss; the MCP spec requires clients to try both the RFC 8414 path and OIDC discovery, so this is acceptable. Metadata MUST include `code_challenge_methods_supported: ["S256"]` or clients refuse to connect, and SHOULD include `authorization_response_iss_parameter_supported: true` (RFC 9207).
+
+### Mandatory OAuth behaviors (non-negotiable MUSTs)
+- OAuth 2.1 auth-code flow with PKCE, S256 only. No implicit, no ROPC, no client-credentials, no tokens in query strings.
+- `resource` parameter (RFC 8707) included in BOTH the authorization and token requests, set to `https://mcp.scholarfeed.org/mcp`. The RS MUST validate the token `aud` matches and reject otherwise.
+- HTTPS on all endpoints and redirect URIs.
+- Refresh tokens with rotation for public clients (else claude.ai/ChatGPT lose access on expiry). Support `offline_access`.
+- Register redirect URIs: `https://claude.ai/api/mcp/auth_callback`, `https://chatgpt.com/connector/oauth/{callback_id}`, and loopback `127.0.0.1:*` (port-agnostic per RFC 8252, for Claude Code). EXACT-match redirect enforcement will break Claude Code's random-port loopback, so wildcard-loopback matching is required.
+
+### Token-to-account mapping and the tier model
+- The OAuth token carries `sf_user_id` (sub). The RS looks up that account's SF_API_KEY and tier in Supabase. The RS then calls `api.scholarfeed.org` with that server-held SF_API_KEY, never the user token.
+- Tier resolution: the Custom Access Token Hook stamps `sf_tier` (anonymous/free/pro) at issue time. ASSUMPTION: stamp the tier into the token so the RS needs no per-request Supabase round-trip for tier; re-check `is_pro` (live-computed from `subscriptions.current_period_end`) on a short cache TTL so a lapsed trial does not keep Pro access for a full token lifetime. FALLBACK: look up tier per request (adds latency).
+- Scope model (the RFC 9728 `scopes_supported`): minimal initial scope `sf:read` for the anonymous-capable read/search tools, then step-up scopes requested when an account tool is first used: `sf:library`, `sf:collections`, `sf:watches`, `sf:pro` (for `embed_text`, `find_gaps`, `ask_library`). Do NOT request all scopes at first consent (scope-inflation anti-pattern the spec warns against).
+
+### Anonymous tier under OAuth
+The 9 read/search tools work anonymously today. DECISION: the `/mcp` endpoint accepts UNAUTHENTICATED requests and serves the anonymous-capable tools with no token (anonymous 100/day rate limit), and returns the `401 + WWW-Authenticate` only when an account-scoped tool is called without a valid token. This preserves the "try it with zero setup" property on claude.ai self-add and avoids forcing OAuth just to run a search. NOTE: the Anthropic Directory listing still requires the full OAuth stack to exist; anonymous access and OAuth coexist. (For ChatGPT, OAuth is mandatory for the connector flow regardless.)
+
+### Coexistence with existing SF_API_KEYs
+No forced migration. The stdio npm package keeps using `SF_API_KEY` from env, unchanged. OAuth is purely additive on the new remote surface. Returning users link their existing account during OAuth consent (same email = same account); new users get an account provisioned at first authorization. ASSUMPTION: account linking is by email claim. RISK: a user whose claude.ai email differs from their Scholar Feed email needs an explicit link step in the consent UI (Section 9 open decision).
+
+---
+
+## 6. Phased build plan
+
+Milestones are sequenced so M1 is the smallest end-to-end proof and OAuth is staged realistically (discovery metadata before full AS wiring). Parallelizable work is flagged.
+
+### M1: Reachable remote server, anonymous, one host (smallest end-to-end proof)
+Tasks:
+- New `src/server-http.ts`: Express + `StreamableHTTPServerTransport` (stateless), POST `/mcp`, GET/DELETE -> 405.
+- Refactor `src/client.ts` + `registerAllTools` to accept a `getCreds` closure (explicit threading). Stdio path passes the env-based closure; HTTP path passes a closure that, for M1, returns a single server-held SF_API_KEY (or null for anonymous) and a fresh per-request session id.
+- Origin validation + CORS (expose the four MCP headers).
+- Deploy to the chosen host (Section 7) at a temporary `*.workers.dev` / Railway URL over HTTPS.
+ACCEPTANCE: add the URL as a custom connector in claude.ai (paid), call `search_papers` and `get_paper`, get correct results. The handler test suite passes unchanged against the HTTP entry point. NO OAuth yet.
+Parallel: none (foundation). Effort: 2 to 3 days.
+
+### M2: Tool annotations + name audit (directory prerequisite, fully parallel to M3)
+Tasks:
+- Add `title`, `readOnlyHint`, `destructiveHint` to all 25 `registerTool` configs. Hint table:
+  - readOnlyHint TRUE (9 + 3 read tools): `search_papers`, `get_paper`, `get_citations`, `fetch_fulltext`, `find_author`, `co_author_graph`, `embed_text`, `get_field_orientation`, `get_foundational_lineage`, `find_gaps`, `ask_library`, `list_library`, `list_collections`, `list_watches`, `check_watches`, `preview_watch`.
+  - write, NOT destructive (`destructiveHint: false`): `save_paper`, `like_paper`, `create_collection`, `add_to_collection`, `create_watch`, `update_watch`.
+  - destructive (`destructiveHint: true`): `unsave_paper`, `remove_from_collection`, `delete_watch`.
+- Programmatic tool-name length check (<= 64).
+ACCEPTANCE: every tool exposes a `title` and the correct hints; lint/type passes; names verified. Effort: 0.5 to 1 day.
+
+### M3: Supabase AS validation spike (de-risk OAuth before building, parallel to M2)
+Tasks:
+- Confirm the Supabase OAuth 2.1 beta on `axqpptygcrgyxftzaeka` exposes RFC 8414 / OIDC discovery with `S256`.
+- Prototype the Custom Access Token Hook to stamp `aud`, `sf_user_id`, `sf_tier` WITHOUT breaking existing RLS (the `aud=authenticated` concern). Validate the separate-MCP-token approach.
+- Confirm DCR works for an Anthropic/ChatGPT-shaped client; record whether CIMD is available.
+ACCEPTANCE: a token minted by Supabase carries the MCP `aud` + custom claims, RLS still works, and the gap list (CIMD?) is resolved into go/no-go for Supabase vs WorkOS/Auth0. This is a SPIKE; its output is a decision, not production code. Effort: 1 to 2 days. If Supabase fails both gaps, swap to WorkOS/Auth0 here (adds ~1 to 2 days).
+
+### M4: OAuth Resource Server: discovery + token validation + key bridge
+Depends on M1 (server) and M3 (AS decision). Tasks:
+- `mcpAuthMetadataRouter`: serve RFC 9728 protected-resource metadata pointing at the chosen AS.
+- `requireBearerAuth` + `OAuthTokenVerifier`: JWKS signature check, `aud` validation, expiry, scope check. 401 + `WWW-Authenticate` on failure.
+- Token-to-key bridge: `sf_user_id` -> SF_API_KEY + tier (cached). Inject into the request `getCreds`.
+- Wire the anonymous-vs-authenticated split: read tools allowed token-free; account tools require a valid token + scope.
+ACCEPTANCE: an account tool (for example `save_paper`) returns 401 with correct `WWW-Authenticate` when called without a token, and succeeds when called with a valid Supabase-issued token whose `aud` is correct; the backend receives the server-held SF_API_KEY, never the user token (verify in backend logs). Effort: 3 to 5 days.
+
+### M5: End-to-end OAuth on a real host + consent UI
+Depends on M4. Tasks:
+- Build/finish the `scholarfeed.org/oauth/authorize` consent screen (Scholar-Feed-branded, shows scopes + client name).
+- Register redirect URIs (claude.ai, chatgpt.com, loopback wildcard). Enable refresh-token rotation + `offline_access`.
+- Full flow test from claude.ai: connect -> log in -> consent -> token -> call an account tool.
+ACCEPTANCE: a fresh claude.ai user completes OAuth sign-in and successfully calls a Pro-gated account tool; token refresh works after expiry. Effort: 2 to 4 days (much of the consent UI is web/backend work that can run in parallel with M4).
+
+### M6: Production hardening + observability (parallel-friendly, partly overlaps M4/M5)
+Tasks:
+- Rate-limit the public OAuth surface: `/token` ~5 req/min/IP, `/register` (DCR) ~1 req/min/IP; rate-limit `/mcp` per caller (delegate quota to backend but guard probing).
+- Verify SF_API_KEY never appears in tool output, logs, or error messages under the remote transport (the existing `throwApiError` sanitizes 401/403/429; re-verify end to end).
+- Structured request logging / metrics; tie into the interaction-instrumentation backend if it has landed (Section 9).
+- Custom domain `mcp.scholarfeed.org` + TLS.
+ACCEPTANCE: load/abuse probes are throttled; no key leakage in any response path; per-tool-call telemetry visible. Effort: 2 to 3 days.
+
+### M7: Directory submissions (Anthropic first, then OpenAI; serial)
+Depends on M2 + M5 + M6. Per Section 8 checklists. Submit Anthropic first (lower risk, write tools allowed), then OpenAI (expose read-only tools first due to write-tool gating). Effort: 1 to 2 days of prep each + open-ended review wait (no SLA).
+
+### Critical path
+M1 -> M4 -> M5 -> M7. M2 and M3 run fully in parallel to each other and to M1. M6 overlaps M4/M5. Realistic wall-clock: a usable anonymous custom-connector (M1+M2) in roughly one week; directory-ready with OAuth (through M6) in roughly 3 to 5 weeks, gated mostly on the AS work and the consent UI.
+
+---
+
+## 7. Where it lives + deployment / ops
+
+### Recommended host: Cloudflare Workers (primary), Railway (fallback)
+- Cloudflare Workers: native long-lived SSE with no routing timeout, zero cold start, global edge, built-in KV for OAuth/discovery state, `wrangler` secrets, `@cloudflare/workers-oauth-provider` as a first-class primitive, and the `WebStandardStreamableHTTPServerTransport` runs there with no adapter. Cost floor ~$5/month (Workers Paid; only needed if Durable Objects are used, which the stateless design AVOIDS, so the free tier may suffice initially). CAVEAT: Workers is V8 isolates, not Node. `src/client.ts` uses `node:crypto` `randomUUID`; enable `nodejs_compat` in `wrangler.toml` OR swap to WebCrypto `crypto.randomUUID()` (available in Workers). This is the one porting cost.
+- Railway (fallback / fastest-to-ship with zero code port): Node Docker container, no routing timeout, ~$2 to $10/month always-on, deploy-from-GitHub, custom domain + auto-TLS. Node runtime means `node:crypto` works unchanged. Single region (no edge), more ops overhead than Workers.
+- DO NOT use Heroku for this net-new service: it entered sustaining-engineering (maintenance) mode February 2026, and its router enforces a 30s first-byte and 55s idle-SSE timeout that fights MCP session init. The existing backend staying on Heroku is fine; the new MCP service should be decoupled from it (a second argument for Cloudflare).
+
+DECISION for v1: start on Cloudflare Workers stateless (no Durable Objects) using `createMcpHandler` / `WebStandardStreamableHTTPServerTransport`. If the V8 port friction is unacceptable under time pressure, ship M1 on Railway (Node, zero port) and migrate later; the transport code is the only thing that differs.
+
+### Domain + TLS
+`mcp.scholarfeed.org`. OPEN: is `scholarfeed.org` DNS on Cloudflare today? If yes, a Workers Custom Domain is a dashboard click with auto-TLS. If DNS is elsewhere, either delegate the subdomain to Cloudflare or CNAME to the host (Railway/Render) with PaaS-managed TLS. The canonical MCP URI (`https://mcp.scholarfeed.org/mcp`) is the RFC 8707 `resource` value and the token `aud`; decide it BEFORE wiring the Custom Access Token Hook and the RFC 9728 doc, because it is baked into both.
+
+### Rate-limiting / abuse
+The OAuth endpoints are a new public attack surface (credential stuffing, token enumeration, DCR phantom-client abuse). Implement `/token` and `/register` throttles BEFORE launch (M6), not after. Quota for tool calls stays delegated to `api.scholarfeed.org` (anonymous 100/day, free 1k/day, Pro 10k/day); the RS passes through 429s.
+
+### Observability
+Structured logs (no key/PII leakage), per-tool-call counters, OAuth flow success/failure, and a dashboard. Tie into the interaction-instrumentation backend if landed. This is what makes the directory traffic legible (Section 9).
+
+### ZDR note
+The Anthropic MCP connector is NOT eligible for Zero Data Retention. Any enterprise customer with a ZDR agreement must stay on the stdio npm package. Document this.
+
+### Effort summary (engineering days, not wall-clock)
+- M1: 2 to 3 | M2: 0.5 to 1 | M3: 1 to 2 (spike) | M4: 3 to 5 | M5: 2 to 4 | M6: 2 to 3 | M7: 1 to 2 prep each + review wait.
+- Minimal viable (M1+M2, anonymous custom connector): ~3 to 5 days. Full directory-ready (through M6): ~3 to 5 weeks.
+
+---
+
+## 8. Per-platform submission checklists
+
+### Anthropic Connectors Directory (submit FIRST)
+- [ ] Streamable HTTP at `https://mcp.scholarfeed.org/mcp`, POST + GET, Origin validation, HTTPS only.
+- [ ] OAuth 2.1 + PKCE (S256), RFC 9728 protected-resource metadata, RFC 8414 AS metadata, RFC 8707 resource param + `aud` validation, refresh tokens.
+- [ ] Client registration via DCR (or CIMD if available); register `https://claude.ai/api/mcp/auth_callback` + loopback wildcard.
+- [ ] All 25 tools have `title`, `readOnlyHint`, `destructiveHint` (M2 table).
+- [ ] Tool names <= 64 chars (verified).
+- [ ] Privacy policy URL (scholarfeed.org/privacy-policy) and ToS URL (scholarfeed.org/terms-of-service): already live.
+- [ ] Test account with sample data + step-by-step reviewer instructions (must be maintained for re-reviews).
+- [ ] 3 working prompt examples demonstrating core functionality.
+- [ ] Support channel (email or Discord).
+- [ ] Branding: logo (URL or SVG) + favicon. (MCP Apps with UI need 3 to 5 screenshots >=1000px; not applicable unless shipping UI.)
+- [ ] Public documentation (blog post or help-center article) live by publish date.
+- [ ] Answer the health-data checklist item (Scholar Feed: no).
+- [ ] Accept the IP license grant to Anthropic; acknowledge removal-at-any-time.
+- [ ] Submit via clau.de/mcp-directory-submission; escalate status to mcp-review@anthropic.com.
+
+### OpenAI / ChatGPT (submit SECOND)
+- [ ] Streamable HTTP endpoint (SSE backwards-compat ok).
+- [ ] OAuth 2.1 + PKCE + DCR or CIMD (plain API-key bearer is NOT accepted for the connector flow). Register `https://chatgpt.com/connector/oauth/{callback_id}`.
+- [ ] DECIDE write-tool exposure: ChatGPT Plus/Pro are limited to read-only connectors; write connectors gated to Business/Enterprise/Edu. RECOMMENDATION: expose the read-only tool subset on the ChatGPT surface for v1; reserve write tools for when OpenAI broadens access.
+- [ ] OpenAI Platform identity verification.
+- [ ] App metadata: name, logo, description, privacy URL, screenshots, test prompts.
+- [ ] Test account with credentials for reviewers.
+- [ ] (Optional) OpenAI Apps SDK only if a native ChatGPT embedded-UI experience is wanted; not required for plain MCP interop.
+- [ ] Submit via the OpenAI Apps submission flow; no SLA, do not request expedited review.
+
+### Other hosts (no formal review)
+- [ ] Cursor, VS Code/Copilot, Windsurf, Goose: nothing to submit; users add the URL. Confirm OAuth browser flow works on each.
+- [ ] GitHub / Official MCP Registry (low effort, high distribution to editors): add `mcpName` to `package.json` and a `server.json`, publish via the `mcp-publisher` CLI. DECIDE whether to register the stdio package, the remote server, or both. RECOMMENDATION: both.
+- [ ] JetBrains AI, Perplexity: best-effort, low priority; do not block launch on them.
+
+---
+
+## 9. Risks and open decisions
+
+### The instrumentation / ICP tension (call this out loudly)
+Per MEMORY (broaden-icp-and-instrumentation, broaden the ICP toward a B2B author/expert-intelligence wedge), the decision to push for broad web reach is explicitly GATED on instrumenting usage first. This spec builds reach. If it ships before per-interaction instrumentation lands on the backend (`docs/interaction-instrumentation-backend-spec.md`), directory traffic arrives un-measured and the operator cannot tell whether the connector validates the value prop or just inflates a vanity number. HARD RECOMMENDATION: land minimal per-tool-call instrumentation in parallel with M1 to M4 (it is partly M6 anyway), and do not submit to the directories (M7) until tool-call telemetry is live. Building distribution ahead of measurement is the precise anti-pattern the ICP-broadening decision was meant to avoid.
+
+### Fast-moving spec (highest external risk)
+The MCP authorization spec is a draft and iterated three times in 2025 (2025-03-26, 2025-06-18, 2025-11-25); a 2026-07-28 release candidate is on the roadmap. CIMD replaced DCR as preferred only in Nov 2025. Anthropic's and OpenAI's clients may lag the spec. MITIGATION: implement the non-negotiable MUSTs (RFC 9728, PKCE/S256, `aud` validation, `resource` param), keep SHOULDs in the backlog, pin to the spec version the review process accepts at submission time, and budget ongoing maintenance.
+
+### Open decisions the operator must make BEFORE the build starts
+1. AS choice: Supabase Auth (recommended, validate in M3) vs WorkOS/Auth0 fallback. Gated on the M3 spike (aud binding + CIMD).
+2. Canonical MCP URI: `https://mcp.scholarfeed.org/mcp` (recommended) vs `api.scholarfeed.org/mcp`. Baked into `aud` and RFC 9728; decide first.
+3. Host: Cloudflare Workers (recommended, ~$5/mo, one V8 port cost) vs Railway (zero port, single region). Confirm whether scholarfeed.org DNS is on Cloudflare.
+4. Account linking by email: what happens when the host-side email differs from the Scholar Feed email? A consent-time link step is likely needed.
+5. Tier in token vs per-request lookup: stamp `sf_tier` in the token (recommended, short cache) vs look up per request. Affects how fast a lapsed trial loses Pro.
+6. ChatGPT write-tool exposure: read-only subset for v1 (recommended) vs wait for OpenAI to broaden write access.
+7. Stateless now (recommended) vs build stateful for future watch-alert push. Stateless avoids a session store and Durable Object cost; revisit only when push is a real feature.
+8. Internal backend credential model: one server-level SF_API_KEY with user identity in a header, vs per-user internal tokens (affects backend rate-limiting and audit granularity). Decide with the backend team.
+
+### Other notable risks
+- ChatGPT structural limit: write connectors gated to Business/Enterprise/Edu (no fix in our control).
+- Anthropic can remove a listing at any time for any reason; directory ranking is opaque and usage-based. Do not let the business depend on directory traffic.
+- Reviewer test account must be maintained indefinitely (or recreated per re-review).
+- Per-request key threading: the stateless model creates a fresh server stack per request; the `getCreds` closure must be wired so no handler ever fires without the request-scoped key. The explicit-threading refactor (Section 4) is the guard.
+- Confused-deputy / token passthrough: NEVER forward the user OAuth token to `api.scholarfeed.org`. Verify in backend logs (M4 acceptance).
+- SDK 2.0 split (`@modelcontextprotocol/server` / `node` / `express`) is at `2.0.0-alpha.2`; 1.29.0 is fine today but a future migration will move the import paths. Pin and revisit.
+
+---
+
+## 10. Recommended NEXT-SESSION build workflow
+
+Structure the build as a Workflow with serial gates around parallel fan-out. Suggested shape:
+
+### Phase 0: Decision lock (serial, operator-in-the-loop, ~30 min)
+Resolve the 8 open decisions in Section 9 (especially: canonical URI, AS choice pending M3, host). These are inputs every downstream agent needs; do not fan out until they are pinned. Output: a short DECISIONS.md the build agents read.
+
+### Phase 1: Fan out the independent foundations (parallel, 3 agents)
+- Agent A (Transport): build M1 (`src/server-http.ts`, client `getCreds` refactor, stateless transport, CORS/Origin). Owns the handler-suite-passes acceptance.
+- Agent B (Annotations): build M2 (25 tool annotations + name audit). Fully independent of A.
+- Agent C (AS spike): run M3 against Supabase via the `supabase` MCP (project `axqpptygcrgyxftzaeka`). Pure investigation; output is the AS go/no-go decision that unblocks Phase 2.
+These three have no shared files (A touches `client.ts`/new entry, B touches `src/tools/*.ts`, C touches no repo code), so they parallelize cleanly.
+
+### Phase 2: OAuth RS (serial after C's decision, depends on A)
+One focused agent builds M4 (discovery router, bearer middleware + verifier, token-to-key bridge, anonymous/authenticated split). This is the highest-stakes security code; keep it single-owner to preserve a coherent threat model rather than fanning it out.
+
+### Phase 3: Integration + hardening (parallel, 2 agents)
+- Agent D: M5 end-to-end OAuth + consent UI wiring (much is backend/web; coordinate with backend).
+- Agent E: M6 hardening (rate limits, key-leakage audit, observability, custom domain).
+
+### Phase 4: Adversarial verification (serial gate, where it earns its keep)
+Before any submission, run a dedicated adversarial-review agent (separate context from the builders) against the security-critical surface:
+- Try to make a tool handler fire without a request-scoped key (regression of the threading guard).
+- Try to get the user OAuth token forwarded to `api.scholarfeed.org` (token passthrough).
+- Try to leak an SF_API_KEY through any tool output, error, or log path.
+- Send a token with the wrong `aud` and confirm rejection; send no token to an account tool and confirm the 401 + `WWW-Authenticate`.
+- Probe `/token` and `/register` for missing rate limits.
+This adversarial pass is where the workflow adds the most value: the builders optimize for "works", the verifier optimizes for "cannot be abused". Gate M7 on it.
+
+### Phase 5: Submissions (serial, operator-in-the-loop)
+M7: Anthropic first, then OpenAI, using the Section 8 checklists. Operator handles the human paperwork (test account, branding, prompt examples).
+
+### Agent-role summary
+Transport builder, Annotations builder, AS-spike investigator (Supabase MCP), OAuth-RS builder (single owner), Integration/consent builder, Hardening builder, and a separate Adversarial verifier. Fan out Phase 1 and Phase 3; keep Phase 0, 2, 4, 5 serial. The single most important structural choice: keep the OAuth RS single-owner and gate submission on an independent adversarial review.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,18 @@
 {
   "name": "scholar-feed-mcp",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scholar-feed-mcp",
-      "version": "3.7.0",
+      "version": "3.7.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "cors": "^2.8.6",
+        "express": "^5.2.1",
+        "jose": "^6.2.3",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -17,6 +20,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@types/cors": "^2.8.19",
+        "@types/express": "^5.0.6",
         "@types/node": "^20.0.0",
         "c8": "^11.0.0",
         "eslint": "^9.39.4",
@@ -1230,10 +1235,73 @@
         "win32"
       ]
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1259,6 +1327,41 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2989,9 +3092,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
-      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --clean --out-dir build",
     "dev": "tsup src/index.ts --format esm --watch --out-dir build",
+    "dev:http": "tsx src/server-http.ts",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "format": "prettier --write .",
@@ -43,10 +44,15 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "cors": "^2.8.6",
+    "express": "^5.2.1",
+    "jose": "^6.2.3",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@types/cors": "^2.8.19",
+    "@types/express": "^5.0.6",
     "@types/node": "^20.0.0",
     "c8": "^11.0.0",
     "eslint": "^9.39.4",

--- a/src/__tests__/annotations.test.ts
+++ b/src/__tests__/annotations.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tool-annotation + name-audit tests (M2).
+ *
+ * Directory submission (Anthropic Connectors / OpenAI) REQUIRES every tool to
+ * carry a human-readable `title` plus `readOnlyHint`/`destructiveHint`
+ * annotations. These tests register the real tools on the fake server and assert
+ * that all 25 are present, each has a non-empty title, the hints match the
+ * locked M2 table (spec §6 / DECISIONS), and every tool name is within the MCP
+ * 64-char name budget.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { registerAllTools } from "../tools/index.js";
+import { makeFakeServer, type CapturedTool } from "./helpers.js";
+
+/** The locked M2 hint table — the single source of truth for this milestone. */
+const READ_ONLY_TOOLS = [
+  "search_papers",
+  "get_paper",
+  "get_citations",
+  "fetch_fulltext",
+  "find_author",
+  "co_author_graph",
+  "embed_text",
+  "get_field_orientation",
+  "get_foundational_lineage",
+  "find_gaps",
+  "ask_library",
+  "list_library",
+  "list_collections",
+  "list_watches",
+  "check_watches",
+  "preview_watch",
+] as const;
+
+const WRITE_NON_DESTRUCTIVE_TOOLS = [
+  "save_paper",
+  "like_paper",
+  "create_collection",
+  "add_to_collection",
+  "create_watch",
+  "update_watch",
+] as const;
+
+const DESTRUCTIVE_TOOLS = [
+  "unsave_paper",
+  "remove_from_collection",
+  "delete_watch",
+] as const;
+
+const ALL_TOOLS = [
+  ...READ_ONLY_TOOLS,
+  ...WRITE_NON_DESTRUCTIVE_TOOLS,
+  ...DESTRUCTIVE_TOOLS,
+];
+
+function buildTools(): Map<string, CapturedTool> {
+  const { server, tools } = makeFakeServer();
+  registerAllTools(server);
+  return tools;
+}
+
+const TOOLS = buildTools();
+
+function toolFor(name: string): CapturedTool {
+  const t = TOOLS.get(name);
+  if (!t) throw new Error(`tool not registered: ${name}`);
+  return t;
+}
+
+describe("tool registry surface", () => {
+  it("registers exactly the 25 expected tools", () => {
+    assert.strictEqual(TOOLS.size, 25);
+    assert.strictEqual(ALL_TOOLS.length, 25);
+    for (const name of ALL_TOOLS) {
+      assert.ok(TOOLS.has(name), `expected tool "${name}" to be registered`);
+    }
+  });
+
+  it("has no unexpected tools beyond the M2 table", () => {
+    const expected = new Set<string>(ALL_TOOLS);
+    for (const name of TOOLS.keys()) {
+      assert.ok(expected.has(name), `unexpected tool registered: "${name}"`);
+    }
+  });
+});
+
+describe("tool titles", () => {
+  for (const name of ALL_TOOLS) {
+    it(`${name} has a non-empty title`, () => {
+      const { title } = toolFor(name);
+      assert.strictEqual(
+        typeof title,
+        "string",
+        `${name} must have a string title`,
+      );
+      assert.ok(
+        (title ?? "").trim().length > 0,
+        `${name} must have a non-empty title`,
+      );
+    });
+  }
+});
+
+describe("tool annotations match the M2 hint table", () => {
+  for (const name of READ_ONLY_TOOLS) {
+    it(`${name} is readOnlyHint:true, destructiveHint:false`, () => {
+      const { annotations } = toolFor(name);
+      assert.ok(annotations, `${name} must have annotations`);
+      assert.strictEqual(annotations?.readOnlyHint, true);
+      assert.strictEqual(annotations?.destructiveHint, false);
+    });
+  }
+
+  for (const name of WRITE_NON_DESTRUCTIVE_TOOLS) {
+    it(`${name} is readOnlyHint:false, destructiveHint:false`, () => {
+      const { annotations } = toolFor(name);
+      assert.ok(annotations, `${name} must have annotations`);
+      assert.strictEqual(annotations?.readOnlyHint, false);
+      assert.strictEqual(annotations?.destructiveHint, false);
+    });
+  }
+
+  for (const name of DESTRUCTIVE_TOOLS) {
+    it(`${name} is readOnlyHint:false, destructiveHint:true`, () => {
+      const { annotations } = toolFor(name);
+      assert.ok(annotations, `${name} must have annotations`);
+      assert.strictEqual(annotations?.readOnlyHint, false);
+      assert.strictEqual(annotations?.destructiveHint, true);
+    });
+  }
+});
+
+describe("tool name-length audit (<= 64 chars)", () => {
+  for (const name of TOOLS.keys()) {
+    it(`${name} is within the 64-char MCP name budget`, () => {
+      assert.ok(
+        name.length <= 64,
+        `tool name "${name}" is ${name.length} chars, exceeds 64`,
+      );
+    });
+  }
+});

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -15,9 +15,17 @@ export type ToolHandler = (
   args: Record<string, unknown>,
 ) => Promise<ToolResult>;
 
+export interface ToolAnnotations {
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  [key: string]: unknown;
+}
+
 export interface CapturedTool {
+  title?: string;
   description: string;
   inputSchema: Record<string, unknown>;
+  annotations?: ToolAnnotations;
   handler: ToolHandler;
 }
 
@@ -34,12 +42,19 @@ export function makeFakeServer(): {
   const fake = {
     registerTool(
       name: string,
-      def: { description: string; inputSchema: Record<string, unknown> },
+      def: {
+        title?: string;
+        description: string;
+        inputSchema: Record<string, unknown>;
+        annotations?: ToolAnnotations;
+      },
       handler: ToolHandler,
     ): void {
       tools.set(name, {
+        title: def.title,
         description: def.description,
         inputSchema: def.inputSchema,
+        annotations: def.annotations,
         handler,
       });
     },

--- a/src/__tests__/http_credentials.test.ts
+++ b/src/__tests__/http_credentials.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Remote-transport credential threading: the load-bearing no-leak + concurrency
+ * invariants the adversarial review flagged as proven-by-reading-but-untested.
+ *
+ * We point SF_API_BASE_URL at a local capture server that records the inbound
+ * Authorization header, drive the real createApp() over the wire with
+ * `tools/call`, and assert:
+ *   1. an `sf_` bearer is forwarded VERBATIM as the backend Bearer;
+ *   2. a NO-token request stays anonymous (no backend Authorization) EVEN WHEN
+ *      process.env.SF_API_KEY is set — the central no-leak invariant
+ *      (AsyncLocalStorage carries apiKey:null, and client.ts honors the null
+ *      instead of falling back to the process env key);
+ *   3. two CONCURRENT tools/call requests with DIFFERENT sf_ keys each forward
+ *      their OWN key (no cross-request bleed under per-request ALS frames).
+ *
+ * This pins the invariant against SDK / @hono internal scheduling changes that
+ * could silently break AsyncLocalStorage continuity.
+ *
+ * CRITICAL: All logging uses console.error() — never console.log().
+ */
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import http, { type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { createApp } from "../server-http.js";
+
+const MCP_ACCEPT = "application/json, text/event-stream";
+const PROTOCOL_VERSION = "2025-11-25";
+
+interface Captured {
+  auth: string | null;
+  path: string;
+}
+
+function toolCall(
+  id: number,
+  name: string,
+  args: Record<string, unknown> = {},
+) {
+  return {
+    jsonrpc: "2.0" as const,
+    id,
+    method: "tools/call",
+    params: { name, arguments: args },
+  };
+}
+
+describe("remote transport credential threading (no-leak + concurrency)", () => {
+  let backend: Server; // captures outbound backend requests
+  let mcp: Server; // the MCP HTTP server under test
+  let mcpBase: string;
+  const captured: Captured[] = [];
+  const savedEnv: Record<string, string | undefined> = {};
+
+  before(async () => {
+    for (const k of ["SF_API_BASE_URL", "SF_API_KEY"])
+      savedEnv[k] = process.env[k];
+
+    // list_library issues GET /library through the shared client; we only care
+    // about the Authorization header the backend receives, so answer everything
+    // with a valid JSON 200.
+    backend = http.createServer((req, res) => {
+      captured.push({
+        auth: (req.headers["authorization"] as string | undefined) ?? null,
+        path: req.url ?? "",
+      });
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ items: [], total: 0 }));
+    });
+    await new Promise<void>((r) => backend.listen(0, () => r()));
+    const { port: bport } = backend.address() as AddressInfo;
+    process.env.SF_API_BASE_URL = `http://127.0.0.1:${bport}`;
+    // The no-leak guard's worst case: a server-level key present in env.
+    process.env.SF_API_KEY = "sf_SERVER_ENV_MUST_NOT_LEAK";
+
+    const app = createApp();
+    await new Promise<void>((r) => {
+      mcp = app.listen(0, () => r());
+    });
+    const { port: mport } = mcp.address() as AddressInfo;
+    mcpBase = `http://127.0.0.1:${mport}`;
+  });
+
+  after(async () => {
+    await new Promise<void>((r) => mcp.close(() => r()));
+    await new Promise<void>((r) => backend.close(() => r()));
+    for (const k of ["SF_API_BASE_URL", "SF_API_KEY"]) {
+      const v = savedEnv[k];
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  async function callTool(
+    auth: string | undefined,
+    id: number,
+  ): Promise<number> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Accept: MCP_ACCEPT,
+      "MCP-Protocol-Version": PROTOCOL_VERSION,
+    };
+    if (auth) headers.Authorization = auth;
+    const res = await fetch(`${mcpBase}/mcp`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(toolCall(id, "list_library", { limit: 1, page: 1 })),
+    });
+    await res.text();
+    return res.status;
+  }
+
+  it("forwards an sf_ bearer verbatim as the backend Authorization", async () => {
+    captured.length = 0;
+    await callTool("Bearer sf_user_alpha_key", 1);
+    assert.strictEqual(
+      captured.length,
+      1,
+      "backend should be called exactly once",
+    );
+    assert.strictEqual(captured[0].auth, "Bearer sf_user_alpha_key");
+  });
+
+  it("a no-token request stays anonymous EVEN WITH process.env.SF_API_KEY set (no-leak)", async () => {
+    captured.length = 0;
+    await callTool(undefined, 2);
+    assert.strictEqual(
+      captured.length,
+      1,
+      "backend should be called exactly once",
+    );
+    assert.strictEqual(
+      captured[0].auth,
+      null,
+      "an anonymous remote request must NOT forward the server's env SF_API_KEY",
+    );
+  });
+
+  it("two concurrent requests with different sf_ keys each forward their OWN key", async () => {
+    captured.length = 0;
+    await Promise.all([
+      callTool("Bearer sf_concurrent_AAA", 10),
+      callTool("Bearer sf_concurrent_BBB", 11),
+    ]);
+    assert.strictEqual(captured.length, 2, "both backend calls should land");
+    const auths = new Set(captured.map((c) => c.auth));
+    assert.ok(
+      auths.has("Bearer sf_concurrent_AAA"),
+      "AAA key must be forwarded",
+    );
+    assert.ok(
+      auths.has("Bearer sf_concurrent_BBB"),
+      "BBB key must be forwarded",
+    );
+    assert.ok(
+      !auths.has("Bearer sf_SERVER_ENV_MUST_NOT_LEAK"),
+      "the server env key must never appear on any backend call",
+    );
+  });
+});

--- a/src/__tests__/http_transport.test.ts
+++ b/src/__tests__/http_transport.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Remote (Streamable HTTP) transport smoke test.
+ *
+ * Starts the real createApp() on an ephemeral port (app.listen(0)) and drives it
+ * with global fetch over the wire — no supertest, only built-ins + the app. The
+ * goal is to prove the stateless transport is mounted and serves the full MCP
+ * tool surface end to end:
+ *   1. POST /mcp initialize -> a successful JSON-RPC result
+ *   2. POST /mcp tools/list -> all 25 tools (this does NOT call the backend, so
+ *      no network is needed)
+ *   3. GET /mcp -> 405 (stateless)
+ *
+ * Stateless transport detail: each POST gets a fresh McpServer + transport, so
+ * `tools/list` is a self-contained request (validateSession is a no-op when
+ * sessionIdGenerator is undefined). The MCP-Protocol-Version header IS required
+ * on non-initialize requests, so we send a supported version. The transport
+ * answers a single request as an SSE stream by default, so the body parser below
+ * handles BOTH application/json and text/event-stream framings.
+ */
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import type { AddressInfo } from "node:net";
+import type { Server } from "node:http";
+import { createApp, isOriginAllowed, isHostAllowed } from "../server-http.js";
+
+const PROTOCOL_VERSION = "2025-11-25";
+const MCP_ACCEPT = "application/json, text/event-stream";
+
+interface JsonRpcEnvelope {
+  jsonrpc: string;
+  id: number | string | null;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+/**
+ * Extract the JSON-RPC envelope from a /mcp POST response, tolerant of the two
+ * framings the transport can use:
+ *   - application/json: the body IS the envelope.
+ *   - text/event-stream: one or more `data: {...}` lines; take the last data
+ *     payload that parses to a JSON-RPC envelope.
+ */
+function parseMcpResponse(contentType: string, body: string): JsonRpcEnvelope {
+  if (contentType.includes("application/json")) {
+    return JSON.parse(body) as JsonRpcEnvelope;
+  }
+  if (contentType.includes("text/event-stream")) {
+    const dataPayloads = body
+      .split("\n")
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice("data:".length).trim())
+      .filter((s) => s.length > 0);
+    assert.ok(
+      dataPayloads.length > 0,
+      `SSE response carried no data lines:\n${body}`,
+    );
+    // The JSON-RPC result is the last data payload for the request stream.
+    return JSON.parse(dataPayloads[dataPayloads.length - 1]) as JsonRpcEnvelope;
+  }
+  throw new Error(`Unexpected content-type from /mcp: ${contentType}`);
+}
+
+async function postMcp(
+  baseUrl: string,
+  payload: unknown,
+  extraHeaders: Record<string, string> = {},
+): Promise<{ status: number; envelope: JsonRpcEnvelope }> {
+  const res = await fetch(`${baseUrl}/mcp`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: MCP_ACCEPT,
+      "MCP-Protocol-Version": PROTOCOL_VERSION,
+      ...extraHeaders,
+    },
+    body: JSON.stringify(payload),
+  });
+  const contentType = res.headers.get("content-type") ?? "";
+  const text = await res.text();
+  return { status: res.status, envelope: parseMcpResponse(contentType, text) };
+}
+
+describe("remote HTTP transport (Streamable HTTP, stateless)", () => {
+  let server: Server;
+  let baseUrl: string;
+
+  before(async () => {
+    const app = createApp();
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, () => resolve());
+    });
+    const { port } = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  after(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("answers a JSON-RPC initialize over POST /mcp", async () => {
+    const { status, envelope } = await postMcp(baseUrl, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: "http-smoke", version: "0" },
+      },
+    });
+    assert.strictEqual(status, 200);
+    assert.strictEqual(envelope.jsonrpc, "2.0");
+    assert.strictEqual(envelope.error, undefined);
+    const result = envelope.result as {
+      serverInfo?: { name?: string };
+      protocolVersion?: string;
+    };
+    assert.strictEqual(result.serverInfo?.name, "scholar-feed");
+  });
+
+  it("lists all 25 tools over POST /mcp tools/list", async () => {
+    const { status, envelope } = await postMcp(baseUrl, {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+      params: {},
+    });
+    assert.strictEqual(status, 200);
+    assert.strictEqual(envelope.error, undefined);
+    const result = envelope.result as { tools: Array<{ name: string }> };
+    assert.ok(
+      Array.isArray(result.tools),
+      "tools/list must return a tools array",
+    );
+    assert.strictEqual(
+      result.tools.length,
+      25,
+      `expected 25 tools, got ${result.tools.length}: ${result.tools
+        .map((t) => t.name)
+        .join(", ")}`,
+    );
+    // Spot-check a representative read tool and a write tool are present.
+    const names = new Set(result.tools.map((t) => t.name));
+    assert.ok(names.has("search_papers"), "search_papers must be registered");
+    assert.ok(names.has("save_paper"), "save_paper must be registered");
+  });
+
+  it("returns 405 for GET /mcp (stateless: no stream to resume)", async () => {
+    const res = await fetch(`${baseUrl}/mcp`, {
+      method: "GET",
+      headers: { Accept: MCP_ACCEPT },
+    });
+    assert.strictEqual(res.status, 405);
+  });
+
+  it("returns 405 for DELETE /mcp (stateless: no session to delete)", async () => {
+    const res = await fetch(`${baseUrl}/mcp`, { method: "DELETE" });
+    assert.strictEqual(res.status, 405);
+  });
+});
+
+describe("DNS-rebinding guards (Origin + Host)", () => {
+  it("isOriginAllowed: allows no-Origin and loopback (incl. bracketed [::1]); rejects others", () => {
+    assert.strictEqual(isOriginAllowed(undefined), true);
+    assert.strictEqual(isOriginAllowed("http://localhost:3000"), true);
+    assert.strictEqual(isOriginAllowed("http://127.0.0.1:5173"), true);
+    assert.strictEqual(isOriginAllowed("http://[::1]:8080"), true); // IPv6 loopback
+    assert.strictEqual(isOriginAllowed("https://evil.example"), false);
+    assert.strictEqual(isOriginAllowed("not a url"), false);
+  });
+
+  it("isHostAllowed: loopback ok; missing/non-loopback rejected unless allowlisted", () => {
+    assert.strictEqual(isHostAllowed("127.0.0.1:3000"), true);
+    assert.strictEqual(isHostAllowed("localhost:3000"), true);
+    assert.strictEqual(isHostAllowed("[::1]:3000"), true);
+    assert.strictEqual(isHostAllowed(undefined), false);
+    assert.strictEqual(isHostAllowed("evil.example"), false); // no allowlist -> reject
+    const prev = process.env.SF_MCP_ALLOWED_HOSTS;
+    process.env.SF_MCP_ALLOWED_HOSTS = "mcp.scholarfeed.org";
+    try {
+      assert.strictEqual(isHostAllowed("mcp.scholarfeed.org"), true);
+      assert.strictEqual(isHostAllowed("evil.example"), false);
+    } finally {
+      if (prev === undefined) delete process.env.SF_MCP_ALLOWED_HOSTS;
+      else process.env.SF_MCP_ALLOWED_HOSTS = prev;
+    }
+  });
+});

--- a/src/__tests__/http_transport.test.ts
+++ b/src/__tests__/http_transport.test.ts
@@ -113,10 +113,20 @@ describe("remote HTTP transport (Streamable HTTP, stateless)", () => {
     assert.strictEqual(envelope.jsonrpc, "2.0");
     assert.strictEqual(envelope.error, undefined);
     const result = envelope.result as {
-      serverInfo?: { name?: string };
+      serverInfo?: {
+        name?: string;
+        title?: string;
+        icons?: Array<{ src?: string }>;
+      };
       protocolVersion?: string;
     };
     assert.strictEqual(result.serverInfo?.name, "scholar-feed");
+    // Branding the host renders for the connector (title + logo icon).
+    assert.strictEqual(result.serverInfo?.title, "Scholar Feed");
+    assert.ok(
+      result.serverInfo?.icons?.[0]?.src?.startsWith("https://"),
+      "serverInfo must advertise an https icon for the connector logo",
+    );
   });
 
   it("lists all 25 tools over POST /mcp tools/list", async () => {

--- a/src/__tests__/oauth_verifier.test.ts
+++ b/src/__tests__/oauth_verifier.test.ts
@@ -1,0 +1,514 @@
+/**
+ * OAuth 2.1 Resource Server unit tests (M4).
+ *
+ * The verifier is exercised entirely OFFLINE: we generate a local ES256 keypair
+ * with jose, sign test tokens with SignJWT, and inject the PUBLIC key into the
+ * verifier via the testability seam (`keyResolver`). No network, no real JWKS.
+ * The negative cases (expired, wrong aud, HS256, alg=none, missing sub) prove
+ * the verifier rejects exactly what backend/api/auth.py rejects.
+ *
+ * Also covered: the RFC 9728 metadata document shape, the fail-loud
+ * UnconfiguredCredentialResolver, and the unauthorizedResponse() challenge.
+ *
+ * CRITICAL: All logging uses console.error() — never console.log().
+ */
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import type { AddressInfo } from "node:net";
+import type { Server } from "node:http";
+import { generateKeyPair, SignJWT, type CryptoKey } from "jose";
+
+import {
+  ScholarFeedTokenVerifier,
+  mapPayloadToAuthInfo,
+} from "../http/oauth/verifier.js";
+import { createApp } from "../server-http.js";
+import {
+  buildProtectedResourceMetadata,
+  unauthorizedResponse,
+  protectedResourceMetadataUrl,
+  SUPPORTED_SCOPES,
+} from "../http/oauth/metadata.js";
+import {
+  UnconfiguredCredentialResolver,
+  UNCONFIGURED_RESOLVER_MESSAGE,
+} from "../http/oauth/credential-resolver.js";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+
+const AUDIENCE = "https://mcp.scholarfeed.org/mcp";
+const ISSUER = "https://test-as.example/auth/v1";
+
+/** Generate a fresh ES256 keypair for each test that needs one. */
+async function es256(): Promise<{
+  privateKey: CryptoKey;
+  publicKey: CryptoKey;
+}> {
+  const { privateKey, publicKey } = await generateKeyPair("ES256");
+  return {
+    privateKey: privateKey as CryptoKey,
+    publicKey: publicKey as CryptoKey,
+  };
+}
+
+/** Mint an ES256 JWT with the given claims, signed by `privateKey`. */
+async function signEs256(
+  privateKey: CryptoKey,
+  claims: Record<string, unknown>,
+  opts: { expiresIn?: string; setExp?: boolean } = {},
+): Promise<string> {
+  let builder = new SignJWT(claims).setProtectedHeader({ alg: "ES256" });
+  builder = builder.setIssuedAt();
+  if (opts.setExp !== false) {
+    builder = builder.setExpirationTime(opts.expiresIn ?? "5m");
+  }
+  return builder.sign(privateKey);
+}
+
+describe("ScholarFeedTokenVerifier (ES256/JWKS, mirrors backend auth.py)", () => {
+  it("accepts a valid token and maps the claims to AuthInfo", async () => {
+    const { privateKey, publicKey } = await es256();
+    const verifier = new ScholarFeedTokenVerifier({
+      audience: AUDIENCE,
+      keyResolver: publicKey,
+    });
+
+    const token = await signEs256(privateKey, {
+      sub: "user-123",
+      aud: AUDIENCE,
+      iss: ISSUER,
+      email: "researcher@example.com",
+      azp: "client-abc",
+      scope: "sf:read sf:library",
+      sf_tier: "pro",
+    });
+
+    const auth = await verifier.verifyAccessToken(token);
+
+    assert.strictEqual(auth.token, token);
+    assert.strictEqual(auth.clientId, "client-abc");
+    assert.deepStrictEqual(auth.scopes, ["sf:read", "sf:library"]);
+    assert.strictEqual(typeof auth.expiresAt, "number");
+    assert.strictEqual(auth.extra?.sub, "user-123");
+    assert.strictEqual(auth.extra?.email, "researcher@example.com");
+    assert.strictEqual(auth.extra?.tier, "pro");
+  });
+
+  it("falls back azp -> client_id -> '' for clientId, and tier -> '' empty scope", async () => {
+    const { privateKey, publicKey } = await es256();
+    const verifier = new ScholarFeedTokenVerifier({
+      audience: AUDIENCE,
+      keyResolver: publicKey,
+    });
+
+    // No azp; client_id present; plain `tier`; no `scope`.
+    const token = await signEs256(privateKey, {
+      sub: "user-xyz",
+      aud: AUDIENCE,
+      client_id: "client-from-client_id",
+      tier: "free",
+    });
+
+    const auth = await verifier.verifyAccessToken(token);
+    assert.strictEqual(auth.clientId, "client-from-client_id");
+    assert.deepStrictEqual(auth.scopes, []);
+    assert.strictEqual(auth.extra?.tier, "free");
+  });
+
+  it("rejects an expired token", async () => {
+    const { privateKey, publicKey } = await es256();
+    const verifier = new ScholarFeedTokenVerifier({
+      audience: AUDIENCE,
+      keyResolver: publicKey,
+    });
+
+    // exp 60s in the past.
+    const token = await new SignJWT({ sub: "user-1", aud: AUDIENCE })
+      .setProtectedHeader({ alg: "ES256" })
+      .setIssuedAt(Math.floor(Date.now() / 1000) - 120)
+      .setExpirationTime(Math.floor(Date.now() / 1000) - 60)
+      .sign(privateKey);
+
+    await assert.rejects(() => verifier.verifyAccessToken(token));
+  });
+
+  it("rejects a token with the wrong audience", async () => {
+    const { privateKey, publicKey } = await es256();
+    const verifier = new ScholarFeedTokenVerifier({
+      audience: AUDIENCE,
+      keyResolver: publicKey,
+    });
+
+    const token = await signEs256(privateKey, {
+      sub: "user-1",
+      aud: "https://some-other-resource.example/mcp",
+    });
+
+    await assert.rejects(() => verifier.verifyAccessToken(token));
+  });
+
+  it("rejects an HS256 token (alg-confusion guard)", async () => {
+    const { publicKey } = await es256();
+    const verifier = new ScholarFeedTokenVerifier({
+      audience: AUDIENCE,
+      keyResolver: publicKey,
+    });
+
+    // Sign with HS256 using an arbitrary symmetric secret. Even if an attacker
+    // tried to use the (public) verification key as an HMAC secret, the
+    // algorithms allowlist (["ES256"]) rejects it before any signature check.
+    const secret = new TextEncoder().encode(
+      "a-very-long-symmetric-secret-value-padding-padding",
+    );
+    const token = await new SignJWT({ sub: "user-1", aud: AUDIENCE })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(secret);
+
+    await assert.rejects(() => verifier.verifyAccessToken(token));
+  });
+
+  it("rejects an unsigned (alg=none) token", async () => {
+    const { publicKey } = await es256();
+    const verifier = new ScholarFeedTokenVerifier({
+      audience: AUDIENCE,
+      keyResolver: publicKey,
+    });
+
+    // Hand-craft an alg=none compact JWT: header.payload. (no signature).
+    const b64 = (obj: unknown): string =>
+      Buffer.from(JSON.stringify(obj)).toString("base64url");
+    const header = b64({ alg: "none", typ: "JWT" });
+    const payload = b64({
+      sub: "user-1",
+      aud: AUDIENCE,
+      exp: Math.floor(Date.now() / 1000) + 300,
+    });
+    const noneToken = `${header}.${payload}.`;
+
+    await assert.rejects(() => verifier.verifyAccessToken(noneToken));
+  });
+
+  it("rejects a token missing the sub claim", async () => {
+    const { privateKey, publicKey } = await es256();
+    const verifier = new ScholarFeedTokenVerifier({
+      audience: AUDIENCE,
+      keyResolver: publicKey,
+    });
+
+    // Valid signature + aud + exp, but no sub.
+    const token = await signEs256(privateKey, { aud: AUDIENCE });
+
+    await assert.rejects(() => verifier.verifyAccessToken(token));
+  });
+
+  it("rejects a token signed by a DIFFERENT key (bad signature)", async () => {
+    const signer = await es256();
+    const other = await es256();
+    const verifier = new ScholarFeedTokenVerifier({
+      audience: AUDIENCE,
+      keyResolver: other.publicKey, // verify with the WRONG public key
+    });
+
+    const token = await signEs256(signer.privateKey, {
+      sub: "user-1",
+      aud: AUDIENCE,
+    });
+
+    await assert.rejects(() => verifier.verifyAccessToken(token));
+  });
+
+  it("enforces issuer only when enforceIssuer is true", async () => {
+    const { privateKey, publicKey } = await es256();
+
+    // Token has the WRONG issuer.
+    const token = await signEs256(privateKey, {
+      sub: "user-1",
+      aud: AUDIENCE,
+      iss: "https://attacker.example/auth/v1",
+    });
+
+    // enforceIssuer off -> accepted despite the wrong iss.
+    const lenient = new ScholarFeedTokenVerifier({
+      audience: AUDIENCE,
+      keyResolver: publicKey,
+      enforceIssuer: false,
+    });
+    await assert.doesNotReject(() => lenient.verifyAccessToken(token));
+
+    // enforceIssuer on with the expected iss -> rejected.
+    const strict = new ScholarFeedTokenVerifier({
+      audience: AUDIENCE,
+      issuer: ISSUER,
+      enforceIssuer: true,
+      keyResolver: publicKey,
+    });
+    await assert.rejects(() => strict.verifyAccessToken(token));
+
+    // ...and accepted when the iss matches.
+    const goodIssToken = await signEs256(privateKey, {
+      sub: "user-1",
+      aud: AUDIENCE,
+      iss: ISSUER,
+    });
+    await assert.doesNotReject(() => strict.verifyAccessToken(goodIssToken));
+  });
+
+  it("throws on construction when the audience is empty (fail closed, no silent bypass)", async () => {
+    const { publicKey } = await es256();
+    // Explicit empty audience.
+    assert.throws(
+      () =>
+        new ScholarFeedTokenVerifier({ audience: "", keyResolver: publicKey }),
+      /audience is empty/,
+    );
+    assert.throws(
+      () =>
+        new ScholarFeedTokenVerifier({
+          audience: "   ",
+          keyResolver: publicKey,
+        }),
+      /audience is empty/,
+    );
+    // Empty via env (the "export SF_MCP_AUDIENCE=" footgun): `??` would pass "".
+    const prev = process.env.SF_MCP_AUDIENCE;
+    process.env.SF_MCP_AUDIENCE = "";
+    try {
+      assert.throws(
+        () => new ScholarFeedTokenVerifier({ keyResolver: publicKey }),
+        /audience is empty/,
+      );
+    } finally {
+      if (prev === undefined) delete process.env.SF_MCP_AUDIENCE;
+      else process.env.SF_MCP_AUDIENCE = prev;
+    }
+  });
+});
+
+describe("mapPayloadToAuthInfo", () => {
+  it("throws when sub is absent or empty", () => {
+    assert.throws(() => mapPayloadToAuthInfo("tok", { aud: AUDIENCE }));
+    assert.throws(() =>
+      mapPayloadToAuthInfo("tok", { sub: "", aud: AUDIENCE }),
+    );
+  });
+});
+
+describe("RFC 9728 protected-resource metadata", () => {
+  it("has the expected shape and scopes", () => {
+    const doc = buildProtectedResourceMetadata();
+    assert.strictEqual(doc.resource, AUDIENCE);
+    assert.deepStrictEqual(doc.scopes_supported, [...SUPPORTED_SCOPES]);
+    assert.deepStrictEqual(doc.bearer_methods_supported, ["header"]);
+    assert.deepStrictEqual(SUPPORTED_SCOPES, [
+      "sf:read",
+      "sf:library",
+      "sf:collections",
+      "sf:watches",
+      "sf:pro",
+    ]);
+  });
+});
+
+describe("UnconfiguredCredentialResolver", () => {
+  it("throws the documented open-decision-#8 message", async () => {
+    const resolver = new UnconfiguredCredentialResolver();
+    const fakeAuth: AuthInfo = {
+      token: "tok",
+      clientId: "c",
+      scopes: ["sf:read"],
+      extra: { sub: "user-1" },
+    };
+    await assert.rejects(
+      () => resolver.resolve(fakeAuth),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.strictEqual(err.message, UNCONFIGURED_RESOLVER_MESSAGE);
+        // Spot-check the message documents the unrecoverable-hash reality + #8.
+        assert.match(err.message, /SHA-256 hashes/);
+        assert.match(err.message, /open decision #8/);
+        return true;
+      },
+    );
+  });
+});
+
+describe("server-http OAuth wiring (createApp, over the wire)", () => {
+  // A test-keyed verifier (local ES256 public key injected) + the DEFAULT
+  // fail-loud resolver, mounted on a real ephemeral listener. Proves the JWT
+  // path verifies, never forwards the user token, and surfaces 501 (resolver
+  // unconfigured) / 401 (bad token) exactly as the milestone requires.
+  let server: Server;
+  let baseUrl: string;
+  let privateKey: CryptoKey;
+
+  before(async () => {
+    const kp = await es256();
+    privateKey = kp.privateKey;
+    const verifier = new ScholarFeedTokenVerifier({
+      audience: AUDIENCE,
+      keyResolver: kp.publicKey,
+    });
+    const app = createApp({ verifier });
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, () => resolve());
+    });
+    const { port } = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  after(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  const MCP_ACCEPT = "application/json, text/event-stream";
+  const PROTOCOL_VERSION = "2025-11-25";
+
+  function toolCall(name: string) {
+    return {
+      jsonrpc: "2.0" as const,
+      id: 1,
+      method: "tools/call",
+      params: { name, arguments: {} },
+    };
+  }
+
+  async function postMcp(
+    auth: string | undefined,
+    payload: unknown,
+  ): Promise<{ status: number; wwwAuth: string | null; text: string }> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Accept: MCP_ACCEPT,
+      "MCP-Protocol-Version": PROTOCOL_VERSION,
+    };
+    if (auth) headers.Authorization = auth;
+    const res = await fetch(`${baseUrl}/mcp`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+    });
+    return {
+      status: res.status,
+      wwwAuth: res.headers.get("www-authenticate"),
+      text: await res.text(),
+    };
+  }
+
+  it("serves RFC 9728 metadata at the well-known path", async () => {
+    const res = await fetch(`${baseUrl}/.well-known/oauth-protected-resource`);
+    assert.strictEqual(res.status, 200);
+    const doc = (await res.json()) as {
+      resource: string;
+      scopes_supported: string[];
+      bearer_methods_supported: string[];
+    };
+    assert.strictEqual(doc.resource, AUDIENCE);
+    assert.deepStrictEqual(doc.bearer_methods_supported, ["header"]);
+    assert.ok(doc.scopes_supported.includes("sf:read"));
+  });
+
+  it("also serves metadata at the /mcp-suffixed well-known path", async () => {
+    const res = await fetch(
+      `${baseUrl}/.well-known/oauth-protected-resource/mcp`,
+    );
+    assert.strictEqual(res.status, 200);
+  });
+
+  it("returns 401 + WWW-Authenticate for an invalid JWT bearer", async () => {
+    const { status, wwwAuth } = await postMcp(
+      "Bearer eyJhbGciOiJFUzI1NiJ9.bogus.signature",
+      toolCall("save_paper"),
+    );
+    assert.strictEqual(status, 401);
+    assert.ok(wwwAuth, "WWW-Authenticate header must be present on 401");
+    assert.match(wwwAuth, /^Bearer /);
+    assert.match(wwwAuth, /resource_metadata="/);
+    assert.match(wwwAuth, /scope="sf:read"/);
+  });
+
+  it("returns 501 for a VALID JWT (verified, but backend credential model pending #8)", async () => {
+    const token = await signEs256(privateKey, {
+      sub: "user-1",
+      aud: AUDIENCE,
+      scope: "sf:read sf:library",
+    });
+    const { status, text } = await postMcp(
+      `Bearer ${token}`,
+      toolCall("save_paper"),
+    );
+    assert.strictEqual(status, 501);
+    // The honest message documents the open decision, not a generic 500.
+    assert.match(text, /open decision #8/);
+    // And it MUST NOT leak the verified user's JWT back to the caller.
+    assert.ok(
+      !text.includes(token),
+      "501 body must not echo the user's OAuth token",
+    );
+  });
+
+  it("preserves the anonymous path: no token -> tool runs (backend handles caps)", async () => {
+    // tools/list needs no backend call and no token; it must still succeed,
+    // proving the OAuth wiring did not break the anonymous/read surface.
+    const { status } = await postMcp(undefined, {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+      params: {},
+    });
+    assert.strictEqual(status, 200);
+  });
+
+  it("preserves the sf_ bearer path: an sf_ key is NOT treated as a JWT", async () => {
+    // An sf_ key must take the passthrough path (not the verifier). tools/list
+    // succeeds without any 401/501 from the OAuth layer.
+    const { status } = await postMcp("Bearer sf_test_fake_key_value", {
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/list",
+      params: {},
+    });
+    assert.strictEqual(status, 200);
+  });
+});
+
+describe("unauthorizedResponse()", () => {
+  it("sets WWW-Authenticate with resource_metadata and emits 401", () => {
+    const headers: Record<string, string> = {};
+    let statusCode = 0;
+    let jsonBody: unknown;
+    // Minimal Express Response double.
+    const res = {
+      setHeader(name: string, value: string) {
+        headers[name] = value;
+      },
+      status(code: number) {
+        statusCode = code;
+        return this;
+      },
+      json(body: unknown) {
+        jsonBody = body;
+        return this;
+      },
+    };
+
+    unauthorizedResponse(
+      res as unknown as Parameters<typeof unauthorizedResponse>[0],
+    );
+
+    assert.strictEqual(statusCode, 401);
+    const challenge = headers["WWW-Authenticate"];
+    assert.ok(challenge, "WWW-Authenticate header must be set");
+    assert.match(challenge, /^Bearer /);
+    assert.ok(
+      challenge.includes(
+        `resource_metadata="${protectedResourceMetadataUrl()}"`,
+      ),
+      `challenge must carry resource_metadata: ${challenge}`,
+    );
+    assert.match(challenge, /scope="sf:read"/);
+    const body = jsonBody as { error?: { code?: number } };
+    assert.strictEqual(body.error?.code, -32001);
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -8,11 +8,17 @@
  * so importing this module has no side effects — that keeps the unit tests honest
  * and lets each test set env per case.
  *
+ * The API key and session id additionally honor a per-request AsyncLocalStorage
+ * context when one is active (the remote Streamable HTTP transport sets it),
+ * falling back to process.env / a per-process singleton when there is none (the
+ * stdio path). See src/http/credentials.ts.
+ *
  * CRITICAL: All logging uses console.error() — never console.log().
  * console.log() on stdout would corrupt the JSON-RPC stdio transport.
  */
 
 import { randomUUID } from "node:crypto";
+import { getCurrentCreds } from "./http/credentials.js";
 
 const DEFAULT_BASE_URL = "https://api.scholarfeed.org/api/v1";
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -27,7 +33,17 @@ function getBaseUrl(): string {
   return process.env.SF_API_BASE_URL ?? DEFAULT_BASE_URL;
 }
 
+// API key resolution. On the remote (Streamable HTTP) transport an
+// AsyncLocalStorage context carries the per-request key, so each caller forwards
+// its OWN downstream key. With no active context (the stdio path and the
+// env-based unit tests) we fall back to process.env, preserving current
+// behavior. Note `getCurrentCreds().apiKey` may itself be null (an anonymous
+// remote request); in that case we honor the null and do NOT fall through to the
+// process env, so a server-level SF_API_KEY can never leak into an anonymous
+// remote request.
 function getApiKey(): string | null {
+  const creds = getCurrentCreds();
+  if (creds) return creds.apiKey;
   return process.env.SF_API_KEY ?? null;
 }
 
@@ -54,6 +70,12 @@ function authHeaders(): Record<string, string> {
  */
 let sessionId: string | null = null;
 function getSessionId(): string {
+  // On the remote transport each request supplies its own fresh session id via
+  // the ALS context; use it so the backend collapses that one request's fan-out
+  // (not the whole multi-tenant process) into a single session. With no active
+  // context, fall back to the stdio path's per-process lazy singleton.
+  const creds = getCurrentCreds();
+  if (creds) return creds.sessionId;
   return (sessionId ??= randomUUID());
 }
 
@@ -240,7 +262,19 @@ class ScholarFeedClient {
             "Raise the limit with SF_API_TIMEOUT_MS if needed.",
         );
       }
-      throw err;
+      // Any other fetch failure (DNS, ECONNREFUSED, TLS, undici "fetch failed")
+      // must not surface raw: the error — and especially `err.cause` — can
+      // disclose the backend hostname / resolved IP / port (e.g.
+      // "getaddrinfo ENOTFOUND <host>", "connect ECONNREFUSED <ip:port>") to the
+      // model. Log the raw error to stderr only and throw a sanitized message.
+      console.error(
+        "[client] network error reaching the Scholar Feed API:",
+        err,
+      );
+      throw new Error(
+        "Could not reach the Scholar Feed API (a transient network or upstream " +
+          "error). Please try again shortly.",
+      );
     }
   }
 

--- a/src/http/credentials.ts
+++ b/src/http/credentials.ts
@@ -1,0 +1,61 @@
+/**
+ * Per-request credential context for the remote (Streamable HTTP) transport.
+ *
+ * The stdio entry point reads credentials from process.env once per process.
+ * The remote HTTP entry point serves many callers from one process, so the API
+ * key and session id must be PER-REQUEST, not module-global. We carry them in an
+ * AsyncLocalStorage store: the HTTP entry sets the store for the duration of one
+ * request->response, and client.ts reads it when a context is active, falling
+ * back to env when there is none (which preserves the stdio path and the
+ * existing env-based unit tests).
+ *
+ * Stateless Streamable HTTP has no server-initiated push, so each request is
+ * fully contained in a single async context — the exact case ALS handles
+ * correctly. (Server-to-client streaming would break ALS continuity; do not
+ * adopt this pattern if v1 ever goes stateful with push.)
+ *
+ * Side-effect-free on import: constructing an AsyncLocalStorage allocates no
+ * resources and runs no I/O, matching the call-time config reads in client.ts.
+ *
+ * CRITICAL: All logging uses console.error() — never console.log().
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * The credentials resolved for a single inbound MCP request.
+ *
+ * - `apiKey`: the downstream Scholar Feed `sf_` key to forward to
+ *   api.scholarfeed.org as the Bearer, or null for an anonymous request.
+ * - `sessionId`: an opaque per-request id stamped as `X-SF-Session` so the
+ *   backend can stitch one request's fan-out together. Generated fresh per
+ *   request by the HTTP entry point (unlike the stdio path's per-process id).
+ */
+export interface RequestCreds {
+  apiKey: string | null;
+  sessionId: string;
+}
+
+/**
+ * The ALS store. Exported so the HTTP entry point (and tests) can reference the
+ * same instance; prefer the runWithCreds / getCurrentCreds helpers below.
+ */
+export const credsStore = new AsyncLocalStorage<RequestCreds>();
+
+/**
+ * Run `fn` with `creds` bound as the active request context. Everything awaited
+ * synchronously within `fn` (the whole transport.handleRequest -> tool handler
+ * -> client.* chain) sees these creds via getCurrentCreds().
+ */
+export function runWithCreds<T>(creds: RequestCreds, fn: () => T): T {
+  return credsStore.run(creds, fn);
+}
+
+/**
+ * The creds for the currently-active request, or undefined when no context is
+ * set (the stdio path and the env-based unit tests). client.ts uses this to
+ * decide between per-request creds and the process.env fallback.
+ */
+export function getCurrentCreds(): RequestCreds | undefined {
+  return credsStore.getStore();
+}

--- a/src/http/oauth/credential-resolver.ts
+++ b/src/http/oauth/credential-resolver.ts
@@ -1,0 +1,95 @@
+/**
+ * The token->key bridge SEAM (open backend decision #8).
+ *
+ * After the verifier validates an OAuth access token, the remote MCP server
+ * must obtain a DOWNSTREAM credential to call api.scholarfeed.org with. It MUST
+ * NOT forward the user's OAuth token to the backend — that is confused-deputy
+ * token passthrough, forbidden by the MCP spec. The backend is only ever called
+ * with an `sf_` key (or whatever credential model the backend ultimately
+ * chooses), never the user JWT.
+ *
+ * The spec originally wrote this bridge as "SELECT the account's SF_API_KEY".
+ * That is IMPOSSIBLE against the live schema: `api_keys` stores only
+ * `key_hash` (SHA-256 of the raw `sf_` key) and the raw key is unrecoverable
+ * (verified against scholar-feed/backend/api/auth.py:get_api_key_user, which
+ * hashes the inbound token and looks it up — there is no column holding the raw
+ * key to read back). So the bridge is a typed SEAM with a fail-loud default;
+ * the backend must pick the credential model before this can resolve.
+ *
+ * The three candidate models (open decision #8) are:
+ *   (a) RS mints a per-user `sf_` key on first authorization — needs an
+ *       `api_keys` insert PLUS a secure raw-key store (the raw key cannot be
+ *       reconstructed from the hash, so it must be retained somewhere safe at
+ *       mint time, or re-minted+revoked each session).
+ *   (b) A GoTrue admin "act-as-user" JWT with `aud=authenticated`, forwarded to
+ *       the backend's existing JWT path (the backend already validates that
+ *       audience). The RS would mint this server-side from the verified `sub`.
+ *   (c) A single service credential plus a trusted `X-SF-User-Id` header that
+ *       the backend reads to attribute the call to the user.
+ *
+ * CRITICAL: All logging uses console.error() — never console.log().
+ */
+
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+
+/**
+ * The downstream credential a CredentialResolver produces for one verified
+ * request. The HTTP entry point turns this into the per-request creds the
+ * client forwards to api.scholarfeed.org.
+ *
+ * - `apiKey`: the `sf_` key to send as the backend Bearer, or null if the
+ *   chosen model carries identity by header instead (model (c)).
+ * - `headers`: extra backend headers (e.g. `X-SF-User-Id` for model (c), or an
+ *   `Authorization` an act-as-user JWT would occupy for model (b)). Never
+ *   contains the user's OAuth token. NOT YET PLUMBED end to end: the HTTP wiring
+ *   currently FAILS LOUD (501) if a resolver returns a non-empty `headers`, since
+ *   RequestCreds (src/http/credentials.ts) carries only `apiKey`. Extend
+ *   RequestCreds + client.ts before adopting a header-bearing model (b)/(c).
+ * - `tier`: the resolved tier (anonymous/free/pro) for downstream gating/logging.
+ */
+export interface ResolvedCredential {
+  apiKey: string | null;
+  headers?: Record<string, string>;
+  tier: string;
+}
+
+/**
+ * The token->key bridge. Given a verified `AuthInfo` (the OAuth token's mapped
+ * claims, including `extra.sub` and `extra.tier`), resolve the downstream
+ * backend credential. Implementations MUST NOT return the user's OAuth token as
+ * the credential.
+ */
+export interface CredentialResolver {
+  resolve(auth: AuthInfo): Promise<ResolvedCredential>;
+}
+
+/**
+ * The message the unconfigured default throws. Exported so the wiring layer can
+ * surface it in the 501 response and so the test can assert on it verbatim.
+ */
+export const UNCONFIGURED_RESOLVER_MESSAGE =
+  "OAuth token verified, but the backend credential model is not configured " +
+  "(open decision #8). Raw sf_ keys are stored ONLY as SHA-256 hashes " +
+  "(api_keys.key_hash) and are UNRECOVERABLE, so there is no SELECT that " +
+  "returns a usable key for a verified user. The backend must choose one of: " +
+  "(a) RS mints a per-user sf_ key on first authorization (needs an api_keys " +
+  "insert plus a secure raw-key store); (b) a GoTrue admin act-as-user JWT " +
+  "with aud=authenticated, forwarded to the backend's JWT path; or " +
+  "(c) a service credential plus a trusted X-SF-User-Id header. Until then, " +
+  "OAuth-authenticated account tools cannot reach api.scholarfeed.org.";
+
+/**
+ * The default resolver. It THROWS, on purpose: there is no correct way to turn a
+ * verified user into a downstream key until the backend picks a model (#8).
+ * Failing loud here (mapped to a clear 501 by the wiring) is strictly better
+ * than silently inventing a credential or — worse — forwarding the user token.
+ */
+export class UnconfiguredCredentialResolver implements CredentialResolver {
+  // Accepts the auth for interface conformance; intentionally unused — there is
+  // nothing to resolve until the backend model lands. The `void auth` keeps the
+  // param referenced (no-unused-vars) without an eslint-disable.
+  async resolve(auth: AuthInfo): Promise<ResolvedCredential> {
+    void auth;
+    throw new Error(UNCONFIGURED_RESOLVER_MESSAGE);
+  }
+}

--- a/src/http/oauth/metadata.ts
+++ b/src/http/oauth/metadata.ts
@@ -1,0 +1,117 @@
+/**
+ * RFC 9728 OAuth 2.0 Protected Resource Metadata for the remote MCP server.
+ *
+ * Hosts that hit `/mcp` without (or with an invalid) token receive a
+ * `401 + WWW-Authenticate: Bearer resource_metadata="<url>", scope="sf:read"`.
+ * They then GET the protected-resource metadata document advertised in that
+ * header to discover which Authorization Server(s) can mint a token for this
+ * resource. We hand-roll the two `.well-known` routes (rather than mounting the
+ * SDK `mcpAuthMetadataRouter`, which also wants a full AS metadata object) so
+ * the document is exactly the RFC 9728 shape the spec section 5 fixes and so
+ * it stays a thin, framework-light handler for the eventual Workers port.
+ *
+ * Both the bare path and the `/mcp`-suffixed path are served because clients
+ * derive the metadata URL two ways: some use the bare well-known path, others
+ * append the resource's path component per RFC 9728 section 3.1
+ * (`/.well-known/oauth-protected-resource/mcp`). Serving both avoids a
+ * discovery miss.
+ *
+ * CRITICAL: All logging uses console.error() — never console.log().
+ */
+
+import type { Express, Request, Response } from "express";
+import type { OAuthProtectedResourceMetadata } from "@modelcontextprotocol/sdk/shared/auth.js";
+
+/** Canonical MCP resource URI / token `aud` when env does not override it. */
+const DEFAULT_RESOURCE_URI = "https://mcp.scholarfeed.org/mcp";
+
+/**
+ * The OAuth scopes this resource understands. Minimal `sf:read` plus the
+ * step-up scopes account tools will request. Advertised so hosts can request
+ * them incrementally rather than at first consent (scope-inflation guard).
+ */
+export const SUPPORTED_SCOPES = [
+  "sf:read",
+  "sf:library",
+  "sf:collections",
+  "sf:watches",
+  "sf:pro",
+] as const;
+
+/** The two well-known paths we serve the protected-resource doc under. */
+export const PROTECTED_RESOURCE_PATH = "/.well-known/oauth-protected-resource";
+export const PROTECTED_RESOURCE_PATH_MCP =
+  "/.well-known/oauth-protected-resource/mcp";
+
+/** The MCP resource URI (token `aud`). Read at call time so tests can set env. */
+export function resourceUri(): string {
+  return process.env.SF_MCP_RESOURCE_URI ?? DEFAULT_RESOURCE_URI;
+}
+
+/**
+ * Build the RFC 9728 protected-resource metadata document. `authorization_servers`
+ * is populated from SF_OAUTH_ISSUER when set; omitted (rather than an empty
+ * array, which is invalid per the schema) when no issuer is configured yet so
+ * the document still validates during the AS-pending window.
+ */
+export function buildProtectedResourceMetadata(): OAuthProtectedResourceMetadata {
+  const issuer = process.env.SF_OAUTH_ISSUER;
+  const metadata: OAuthProtectedResourceMetadata = {
+    resource: resourceUri(),
+    scopes_supported: [...SUPPORTED_SCOPES],
+    bearer_methods_supported: ["header"],
+  };
+  if (issuer) {
+    metadata.authorization_servers = [issuer];
+  }
+  return metadata;
+}
+
+/**
+ * The absolute URL of the protected-resource metadata document, for the
+ * `resource_metadata` field of the WWW-Authenticate challenge. Derived from the
+ * resource URI's origin so it tracks SF_MCP_RESOURCE_URI automatically.
+ */
+export function protectedResourceMetadataUrl(): string {
+  const origin = new URL(resourceUri()).origin;
+  return `${origin}${PROTECTED_RESOURCE_PATH}`;
+}
+
+/**
+ * Emit an RFC 9728 / RFC 6750 `401 Unauthorized` with the WWW-Authenticate
+ * challenge that points the host at the protected-resource metadata. This is
+ * the single place the challenge header is constructed so every unauthenticated
+ * path produces an identical, spec-correct value.
+ *
+ * Header form:
+ *   WWW-Authenticate: Bearer resource_metadata="<url>", scope="sf:read"
+ *
+ * The `scope` advertises the minimum scope (`sf:read`); a host that needs a
+ * step-up scope discovers it from the metadata document's `scopes_supported`.
+ */
+export function unauthorizedResponse(
+  res: Response,
+  message = "Authentication required: a valid OAuth bearer token is needed for this tool.",
+): void {
+  const challenge =
+    `Bearer resource_metadata="${protectedResourceMetadataUrl()}", ` +
+    `scope="sf:read"`;
+  res.setHeader("WWW-Authenticate", challenge);
+  res.status(401).json({
+    jsonrpc: "2.0",
+    error: { code: -32001, message },
+    id: null,
+  });
+}
+
+/**
+ * Mount the RFC 9728 metadata routes at the app root. Serves the same document
+ * at the bare and `/mcp`-suffixed well-known paths (see file header).
+ */
+export function mountMetadataRoutes(app: Express): void {
+  const handler = (_req: Request, res: Response): void => {
+    res.status(200).json(buildProtectedResourceMetadata());
+  };
+  app.get(PROTECTED_RESOURCE_PATH, handler);
+  app.get(PROTECTED_RESOURCE_PATH_MCP, handler);
+}

--- a/src/http/oauth/verifier.ts
+++ b/src/http/oauth/verifier.ts
@@ -1,0 +1,284 @@
+/**
+ * OAuth 2.1 Resource Server token verifier (ES256 / JWKS).
+ *
+ * This is the security core of the remote MCP server. It implements the MCP SDK
+ * `OAuthTokenVerifier` interface (`verifyAccessToken(token): Promise<AuthInfo>`)
+ * by validating a Supabase-issued access token the same way the production
+ * backend does (scholar-feed/backend/api/auth.py `decode_supabase_jwt`):
+ *
+ *   - ES256 ONLY. The algorithm allowlist is LOCKED to ["ES256"]. jose checks
+ *     the JWS `alg` against this list BEFORE any signature verification, so a
+ *     token claiming `none`, `HS256`, or `RS256` is rejected outright. This is
+ *     the alg-confusion guard: an asymmetric verifier that also accepted HS256
+ *     could be tricked into verifying an attacker-forged token against the
+ *     PUBLIC key used as an HMAC secret.
+ *   - Signature verified against the AS JWKS (Supabase
+ *     `{SUPABASE_URL}/auth/v1/.well-known/jwks.json`) via createRemoteJWKSet,
+ *     which caches keys and handles rotation.
+ *   - `aud` MUST equal the MCP resource URI (NOT Supabase's default
+ *     `authenticated`). jose enforces this when `audience` is passed. The
+ *     Custom Access Token Hook that stamps this `aud` is backend work and OUT
+ *     OF SCOPE here; the target is read from env so the AS can be swapped
+ *     (Supabase -> WorkOS/Auth0) by config alone.
+ *   - `exp` enforced by jose (a token with no `exp` or a past `exp` is
+ *     rejected).
+ *   - `sub` REQUIRED and explicitly re-checked (defense in depth; jose does not
+ *     require `sub` on its own).
+ *   - `iss` enforced ONLY when SF_OAUTH_ENFORCE_ISSUER is truthy, mirroring the
+ *     backend's gated `enforce_jwt_issuer`. An incorrect expected issuer would
+ *     401 every real token, and the exact value cannot be confirmed against a
+ *     live token from here, so enforcement is opt-in.
+ *
+ * On any validation failure this THROWS; the bearer-auth layer maps the throw
+ * to a 401 + WWW-Authenticate challenge. It never returns a partially-validated
+ * AuthInfo.
+ *
+ * TESTABILITY SEAM: the constructor accepts an optional `keyResolver` — a jose
+ * key (CryptoKey/KeyObject/JWK/Uint8Array) or a JWTVerifyGetKey function. When
+ * provided it is used verbatim instead of createRemoteJWKSet, so unit tests
+ * verify tokens signed by a locally-generated ES256 keypair with NO network.
+ * Production omits it and the remote JWKS is built lazily from `jwksUrl`.
+ *
+ * CRITICAL: All logging uses console.error() — never console.log().
+ */
+
+import {
+  createRemoteJWKSet,
+  jwtVerify,
+  type JWTPayload,
+  type JWTVerifyGetKey,
+  type CryptoKey,
+  type KeyObject,
+  type JWK,
+} from "jose";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import type { OAuthTokenVerifier } from "@modelcontextprotocol/sdk/server/auth/provider.js";
+
+/** The only signature algorithm we trust. LOCKED — see file header. */
+const ALLOWED_ALGORITHMS = ["ES256"] as const;
+
+/** The MCP resource URI the token `aud` must equal (default canonical URI). */
+const DEFAULT_AUDIENCE = "https://mcp.scholarfeed.org/mcp";
+
+/**
+ * A key the verifier can hand to jose's `jwtVerify`. This is exactly the union
+ * `jwtVerify` accepts: a static key (CryptoKey/KeyObject/JWK/Uint8Array) for the
+ * single-overload, or a JWTVerifyGetKey resolver (what createRemoteJWKSet
+ * returns) for the dynamic overload.
+ */
+export type KeyResolver =
+  | CryptoKey
+  | KeyObject
+  | JWK
+  | Uint8Array
+  | JWTVerifyGetKey;
+
+/** Construction-time options. All optional; production reads from env. */
+export interface VerifierOptions {
+  /**
+   * The expected token `aud`. Defaults to SF_MCP_AUDIENCE, then the canonical
+   * MCP resource URI.
+   */
+  audience?: string;
+  /**
+   * The expected `iss`. Only enforced when `enforceIssuer` is true.
+   * Defaults to SF_OAUTH_ISSUER.
+   */
+  issuer?: string;
+  /**
+   * Whether to enforce the `iss` claim. Defaults to the truthiness of
+   * SF_OAUTH_ENFORCE_ISSUER (mirrors the backend's `enforce_jwt_issuer` gate).
+   */
+  enforceIssuer?: boolean;
+  /**
+   * The JWKS URL to fetch signing keys from. Defaults to SF_OAUTH_JWKS_URL,
+   * then `{SF_OAUTH_ISSUER}/.well-known/jwks.json`. For Supabase the form is
+   * `{SUPABASE_URL}/auth/v1/.well-known/jwks.json`.
+   */
+  jwksUrl?: string;
+  /**
+   * TESTABILITY SEAM. An injected jose key or JWTVerifyGetKey. When set, this is
+   * used to verify signatures instead of building a remote JWKS, so tests can
+   * sign with a local ES256 keypair and verify with its public key offline.
+   */
+  keyResolver?: KeyResolver;
+}
+
+/**
+ * Read SF_OAUTH_ENFORCE_ISSUER as a boolean. Truthy = the literal "1", "true",
+ * "yes", "on" (case-insensitive); everything else (including unset) is false.
+ * This mirrors the backend treating it as an off-by-default gate.
+ */
+function envIssuerEnforced(): boolean {
+  const raw = (process.env.SF_OAUTH_ENFORCE_ISSUER ?? "").trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+
+/**
+ * Compute the default JWKS URL from the issuer when no explicit URL is set.
+ * Standard RFC 8414 path is `{issuer}/.well-known/jwks.json`. (Supabase serves
+ * its keys at `{SUPABASE_URL}/auth/v1/.well-known/jwks.json`; set
+ * SF_OAUTH_JWKS_URL or an issuer of `{SUPABASE_URL}/auth/v1` to match.)
+ */
+function jwksUrlFromIssuer(issuer: string | undefined): string | undefined {
+  if (!issuer) return undefined;
+  // Trim any trailing slash so we don't emit a doubled `//.well-known`.
+  const base = issuer.replace(/\/+$/, "");
+  return `${base}/.well-known/jwks.json`;
+}
+
+/**
+ * The ES256/JWKS access-token verifier. Implements the SDK `OAuthTokenVerifier`
+ * so it drops straight into `requireBearerAuth({ verifier })`.
+ */
+export class ScholarFeedTokenVerifier implements OAuthTokenVerifier {
+  private readonly audience: string;
+  private readonly issuer: string | undefined;
+  private readonly enforceIssuer: boolean;
+  private readonly jwksUrl: string | undefined;
+  /** Either the injected resolver or a lazily-built remote JWKS. */
+  private readonly injectedResolver: KeyResolver | undefined;
+  private remoteJwks: JWTVerifyGetKey | undefined;
+
+  constructor(opts: VerifierOptions = {}) {
+    // Audience: trim and REQUIRE non-empty. `??` only falls through on
+    // null/undefined, so an empty-string SF_MCP_AUDIENCE ("export SF_MCP_AUDIENCE="
+    // or a blank templated value) would slip through as "" — and jose treats a
+    // falsy `audience` as "skip the check", silently disabling audience binding
+    // and accepting ANY signed token issued for this resource. Fail closed.
+    const audience = (
+      opts.audience ??
+      process.env.SF_MCP_AUDIENCE ??
+      DEFAULT_AUDIENCE
+    ).trim();
+    if (!audience) {
+      throw new Error(
+        "OAuth verifier misconfigured: audience is empty. Set SF_MCP_AUDIENCE to " +
+          "the MCP resource URI (e.g. https://mcp.scholarfeed.org/mcp). An empty " +
+          "audience would disable audience validation entirely (jose treats a " +
+          "falsy audience as 'skip'), accepting any signed token for this resource.",
+      );
+    }
+    this.audience = audience;
+    this.issuer = opts.issuer ?? process.env.SF_OAUTH_ISSUER;
+    this.enforceIssuer = opts.enforceIssuer ?? envIssuerEnforced();
+    this.jwksUrl =
+      opts.jwksUrl ??
+      process.env.SF_OAUTH_JWKS_URL ??
+      jwksUrlFromIssuer(this.issuer);
+    this.injectedResolver = opts.keyResolver;
+  }
+
+  /**
+   * Resolve the key argument for jose. Prefers the injected resolver (tests);
+   * otherwise builds (once, lazily) a remote JWKS from `jwksUrl`. Constructing
+   * the remote JWKS performs no network I/O — keys are fetched on first verify
+   * and cached — so this is safe to defer to the first request.
+   */
+  private resolveKey(): KeyResolver {
+    if (this.injectedResolver !== undefined) return this.injectedResolver;
+    if (this.remoteJwks === undefined) {
+      if (!this.jwksUrl) {
+        throw new Error(
+          "OAuth verifier misconfigured: no JWKS source. Set SF_OAUTH_JWKS_URL " +
+            "(e.g. {SUPABASE_URL}/auth/v1/.well-known/jwks.json) or SF_OAUTH_ISSUER, " +
+            "or inject a keyResolver for tests.",
+        );
+      }
+      this.remoteJwks = createRemoteJWKSet(new URL(this.jwksUrl));
+      if (!this.enforceIssuer) {
+        // Production-only warning (the injected-resolver test path never reaches
+        // here). With issuer enforcement off, a token from a DIFFERENT issuer is
+        // still rejected today by the JWKS signature + audience checks — but once
+        // the access-token hook stamps the shared MCP `aud`, the issuer becomes
+        // the only project discriminator left to enable.
+        console.error(
+          "[oauth] WARNING: issuer enforcement is OFF (SF_OAUTH_ENFORCE_ISSUER " +
+            "unset) while verifying against a live JWKS. Token-to-resource binding " +
+            "then rests only on the JWKS signature + audience. Before opening OAuth " +
+            "to real tokens set SF_OAUTH_ENFORCE_ISSUER=true and SF_OAUTH_ISSUER " +
+            "(see docs/plans/2026-06-04-remote-mcp-DECISIONS.md).",
+        );
+      }
+    }
+    return this.remoteJwks;
+  }
+
+  /**
+   * Verify an access token and map it to the SDK `AuthInfo`. Throws on any
+   * validation failure (bad signature, wrong/none alg, expired, wrong aud,
+   * missing sub, wrong iss when enforced).
+   */
+  async verifyAccessToken(token: string): Promise<AuthInfo> {
+    const key = this.resolveKey();
+
+    const options: Parameters<typeof jwtVerify>[2] = {
+      algorithms: [...ALLOWED_ALGORITHMS],
+      audience: this.audience,
+      // exp is enforced by default; require it to be present so a token without
+      // an expiry cannot live forever (backend requires exp/sub/aud).
+      requiredClaims: ["exp", "sub", "aud"],
+    };
+    if (this.enforceIssuer) {
+      if (!this.issuer) {
+        throw new Error(
+          "OAuth verifier misconfigured: SF_OAUTH_ENFORCE_ISSUER is set but " +
+            "SF_OAUTH_ISSUER is empty.",
+        );
+      }
+      options.issuer = this.issuer;
+    }
+
+    // jose verifies: JWS format, alg in the allowlist, signature against the
+    // key, exp not in the past, aud == this.audience, iss == this.issuer (when
+    // enforced), and the requiredClaims are present. Any failure throws.
+    // The two-arg overloads differ only in the key vs getKey type; cast keeps a
+    // single call site without re-implementing jose's overload resolution.
+    const { payload } = await jwtVerify(token, key as JWTVerifyGetKey, options);
+
+    return mapPayloadToAuthInfo(token, payload);
+  }
+}
+
+/**
+ * Map a verified JWT payload to the SDK `AuthInfo`. Exported for direct unit
+ * testing of the claim mapping. Re-checks `sub` (defense in depth) even though
+ * `requiredClaims` already enforces presence.
+ */
+export function mapPayloadToAuthInfo(
+  token: string,
+  payload: JWTPayload,
+): AuthInfo {
+  const sub = payload.sub;
+  if (typeof sub !== "string" || sub.length === 0) {
+    throw new Error("Token is missing the required `sub` claim.");
+  }
+
+  // azp (authorized party) is the OAuth client; fall back to client_id, then "".
+  const azp = typeof payload.azp === "string" ? payload.azp : undefined;
+  const clientIdClaim =
+    typeof payload.client_id === "string" ? payload.client_id : undefined;
+  const clientId = azp ?? clientIdClaim ?? "";
+
+  // Space-delimited `scope` string -> array, dropping empties.
+  const scopeClaim = typeof payload.scope === "string" ? payload.scope : "";
+  const scopes = scopeClaim.split(" ").filter(Boolean);
+
+  const email = typeof payload.email === "string" ? payload.email : undefined;
+  // The Custom Access Token Hook (backend) stamps the tier as `sf_tier`; accept
+  // a plain `tier` as a fallback. Left undefined when neither is present.
+  const tier =
+    typeof payload.sf_tier === "string"
+      ? payload.sf_tier
+      : typeof payload.tier === "string"
+        ? payload.tier
+        : undefined;
+
+  return {
+    token,
+    clientId,
+    scopes,
+    expiresAt: payload.exp,
+    extra: { sub, email, tier },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { createRequire } from "module";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerAllTools } from "./tools/index.js";
+import { buildServerInfo } from "./server-info.js";
 
 // Handle subcommands before starting the MCP server
 if (process.argv[2] === "init") {
@@ -35,10 +36,7 @@ if (process.argv[2] === "--version" || process.argv[2] === "-v") {
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json") as { version: string };
 
-const server = new McpServer({
-  name: "scholar-feed",
-  version,
-});
+const server = new McpServer(buildServerInfo(version));
 
 registerAllTools(server);
 

--- a/src/server-http.ts
+++ b/src/server-http.ts
@@ -24,6 +24,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import type { OAuthTokenVerifier } from "@modelcontextprotocol/sdk/server/auth/provider.js";
 import { registerAllTools } from "./tools/index.js";
+import { buildServerInfo } from "./server-info.js";
 import { runWithCreds } from "./http/credentials.js";
 import { ScholarFeedTokenVerifier } from "./http/oauth/verifier.js";
 import {
@@ -315,7 +316,7 @@ async function handleMcpPost(
     return;
   }
 
-  const server = new McpServer({ name: "scholar-feed", version });
+  const server = new McpServer(buildServerInfo(version));
   registerAllTools(server);
 
   const transport = new StreamableHTTPServerTransport({

--- a/src/server-http.ts
+++ b/src/server-http.ts
@@ -1,0 +1,483 @@
+/**
+ * Scholar Feed MCP — remote (Streamable HTTP) entry point.
+ *
+ * A SECOND surface alongside the stdio package (src/index.ts is unchanged). This
+ * is an Express app that speaks the MCP Streamable HTTP transport in STATELESS
+ * mode: every POST /mcp builds a fresh McpServer + transport, runs the request
+ * inside a per-request credential context (AsyncLocalStorage, see
+ * src/http/credentials.ts), and tears everything down when the response closes.
+ * GET/DELETE on /mcp return 405 (stateless has no session to resume or delete).
+ *
+ * This file is NOT part of the npm `bin` build (`tsup src/index.ts`); it is built
+ * by the deploy target. Keep all logic framework-light so the Cloudflare Workers
+ * port is a thin entry-point swap.
+ *
+ * CRITICAL: All logging uses console.error() — never console.log(). stdout
+ * hygiene is enforced across server runtime files by a test + lint rule.
+ */
+
+import { createRequire } from "node:module";
+import { randomUUID } from "node:crypto";
+import express, { type Request, type Response } from "express";
+import cors from "cors";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import type { OAuthTokenVerifier } from "@modelcontextprotocol/sdk/server/auth/provider.js";
+import { registerAllTools } from "./tools/index.js";
+import { runWithCreds } from "./http/credentials.js";
+import { ScholarFeedTokenVerifier } from "./http/oauth/verifier.js";
+import {
+  mountMetadataRoutes,
+  unauthorizedResponse,
+} from "./http/oauth/metadata.js";
+import {
+  UnconfiguredCredentialResolver,
+  UNCONFIGURED_RESOLVER_MESSAGE,
+  type CredentialResolver,
+} from "./http/oauth/credential-resolver.js";
+
+const require = createRequire(import.meta.url);
+const { version } = require("../package.json") as { version: string };
+
+/** Cap inbound JSON bodies. MCP tool-call payloads are small; this guards the
+ * public surface against oversized-body abuse without clipping real requests. */
+const BODY_LIMIT = "4mb";
+
+/** Returned on a 501 when the resolver throws ANYTHING other than the vetted,
+ * secret-free UnconfiguredCredentialResolver message — so an arbitrary (future)
+ * resolver error string can never carry a minted sf_ key / act-as-user JWT back
+ * to the caller. The full detail is logged to stderr only. */
+const GENERIC_BACKEND_PENDING_MESSAGE =
+  "OAuth token verified, but this server is not yet configured to complete " +
+  "authenticated requests (backend credential model pending). Contact the operator.";
+
+/** MCP transport headers the browser/host must be able to READ off responses.
+ * Includes WWW-Authenticate so the eventual OAuth 401 challenge is visible to
+ * the client (Agent C / M4 wires the challenge itself). */
+const EXPOSED_HEADERS = [
+  "Mcp-Session-Id",
+  "Last-Event-ID",
+  "Mcp-Protocol-Version",
+  "WWW-Authenticate",
+];
+
+/** Strip IPv6 brackets + lowercase so `new URL(...).hostname` ("[::1]") compares
+ * cleanly to "::1". `new URL("http://[::1]:3000").hostname` is the BRACKETED form. */
+function normalizeHostname(hostname: string): string {
+  return hostname.replace(/^\[/, "").replace(/\]$/, "").toLowerCase();
+}
+
+/** Loopback hostnames we always trust (local dev). */
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1"]);
+function isLoopbackHostname(hostname: string): boolean {
+  return LOOPBACK_HOSTNAMES.has(normalizeHostname(hostname));
+}
+
+/**
+ * Parse a comma-separated env allowlist into a trimmed, lowercased Set.
+ * Read at call time (not import) so tests/deploys can set it per-process.
+ */
+function envAllowlist(name: string): Set<string> {
+  const raw = process.env[name] ?? "";
+  return new Set(
+    raw
+      .split(",")
+      .map((s) => s.trim().toLowerCase())
+      .filter((s) => s.length > 0),
+  );
+}
+
+/**
+ * Origin half of the DNS-rebinding guard. The Origin header is the browser-set
+ * signal. Policy:
+ *   - No Origin header (native MCP clients, server-to-server) -> allow.
+ *   - localhost / 127.0.0.1 / [::1] (any scheme/port) -> allow by default.
+ *   - Anything in the SF_MCP_ALLOWED_ORIGINS allowlist -> allow.
+ *   - Else -> reject (the caller returns 403).
+ * Exported for unit testing.
+ */
+export function isOriginAllowed(origin: string | undefined): boolean {
+  if (origin === undefined) return true; // no Origin: not a browser cross-site request
+  if (envAllowlist("SF_MCP_ALLOWED_ORIGINS").has(origin.toLowerCase())) {
+    return true;
+  }
+  try {
+    return isLoopbackHostname(new URL(origin).hostname);
+  } catch {
+    return false; // unparseable Origin -> untrusted
+  }
+}
+
+/**
+ * Host half of the DNS-rebinding guard. Origin alone is insufficient: a classic
+ * rebinding attack pivots on the Host header (the victim browser still believes
+ * it is talking to evil.com, so it sends `Host: evil.com`) and may carry NO
+ * Origin — which the Origin guard allows. We therefore also pin the Host:
+ *   - Loopback host (localhost / 127.0.0.1 / [::1], any port) -> allow (dev).
+ *   - Host in SF_MCP_ALLOWED_HOSTS -> allow (set this to mcp.scholarfeed.org, or
+ *     the tunnel host, on any non-loopback deploy).
+ *   - Else -> reject. With NO allowlist configured, ONLY loopback is accepted
+ *     (fail closed): an unconfigured public deploy rejects everything until the
+ *     operator pins its host — which is also exactly the rebinding shape.
+ * A missing Host (illegal under HTTP/1.1) is rejected. Exported for unit testing.
+ */
+export function isHostAllowed(hostHeader: string | undefined): boolean {
+  if (!hostHeader) return false;
+  // Derive the bare hostname (strip :port and IPv6 brackets) robustly.
+  let hostname: string;
+  try {
+    hostname = new URL(`http://${hostHeader}`).hostname;
+  } catch {
+    hostname = hostHeader;
+  }
+  if (isLoopbackHostname(hostname)) return true;
+  const allow = envAllowlist("SF_MCP_ALLOWED_HOSTS");
+  if (allow.size === 0) return false; // unconfigured: loopback only
+  return (
+    allow.has(hostHeader.toLowerCase()) ||
+    allow.has(normalizeHostname(hostname))
+  );
+}
+
+/**
+ * Per-process OAuth primitives (M4). The verifier is AS-agnostic: it reads its
+ * audience / issuer / JWKS source from env (see verifier.ts). The default
+ * CredentialResolver is the fail-loud UnconfiguredCredentialResolver — it THROWS
+ * because the backend credential model (open decision #8) is not yet chosen, so
+ * an OAuth-authenticated account call surfaces a clear 501 rather than silently
+ * doing the wrong thing. Both are overridable via createApp() options so a later
+ * milestone (or a test) can inject a working resolver / a test-keyed verifier.
+ */
+const defaultVerifier: OAuthTokenVerifier = new ScholarFeedTokenVerifier();
+const defaultCredentialResolver: CredentialResolver =
+  new UnconfiguredCredentialResolver();
+
+/**
+ * The outcome of resolving creds for one request. A JWT path can either succeed
+ * (creds), fail verification (401 challenge), or verify but have no backend
+ * credential model yet (501). The `sf_`-bearer and anonymous paths always
+ * succeed (they need no token verification).
+ */
+type CredResolution =
+  | { kind: "ok"; creds: { apiKey: string | null; sessionId: string } }
+  | { kind: "unauthorized" }
+  | { kind: "not-configured"; message: string };
+
+/**
+ * Resolve the per-request credentials from the inbound request.
+ *
+ * Three Authorization shapes, preserving the M1 behavior for the first two:
+ *   - `Bearer sf_...`  : the caller supplies their OWN downstream Scholar Feed
+ *     key — the SAME credential the stdio package uses — so we forward it
+ *     verbatim. This is NOT confused-deputy passthrough; it is the user handing
+ *     us the key meant for api.scholarfeed.org.
+ *   - no token         : anonymous (apiKey null); the backend serves it with
+ *     lower caps. Account tools then surface the backend's own 401.
+ *   - `Bearer eyJ...`  : an OAuth JWT (M4). Verify it (ES256/JWKS, aud ==
+ *     SF_MCP_RESOURCE_URI, exp, sub) via the verifier, then call the
+ *     CredentialResolver to obtain a DOWNSTREAM backend credential. The user's
+ *     JWT is NEVER set as the backend creds (token passthrough is forbidden).
+ *     - verify fails  -> { unauthorized } (caller emits 401 + WWW-Authenticate)
+ *     - resolver throws (the default Unconfigured one always does) ->
+ *       { not-configured } (caller emits 501): EXPECTED until the backend
+ *       chooses a credential model (open decision #8).
+ *
+ * A fresh sessionId is generated per request (stateless: no session continuity).
+ */
+async function resolveRequestCreds(
+  req: Request,
+  verifier: OAuthTokenVerifier,
+  resolver: CredentialResolver,
+): Promise<CredResolution> {
+  const header = req.header("authorization") ?? "";
+  const match = /^Bearer\s+(.+)$/i.exec(header);
+  const token = match?.[1]?.trim();
+
+  // sf_ key: forward it verbatim (M1 path, unchanged).
+  if (token && token.startsWith("sf_")) {
+    return {
+      kind: "ok",
+      creds: { apiKey: token, sessionId: randomUUID() },
+    };
+  }
+
+  // OAuth JWT bearer: verify, then bridge to a downstream credential (M4).
+  if (token) {
+    let auth;
+    try {
+      auth = await verifier.verifyAccessToken(token);
+    } catch (err) {
+      // Bad signature, wrong/none alg, expired, wrong aud, missing sub, etc.
+      // Log ONLY a redacted reason: jose's JWTClaimValidationFailed / JWTExpired
+      // errors carry a `.payload` of the (signature-UNVERIFIED) claims — which for
+      // Supabase tokens includes email/sub/tier — and may carry `.token`. Dumping
+      // the whole err would spill that decoded PII into the logs for every
+      // rejected token; the name/code is enough to diagnose.
+      const reason =
+        err instanceof Error
+          ? ((err as { code?: string }).code ?? err.name)
+          : "unknown";
+      console.error("[server-http] OAuth token verification failed:", reason);
+      return { kind: "unauthorized" };
+    }
+
+    try {
+      const resolved = await resolver.resolve(auth);
+      // The resolver may hand back extra backend headers for credential models
+      // (b)/(c). RequestCreds cannot forward them yet (only apiKey is plumbed), so
+      // a resolver that returns headers must FAIL LOUD rather than have them
+      // silently dropped — a silent drop would ship a half-wired, possibly
+      // confused-deputy model. (Caught below -> generic 501 + stderr detail.)
+      if (resolved.headers && Object.keys(resolved.headers).length > 0) {
+        throw new Error(
+          "CredentialResolver returned headers, but the per-request creds cannot " +
+            "forward them to the backend yet (only apiKey is plumbed). Extend " +
+            "RequestCreds + client.ts before using a header-bearing credential " +
+            "model (#8 model b/c).",
+        );
+      }
+      // NEVER set the user JWT as the backend credential. We forward only the
+      // resolver's chosen downstream creds (an sf_ key, or null). The user's
+      // OAuth token does not leave this server.
+      return {
+        kind: "ok",
+        creds: { apiKey: resolved.apiKey, sessionId: randomUUID() },
+      };
+    } catch (err) {
+      // The default resolver always throws (backend model pending, #8). Log the
+      // full detail to stderr, but only ECHO the vetted, secret-free Unconfigured
+      // message back to the client. Any OTHER resolver throw (a future key-minting
+      // resolver, or the headers guard above) gets a GENERIC 501 — its raw message
+      // could embed a freshly minted sf_ key or act-as-user JWT, which must never
+      // reach the caller.
+      const detail = err instanceof Error ? err.message : String(err);
+      console.error(
+        "[server-http] credential resolver could not bridge token->key:",
+        detail,
+      );
+      const message =
+        detail === UNCONFIGURED_RESOLVER_MESSAGE
+          ? UNCONFIGURED_RESOLVER_MESSAGE
+          : GENERIC_BACKEND_PENDING_MESSAGE;
+      return { kind: "not-configured", message };
+    }
+  }
+
+  // No token -> anonymous (M1 path, unchanged). Account tools surface the
+  // backend's own 401; truly token-gated paths use unauthorizedResponse().
+  return { kind: "ok", creds: { apiKey: null, sessionId: randomUUID() } };
+}
+
+/**
+ * Handle one stateless POST /mcp. A fresh server + transport per request keeps
+ * tenants isolated (no shared in-process state across callers); both are closed
+ * when the response finishes.
+ */
+async function handleMcpPost(
+  req: Request,
+  res: Response,
+  verifier: OAuthTokenVerifier,
+  resolver: CredentialResolver,
+): Promise<void> {
+  // Resolve creds BEFORE building the server so a 401/501 short-circuits without
+  // standing up an McpServer + transport for a request we will not serve.
+  let resolution: CredResolution;
+  try {
+    resolution = await resolveRequestCreds(req, verifier, resolver);
+  } catch (err) {
+    console.error("[server-http] error resolving request creds:", err);
+    if (!res.headersSent) {
+      res.status(500).json({
+        jsonrpc: "2.0",
+        error: { code: -32603, message: "Internal server error" },
+        id: null,
+      });
+    }
+    return;
+  }
+
+  if (resolution.kind === "unauthorized") {
+    // Invalid / unverifiable OAuth token: 401 + WWW-Authenticate challenge that
+    // points the host at the RFC 9728 protected-resource metadata.
+    unauthorizedResponse(res);
+    return;
+  }
+
+  if (resolution.kind === "not-configured") {
+    // Token verified, but no backend credential model yet (open decision #8).
+    // 501 Not Implemented is the honest status: the request is well-formed and
+    // authenticated, the server just cannot yet bridge it to a backend call.
+    res.status(501).json({
+      jsonrpc: "2.0",
+      error: { code: -32002, message: resolution.message },
+      id: null,
+    });
+    return;
+  }
+
+  const server = new McpServer({ name: "scholar-feed", version });
+  registerAllTools(server);
+
+  const transport = new StreamableHTTPServerTransport({
+    // Stateless: no session id, no session validation, GET/DELETE unsupported.
+    sessionIdGenerator: undefined,
+  });
+
+  // Tear down per-request resources once the client disconnects / response ends.
+  res.on("close", () => {
+    void transport.close();
+    void server.close();
+  });
+
+  try {
+    await server.connect(transport);
+    // Bind the per-request creds for the whole handleRequest -> tool -> client
+    // chain via AsyncLocalStorage, then let the transport drive the response.
+    await runWithCreds(resolution.creds, () =>
+      transport.handleRequest(req, res, req.body),
+    );
+  } catch (err) {
+    console.error("[server-http] error handling POST /mcp:", err);
+    if (!res.headersSent) {
+      res.status(500).json({
+        jsonrpc: "2.0",
+        error: { code: -32603, message: "Internal server error" },
+        id: null,
+      });
+    }
+  }
+}
+
+/** GET/DELETE /mcp in stateless mode: there is no session to stream or delete. */
+function methodNotAllowed(_req: Request, res: Response): void {
+  res.status(405).json({
+    jsonrpc: "2.0",
+    error: {
+      code: -32000,
+      message:
+        "Method Not Allowed: this stateless MCP server only accepts POST",
+    },
+    id: null,
+  });
+}
+
+/**
+ * createApp options. Both default to the process-level OAuth primitives; a test
+ * (or a later milestone) injects a test-keyed verifier and/or a working
+ * CredentialResolver without touching the wiring.
+ */
+export interface CreateAppOptions {
+  /** OAuth access-token verifier. Defaults to the env-configured ES256/JWKS one. */
+  verifier?: OAuthTokenVerifier;
+  /** token->key bridge. Defaults to the fail-loud UnconfiguredCredentialResolver. */
+  credentialResolver?: CredentialResolver;
+}
+
+/**
+ * Build the Express app. Exported (alongside the default `app`) so tests can
+ * mount it on an ephemeral port without spawning a process.
+ */
+export function createApp(opts: CreateAppOptions = {}): express.Express {
+  const verifier = opts.verifier ?? defaultVerifier;
+  const credentialResolver =
+    opts.credentialResolver ?? defaultCredentialResolver;
+  const app = express();
+
+  // CORS: expose the MCP transport headers so browser-based hosts can read them.
+  // Origin enforcement itself is handled by the explicit guard below (CORS
+  // `origin: true` reflects the request origin for the browser; the guard is
+  // the actual DNS-rebinding gate).
+  app.use(
+    cors({
+      origin: true,
+      exposedHeaders: EXPOSED_HEADERS,
+      allowedHeaders: [
+        "Content-Type",
+        "Authorization",
+        "Mcp-Session-Id",
+        "Mcp-Protocol-Version",
+        "Last-Event-ID",
+      ],
+      methods: ["POST", "GET", "DELETE", "OPTIONS"],
+    }),
+  );
+
+  // DNS-rebinding guard (Origin half): reject browser cross-site Origins not on
+  // the allowlist.
+  app.use((req: Request, res: Response, next) => {
+    if (!isOriginAllowed(req.header("origin") ?? undefined)) {
+      res.status(403).json({
+        jsonrpc: "2.0",
+        error: { code: -32000, message: "Forbidden: origin not allowed" },
+        id: null,
+      });
+      return;
+    }
+    next();
+  });
+
+  // DNS-rebinding guard (Host half): pin the Host header. Origin alone misses
+  // rebinding attacks that send no Origin and a Host of the attacker's domain.
+  app.use((req: Request, res: Response, next) => {
+    if (!isHostAllowed(req.headers.host)) {
+      res.status(403).json({
+        jsonrpc: "2.0",
+        error: { code: -32000, message: "Forbidden: host not allowed" },
+        id: null,
+      });
+      return;
+    }
+    next();
+  });
+
+  // RFC 9728 protected-resource metadata at the app root. Served at both the
+  // bare and /mcp-suffixed well-known paths so a host's discovery probe (which
+  // the 401 WWW-Authenticate challenge points at) always resolves. Mounted
+  // before the JSON body parser since these are GETs with no body.
+  mountMetadataRoutes(app);
+
+  app.use(express.json({ limit: BODY_LIMIT }));
+
+  app.post("/mcp", (req, res) => {
+    void handleMcpPost(req, res, verifier, credentialResolver);
+  });
+  app.get("/mcp", methodNotAllowed);
+  app.delete("/mcp", methodNotAllowed);
+
+  return app;
+}
+
+export const app = createApp();
+
+// Run-directly guard: only listen when this module is the process entry point,
+// never when imported by a test. import.meta.url vs argv[1] is the ESM idiom.
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  import.meta.url === `file://${process.argv[1]}`;
+
+if (invokedDirectly) {
+  // The remote transport derives EACH request's key from its own Authorization
+  // header. A process-level SF_API_KEY is a latent cross-tenant leak: client.ts
+  // falls back to it only if a request's ALS credential context is ever lost, so
+  // it must simply never be set on the remote server. Fail fast over shipping
+  // that footgun.
+  if (process.env.SF_API_KEY) {
+    console.error(
+      "[server-http] FATAL: SF_API_KEY must NOT be set in the remote server's " +
+        "environment — each request carries its own key. A process-level key is a " +
+        "latent cross-tenant leak. Unset SF_API_KEY and redeploy.",
+    );
+    process.exit(1);
+  }
+  if (envAllowlist("SF_MCP_ALLOWED_HOSTS").size === 0) {
+    console.error(
+      "[server-http] WARNING: SF_MCP_ALLOWED_HOSTS is unset — only loopback Host " +
+        "headers are accepted (fine for local dev). Set it to your public host " +
+        "(e.g. mcp.scholarfeed.org) or tunnel host before exposing this server.",
+    );
+  }
+  const port = Number(process.env.PORT) || 3000;
+  app.listen(port, () => {
+    console.error(`Scholar Feed MCP (remote/HTTP) listening on :${port}/mcp`);
+  });
+}

--- a/src/server-info.ts
+++ b/src/server-info.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared MCP server identity (the `serverInfo` / `Implementation` returned in the
+ * initialize response). Used by BOTH entry points — the stdio package
+ * (src/index.ts) and the remote Streamable HTTP server (src/server-http.ts) — so
+ * the name, title, website, and logo stay in sync across surfaces.
+ *
+ * `title` + `icons` are what a host (claude.ai, Claude Desktop, Cursor, ...)
+ * renders for the connector. Without them a host shows a placeholder. `icons[].src`
+ * MUST be a publicly reachable HTTPS image URL — the host fetches it directly.
+ *
+ * The default icon is the branded 400x400 PNG committed to this repo, served via
+ * GitHub raw (a stable public URL, no deploy needed). Override with SF_MCP_ICON_URL
+ * once the asset is hosted on your own domain (e.g. https://www.scholarfeed.org/icon.png).
+ */
+
+import type { Implementation } from "@modelcontextprotocol/sdk/types.js";
+
+/** Stable public URL of the branded marketplace icon (overridable via env). */
+const DEFAULT_ICON_URL =
+  "https://raw.githubusercontent.com/YGao2005/scholar-feed-mcp/main/assets/icon-marketplace.png";
+
+/** The icon URL a host fetches for the connector logo. */
+export function iconUrl(): string {
+  return process.env.SF_MCP_ICON_URL ?? DEFAULT_ICON_URL;
+}
+
+/**
+ * Build the server identity for a given package version. Taken as a parameter
+ * (rather than read here) so each entry point keeps its single createRequire
+ * read of package.json.
+ */
+export function buildServerInfo(version: string): Implementation {
+  return {
+    name: "scholar-feed",
+    title: "Scholar Feed",
+    version,
+    websiteUrl: "https://www.scholarfeed.org",
+    description:
+      "Search 600,000+ CS/AI/ML papers with LLM analysis, a citation graph, and full-text extraction.",
+    icons: [
+      {
+        src: iconUrl(),
+        mimeType: "image/png",
+        sizes: ["400x400"],
+      },
+    ],
+  };
+}

--- a/src/tools/ask_library.ts
+++ b/src/tools/ask_library.ts
@@ -35,6 +35,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "ask_library",
     {
+      title: "Ask Library",
+      annotations: { readOnlyHint: true, destructiveHint: false },
       description:
         "Answer a question using ONLY the papers you've saved — a synthesis over your library (or one collection) with inline [arXiv-ID] citations. The inverse of find_gaps (which finds important work you're MISSING): ask_library reasons over what you HAVE. Optionally scope to one collection (collection_name OR collection_id); omit both to use your whole library. Read-only. Requires SF_API_KEY (it reads your saved set). Free accounts get 1 question/month; Pro raises this to 200/day.",
       inputSchema: {

--- a/src/tools/citations.ts
+++ b/src/tools/citations.ts
@@ -13,6 +13,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "get_citations",
     {
+      title: "Get Citations",
+      annotations: { readOnlyHint: true, destructiveHint: false },
       description:
         "Get the citation graph for a paper, sorted by citing-paper rank_score (highest-impact first). 'citing' = outgoing references this paper cites; 'cited_by' = incoming citations from other papers. Default response is a lean 12-field shape per paper — pass verbose=true for the full 28-field shape.",
       inputSchema: {

--- a/src/tools/co_author_graph.ts
+++ b/src/tools/co_author_graph.ts
@@ -13,6 +13,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "co_author_graph",
     {
+      title: "Co-Author Graph",
+      annotations: { readOnlyHint: true, destructiveHint: false },
       description:
         "Find the co-authorship neighborhood of one or more authors. Given a list of author_ids, returns edges {from, to, papers_count, last_collab_year} where 'from' is one of the input authors and 'to' is any co-author appearing on a shared paper within the window. Use for AC reviewer triage (find conflicts), disambiguating researchers (who do they actually work with?), or expanding an author seed into a research community. window_years defaults to 10. Result is capped at 500 edges, sorted by papers_count DESC.",
       inputSchema: {

--- a/src/tools/collections_write.ts
+++ b/src/tools/collections_write.ts
@@ -82,6 +82,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "list_collections",
     {
+      title: "List Collections",
+      annotations: { readOnlyHint: true, destructiveHint: false },
       description:
         "List the authenticated user's collections (named groups of saved papers) with paper counts. Read-only. Use before add_to_collection to see existing collections. Requires SF_API_KEY.",
       inputSchema: {},
@@ -99,6 +101,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "create_collection",
     {
+      title: "Create Collection",
+      annotations: { readOnlyHint: false, destructiveHint: false },
       description:
         "Create a new named collection. MUTATES. If a collection with that name already exists, returns the existing one (get-or-create — never errors on duplicate). Requires SF_API_KEY.",
       inputSchema: {
@@ -130,6 +134,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "add_to_collection",
     {
+      title: "Add to Collection",
+      annotations: { readOnlyHint: false, destructiveHint: false },
       description:
         "Add a paper to a collection, addressed by collection_id OR collection_name (get-or-create by name — no need to look up an id first). MUTATES: also auto-saves the paper to the library. Idempotent (adding a paper already in the collection is a no-op). Requires SF_API_KEY.",
       inputSchema: {
@@ -172,6 +178,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "remove_from_collection",
     {
+      title: "Remove from Collection",
+      annotations: { readOnlyHint: false, destructiveHint: true },
       description:
         "Remove a paper from a collection, addressed by collection_id OR collection_name. MUTATES (the paper stays in your library; it's only removed from this collection). Idempotent. Requires SF_API_KEY.",
       inputSchema: {

--- a/src/tools/embed_text.ts
+++ b/src/tools/embed_text.ts
@@ -13,6 +13,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "embed_text",
     {
+      title: "Embed Text",
+      annotations: { readOnlyHint: true, destructiveHint: false },
       description:
         "Embed a text string into a 768-dim Gemini Flash vector. Use for HyDE-style retrieval: (1) write a hypothetical short paper that would perfectly answer the user's query, (2) embed it with task_type='RETRIEVAL_DOCUMENT' (default — matches the corpus embedding side), (3) pass the resulting embedding back through search-style tools to find real papers nearest to the hypothetical. task_type='RETRIEVAL_QUERY' matches the query side and is useful for direct user-query embedding without HyDE. Pro-only — requires an SF_API_KEY on a Pro account; anonymous and free callers get a 403 pro_required. Cost: ~$0.0001/call; rate-limited at 30/minute per API key.",
       inputSchema: {

--- a/src/tools/find_author.ts
+++ b/src/tools/find_author.ts
@@ -17,6 +17,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "find_author",
     {
+      title: "Find Author",
+      annotations: { readOnlyHint: true, destructiveHint: false },
       description:
         "Two-mode author tool — replaces discover_authors and get_author. Provide exactly one of q or id. Q-MODE (q=...): search for researchers by topic or name — uses embedding similarity for topics ('efficient LLM inference'), fuzzy matching for names ('Yann LeCun'). Returns a list of matching authors with author_id, name, h_index, total_papers, primary_field, research_topics. ID-MODE (id=...): look up a single author profile by author_id (obtained from a previous q-mode call or from co_author_graph results). Returns h-index, total citations, global rank, primary field, novelty score distribution, research topics, code/venue scores, years active, and their top 10 papers by rank score.",
       inputSchema: {

--- a/src/tools/fulltext.ts
+++ b/src/tools/fulltext.ts
@@ -13,6 +13,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "fetch_fulltext",
     {
+      title: "Fetch Full Text",
+      annotations: { readOnlyHint: true, destructiveHint: false },
       description:
         "Extract paper content from an arXiv paper's LaTeX source. Two modes: 'results' (default) returns 800 chars of results/experiments + 3 table captions. 'all' returns full paper sections (abstract, introduction, related work, method, results, conclusion) at up to 3000 chars each + 5 table captions. ~62% of arXiv papers have LaTeX source. May take a few seconds.",
       inputSchema: {

--- a/src/tools/gaps.ts
+++ b/src/tools/gaps.ts
@@ -38,6 +38,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "find_gaps",
     {
+      title: "Find Research Gaps",
+      annotations: { readOnlyHint: true, destructiveHint: false },
       description:
         "Find important work you HAVEN'T saved, for a collection or topic — a 'what am I missing?' analysis. Returns two buckets: foundational_gaps (canonical citation-graph anchors in the niche, not in your library) and frontier_gaps (recent high-novelty work in the niche, not yet saved). Provide exactly one seed: collection_name OR collection_id OR topic. The backend derives the niche, runs lineage + recent-novelty search, and subtracts your saved set. Read-only. Requires SF_API_KEY (it needs your library to subtract) and is a Pro feature — free accounts receive an upgrade prompt.",
       inputSchema: {

--- a/src/tools/get_field_orientation.ts
+++ b/src/tools/get_field_orientation.ts
@@ -23,6 +23,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "get_field_orientation",
     {
+      title: "Get Field Orientation",
+      annotations: { readOnlyHint: true, destructiveHint: false },
       description:
         "Returns CANDIDATE FOUNDATIONAL PAPERS for a research topic — cheap retrieval only, no synthesis. Ranks papers by a blend of citation count (0.6 weight, captures importance) and semantic similarity to your topic (0.4 weight). Use this to bootstrap a literature survey or get a fast sense of the landscape. For a synthesized orientation report (key concepts, open problems, reading order), use the /field-guide skill which calls this tool internally. Does not require a Pro API key — no LLM calls are made.",
       inputSchema: {

--- a/src/tools/get_foundational_lineage.ts
+++ b/src/tools/get_foundational_lineage.ts
@@ -20,6 +20,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "get_foundational_lineage",
     {
+      title: "Get Foundational Lineage",
+      annotations: { readOnlyHint: true, destructiveHint: false },
       description:
         "Returns the FOUNDATIONAL WORK FOR A PAPER'S NICHE via the citation graph — the relative question ('what is foundational for THIS paper's specific sub-field', often itself only modestly cited) rather than the obvious global landmarks. Anchors on the paper, takes its embedding neighbourhood as the niche, and ranks what the niche cites into three tiers: `niche_roots` (the niche-specific foundations, ranked by how specifically the neighbourhood builds on them — surfaces canonical anchors that semantic search misses), `field_level` (broader secondary foundations), and `discipline` (universal landmarks like Attention Is All You Need, collapsed out of the way). Each paper carries `cited_by_in_niche` evidence so the claim is grounded, not asserted. Use this to trace prior art / lineage for a paper, or to find the canonical methods a niche is built on. Complements get_field_orientation (which is topic-anchored and retrieval-only). No Pro key and no LLM calls required.",
       inputSchema: {

--- a/src/tools/get_paper.ts
+++ b/src/tools/get_paper.ts
@@ -21,6 +21,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "get_paper",
     {
+      title: "Get Paper",
+      annotations: { readOnlyHint: true, destructiveHint: false },
       description:
         "Get full details for one or more papers by arXiv ID. Pass a single-element array for one paper; pass multiple IDs to batch-fetch up to 50 papers in one call (replaces the removed batch_lookup tool). Pass format='bibtex' to get a .bib citation entry (replaces the removed export_bibtex tool — bibtex is single-paper only; for multi-paper bibtex, call repeatedly). Default returns a lean 12-field shape (arxiv_id, title, authors, year, categories, has_code, github_url, citation_count, venue_name, llm_summary, llm_significance, llm_novelty_score). Pass verbose=true for the full 28-field shape with structured extraction (method_name, contribution_type, task_category, datasets, baselines) and institution_tags. Use fields='arxiv_id,title,abstract' to select an exact subset, or fetch_fulltext with sections='all' for the full paper.",
       inputSchema: {

--- a/src/tools/library.ts
+++ b/src/tools/library.ts
@@ -47,6 +47,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "save_paper",
     {
+      title: "Save Paper",
+      annotations: { readOnlyHint: false, destructiveHint: false },
       description:
         "Save a paper to the authenticated user's Scholar Feed library (bookmark). MUTATES the library and feeds the user's personalization — saved papers are the strongest signal in the For You feed and the email digest. Idempotent: calling it again on an already-saved paper leaves it saved. Requires SF_API_KEY. To file it into a named collection in one step, use add_to_collection (that also saves).",
       inputSchema: {
@@ -78,6 +80,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "unsave_paper",
     {
+      title: "Unsave Paper",
+      annotations: { readOnlyHint: false, destructiveHint: true },
       description:
         "Remove a paper from the authenticated user's Scholar Feed library. MUTATES the library. Idempotent: removing a paper that isn't saved leaves it unsaved. Note: the saved library is a superset of all collections, so un-saving a paper ALSO removes it from every collection it was in. To keep it filed in a collection, use remove_from_collection instead (that leaves the paper saved). Requires SF_API_KEY.",
       inputSchema: {
@@ -109,6 +113,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "like_paper",
     {
+      title: "Like Paper",
+      annotations: { readOnlyHint: false, destructiveHint: false },
       description:
         "Like a paper — a 'more like this' calibration signal that tunes the user's For You feed toward similar work. INSERT-only and idempotent (liking twice is a no-op, never un-likes). Distinct from save_paper: like expresses taste for ranking; save bookmarks for later reading. Requires SF_API_KEY.",
       inputSchema: {
@@ -130,6 +136,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "list_library",
     {
+      title: "List Library",
+      annotations: { readOnlyHint: true, destructiveHint: false },
       description:
         "List the authenticated user's saved papers (their library), newest first. Read-only. Use this to review a reading list or to see what's already saved before saving more. Requires SF_API_KEY.",
       inputSchema: {

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -17,6 +17,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "search_papers",
     {
+      title: "Search Papers",
+      annotations: { readOnlyHint: true, destructiveHint: false },
       description:
         "Search Scholar Feed's 600k+ CS/AI/ML paper corpus. Defaults to semantic (embedding) search — finds conceptually related papers even when the user's wording doesn't match the paper's title/abstract. Pass mode='keyword' for exact-string full-text search. CAVEAT: semantic search often misses old high-citation CANONICAL papers (e.g. foundational anchors like H2O for KV eviction, GRIT for unified embedding+generation) because the ranker prefers recent stylistically-matched papers. If you're hunting the canonical anchor for an area, parse the top-5 result abstracts for baseline mentions ('we compare against X, Y, Z'), then look the most-mentioned name up directly. Returns papers with LLM-generated summaries, novelty scores, and structured extraction data. Default response is a lean 12-field shape (arxiv_id, title, authors, year, categories, has_code, github_url, citation_count, venue_name, llm_summary, llm_significance, llm_novelty_score) — pass verbose=true or fields=... for the full 28-field shape with method/task/dataset extraction. Supports filtering by category, novelty, recency, method, task, dataset, and contribution type. v3 ABSORPTIONS: pass sort='trending' to replicate whats_trending; pass anchor_paper_id to replicate find_similar (q is ignored in anchor mode, results carry similarity_score); pass scope_to_citations_of to restrict search to a paper's citation graph (replaces find_citations_about).",
       inputSchema: {

--- a/src/tools/watches.ts
+++ b/src/tools/watches.ts
@@ -179,6 +179,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "create_watch",
     {
+      title: "Create Watch",
+      annotations: { readOnlyHint: false, destructiveHint: false },
       description:
         "Create a standing watch — evaluated daily against newly-indexed papers, surfacing new matches via the email digest and via check_watches. MUTATES. Get-or-create by name (re-creating with an existing name returns it unchanged — never errors on duplicate). TWO forms: (1) the v2 STRUCTURED filter via `criteria` (collections/authors/categories/text/has_code/min_novelty/similar, AND-composed) — the composable, agent-tunable form, recommended; tune it with preview_watch first, and edit later with update_watch. (2) a single legacy seed selector (q OR collection_name OR collection_id OR anchor_paper_id); if `criteria` is given it takes precedence. Requires SF_API_KEY.",
       inputSchema: {
@@ -307,6 +309,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "list_watches",
     {
+      title: "List Watches",
+      annotations: { readOnlyHint: true, destructiveHint: false },
       description:
         "List the authenticated user's watches with name, a one-line definition summary, last_evaluated_at, and pending_hits (count of new matches since the last digest delivery). Read-only. Use before create_watch to see what's already tracked. Requires SF_API_KEY.",
       inputSchema: {},
@@ -324,6 +328,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "check_watches",
     {
+      title: "Check Watches",
+      annotations: { readOnlyHint: true, destructiveHint: false },
       description:
         "Pull new matching papers since the last digest delivery, in the same shape as search_papers results. Optionally scope to one watch by watch_name OR watch_id; omit both for all watches. Read-only and idempotent — does NOT advance any watermark (only digest delivery does), so it is safe to call repeatedly (no mark-on-read). This is the in-session 'anything new on my watches?' pull. Requires SF_API_KEY.",
       inputSchema: {
@@ -372,6 +378,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "delete_watch",
     {
+      title: "Delete Watch",
+      annotations: { readOnlyHint: false, destructiveHint: true },
       description:
         "Delete a watch, addressed by watch_id OR name. MUTATES. Idempotent: deleting a non-existent watch is a no-op (no error). To change a watch in place (rename / novelty_min / retarget criteria) use update_watch instead of delete-and-recreate. Requires SF_API_KEY.",
       inputSchema: {
@@ -410,6 +418,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "update_watch",
     {
+      title: "Update Watch",
+      annotations: { readOnlyHint: false, destructiveHint: false },
       description:
         "Update an existing watch in place — rename, change novelty_min, or RETARGET its structured filter `criteria`. MUTATES. Address by watch_id OR name. Changing criteria replaces the definition and clears the watch's pending hits (so stale matches don't deliver); the next daily eval repopulates. Tune the new criteria with preview_watch first. Requires SF_API_KEY.",
       inputSchema: {
@@ -493,6 +503,8 @@ export function register(server: McpServer): void {
   server.registerTool(
     "preview_watch",
     {
+      title: "Preview Watch",
+      annotations: { readOnlyHint: true, destructiveHint: false },
       description:
         "Dry-run a structured filter over recent papers WITHOUT creating a watch — the tuning loop. Returns {window_days, needs_similarity, match_count, sample} so you can iterate (add a category, raise min_novelty, switch the collection relation) before saving with create_watch. NOTE: for a similarity filter, match_count is capped at 200 (the cosine fetch window) and so saturates at 200 on broad/hot topics — tune by the `sample` scores and narrow with categories/min_novelty (or a higher similar floor) rather than relying on match_count alone. Read-only. Requires SF_API_KEY.",
       inputSchema: {


### PR DESCRIPTION
Additive **second surface** alongside the stdio package (stdio entry + shipped npm bin unchanged): a remote stateless Streamable HTTP MCP server that proxies to api.scholarfeed.org, plus OAuth 2.1 Resource Server primitives. Validated live in claude.ai via a tunnel (anonymous `search_papers` returns real prod papers); 228 tests green; built by a workflow + a 5-lens adversarial security review whose findings were fixed.

## What's in it
- **Transport (M1):** `src/server-http.ts` (Express, stateless; GET/DELETE → 405) + per-request creds via AsyncLocalStorage (`client.ts` refactored, 25 handlers untouched). sf_-bearer passthrough / anonymous / OAuth-JWT paths. Origin + Host DNS-rebinding guards, CORS.
- **Annotations (M2):** `title`/`readOnlyHint`/`destructiveHint` on all 25 tools + name audit.
- **OAuth RS code (M4, AS-agnostic):** ES256/JWKS verifier mirroring `backend/api/auth.py`, RFC 9728 metadata + 401 challenge, and the token→key bridge **seam** (fails loud — raw sf_ keys are stored hashed/unrecoverable).
- **Branding:** `serverInfo` now carries title/website/logo icon.

## Adversarial-review hardening
Empty-audience fails closed; Host header validated (+ IPv6 fix); 501 never echoes a resolver string; network errors sanitized; verify-logs redacted; `SF_API_KEY` refused on the remote process; resolver headers fail loud.

## Known blockers (backend/ops — NOT this repo)
- **Decision #8** (credential model): how the RS acts as a user. OAuth account tools return a clean 501 until chosen.
- **Supabase Custom Access Token Hook** must stamp `aud=<MCP URI>` + `sf_tier`.
- **Reality check:** claude.ai's connector UI is OAuth-or-anonymous only (no static-key field) — anonymous works today; per-account access on claude.ai needs the OAuth work above.
- **Gate:** do not submit to directories until per-tool-call instrumentation is live.

Spec + locked decisions: `docs/plans/2026-06-04-remote-mcp-*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)