### PR TITLE
fix(dist): self-contained bundle + @latest pins to kill cold-start silent failures (v3.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [3.8.0] - 2026-06-04
+
+### Changed (install reliability — fixes silent cold-start failures)
+
+- **The published bin is now a single self-contained bundle.** `build/index.js` is built with
+  esbuild bundling (tsup `noExternal`), inlining and tree-shaking the only code the stdio path
+  uses (the MCP SDK's stdio/server classes + zod). All five former runtime dependencies moved
+  to `devDependencies`, so `dependencies` is now empty and **`npx scholar-feed-mcp` installs
+  zero transitive packages** — the cold download drops from ~24 MB of `node_modules` (the SDK
+  dragged in its full Streamable-HTTP closure: express, cors, ajv, the hono tree) to one
+  ~0.6 MB file. The old heavy cold install could outrun an MCP client's start-up timeout on a
+  slow link and make the server "fail silently"; bundling removes that failure mode and the
+  per-publish re-download cost. The HTTP/Worker deploy targets bundle these deps at build time
+  from `devDependencies`, unchanged. No tool or API change.
+- **All install snippets now pin `@latest`.** The README config blocks and the `init` wizard
+  write `scholar-feed-mcp@latest` (was bare `scholar-feed-mcp`), so a launch always re-resolves
+  the newest version instead of getting pinned to a stale npx-cached build — which silently kept
+  users on old tool surfaces (and, before 3.7.0, without prompt-injection fencing).
+- **Troubleshooting docs** gained a "server shows as failed with no error" section: warm the
+  cache (`npx -y scholar-feed-mcp@latest --version`), raise `MCP_TIMEOUT`, or `npm i -g` for the
+  fastest offline-capable launches.
+
 ## [3.7.1] - 2026-06-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Search 600,000+ CS/AI/ML research papers with LLM-generated novelty analysis, wi
 ## Quick Start
 
 ```bash
-npx scholar-feed-mcp init
+npx scholar-feed-mcp@latest init
 ```
 
 This interactive wizard will:
@@ -45,16 +45,16 @@ Try asking: *"Search for recent papers on test-time compute scaling"*
 
 ## Installation
 
-The fastest path is `npx scholar-feed-mcp init`, which auto-detects your client and writes the config. To set it up by hand, every client launches the same stdio server (`npx -y scholar-feed-mcp`); only the config-file location and the wrapper key differ.
+The fastest path is `npx scholar-feed-mcp@latest init`, which auto-detects your client and writes the config. To set it up by hand, every client launches the same stdio server (`npx -y scholar-feed-mcp@latest`); only the config-file location and the wrapper key differ.
 
 **Claude Code** takes a one-line command:
 
 ```bash
 # Anonymous (100 calls/day)
-claude mcp add scholar-feed -- npx -y scholar-feed-mcp
+claude mcp add scholar-feed -- npx -y scholar-feed-mcp@latest
 
 # With an API key (1,000 calls/day per account)
-claude mcp add scholar-feed -e SF_API_KEY=sf_your_key_here -- npx -y scholar-feed-mcp
+claude mcp add scholar-feed -e SF_API_KEY=sf_your_key_here -- npx -y scholar-feed-mcp@latest
 ```
 
 **Every other client** takes this standard JSON block:
@@ -64,7 +64,7 @@ claude mcp add scholar-feed -e SF_API_KEY=sf_your_key_here -- npx -y scholar-fee
   "mcpServers": {
     "scholar-feed": {
       "command": "npx",
-      "args": ["-y", "scholar-feed-mcp"]
+      "args": ["-y", "scholar-feed-mcp@latest"]
     }
   }
 }
@@ -97,7 +97,7 @@ A few clients need a different wrapper key or file format:
     "scholar-feed": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "scholar-feed-mcp"]
+      "args": ["-y", "scholar-feed-mcp@latest"]
     }
   }
 }
@@ -111,7 +111,7 @@ A few clients need a different wrapper key or file format:
     "scholar-feed": {
       "source": "custom",
       "command": "npx",
-      "args": ["-y", "scholar-feed-mcp"]
+      "args": ["-y", "scholar-feed-mcp@latest"]
     }
   }
 }
@@ -126,7 +126,7 @@ mcpServers:
     command: npx
     args:
       - "-y"
-      - scholar-feed-mcp
+      - scholar-feed-mcp@latest
 ```
 
 **Project-scoped** (`.mcp.json`), to share the server across a repo:
@@ -136,7 +136,7 @@ mcpServers:
   "mcpServers": {
     "scholar-feed": {
       "command": "npx",
-      "args": ["-y", "scholar-feed-mcp"],
+      "args": ["-y", "scholar-feed-mcp@latest"],
       "env": { "SF_API_KEY": "${SF_API_KEY}" }
     }
   }
@@ -145,7 +145,7 @@ mcpServers:
 
 </details>
 
-**Windows:** for any JSON config above, use `"command": "cmd"` and `"args": ["/c", "npx", "-y", "scholar-feed-mcp"]`.
+**Windows:** for any JSON config above, use `"command": "cmd"` and `"args": ["/c", "npx", "-y", "scholar-feed-mcp@latest"]`.
 
 Scholar Feed is a standard stdio MCP server, so any other MCP-compatible client works with the standard block too.
 
@@ -297,14 +297,22 @@ The key may have been revoked. Generate a new one at [scholarfeed.org/settings](
 **"Rate limit exceeded" or "Anonymous daily limit exceeded"**
 Anonymous mode allows 100 calls/day. Get a free API key at [scholarfeed.org/settings](https://www.scholarfeed.org/settings) for 1,000 calls/day per account.
 
+**Server shows as "failed" with no error — especially right after an update**
+The first launch (and the first launch after each new release) makes `npx` download the package. The published bin is a single self-contained file with no dependency tree to resolve, so this is fast — but on a slow link it can still outrun your client's start-up timeout, and the server then shows as "failed" with no detail. Fixes: (1) warm the cache by running it once in a terminal — `npx -y scholar-feed-mcp@latest --version` — then restart your client; (2) raise the MCP start-up timeout if your client supports it (Claude Code: `MCP_TIMEOUT=60000`). For the fastest, offline-capable launches, install once globally and point the config at it instead of `npx`:
+
+```bash
+npm install -g scholar-feed-mcp
+# then in your MCP config:  "command": "scholar-feed-mcp", "args": []
+```
+
 **Tool calls time out or fail silently**
 Ensure Node.js 18+ is installed (`node --version`). Older versions lack the native `fetch` API.
 
 **Stale npx cache**
-If you're stuck on an old version after an update: `npx --yes scholar-feed-mcp@latest`
+The config blocks above pin `scholar-feed-mcp@latest`, which re-resolves the newest version each launch. If you previously used an unpinned `scholar-feed-mcp` and are stuck on an old build: `npx --yes scholar-feed-mcp@latest`.
 
 **Windows: "command not found"**
-Use `"command": "cmd"` with `"args": ["/c", "npx", "-y", "scholar-feed-mcp"]` in your MCP config.
+Use `"command": "cmd"` with `"args": ["/c", "npx", "-y", "scholar-feed-mcp@latest"]` in your MCP config.
 
 ## Migrating from v1.x
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "scholar-feed-mcp",
   "display_name": "Scholar Feed",
-  "version": "3.7.1",
+  "version": "3.8.0",
   "description": "Semantic search, citation graph, full text, embeddings, and BibTeX export over 600,000+ CS/AI/ML papers.",
   "icon": "assets/icon-marketplace.png",
   "long_description": "Scholar Feed gives your AI assistant a research copilot over 600,000+ CS/AI/ML papers: semantic search, citation-graph traversal, co-author graphs, full-text extraction, foundational-lineage lookup, text embeddings, and saved libraries, collections, and standing watches. Works anonymously at 100 calls/day, or 1,000/day with a free API key.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,38 +1,36 @@
 {
   "name": "scholar-feed-mcp",
-  "version": "3.7.1",
+  "version": "3.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scholar-feed-mcp",
-      "version": "3.7.1",
+      "version": "3.8.0",
       "license": "MIT",
-      "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
-        "cors": "^2.8.6",
-        "express": "^5.2.1",
-        "jose": "^6.2.3",
-        "zod": "^4.4.3"
-      },
       "bin": {
         "scholar-feed-mcp": "build/index.js"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
         "@types/node": "^20.0.0",
         "c8": "^11.0.0",
+        "cors": "^2.8.6",
         "eslint": "^9.39.4",
         "eslint-config-prettier": "^10.1.8",
+        "express": "^5.2.1",
         "globals": "^17.6.0",
+        "jose": "^6.2.3",
         "prettier": "^3.8.3",
         "tsup": "^8.0.0",
         "tsx": "^4.22.3",
         "typescript": "^5.5.0",
         "typescript-eslint": "^8.60.0",
-        "wrangler": "^4.97.0"
+        "wrangler": "^4.97.0",
+        "zod": "^4.4.3"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -883,6 +881,7 @@
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1500,6 +1499,7 @@
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -2311,6 +2311,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
@@ -2347,6 +2348,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2363,6 +2365,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -2437,6 +2440,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
       "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -2490,6 +2494,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2543,6 +2548,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2556,6 +2562,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2684,6 +2691,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
       "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2697,6 +2705,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2713,6 +2722,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2722,6 +2732,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
@@ -2731,6 +2742,7 @@
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
@@ -2748,6 +2760,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2762,6 +2775,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2786,6 +2800,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2805,6 +2820,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2819,6 +2835,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
@@ -2832,6 +2849,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2851,6 +2869,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2860,6 +2879,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2869,6 +2889,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2933,6 +2954,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -3203,6 +3225,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3212,6 +3235,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.1"
@@ -3224,6 +3248,7 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
       "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -3233,6 +3258,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
@@ -3276,6 +3302,7 @@
       "version": "8.5.2",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
       "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ip-address": "^10.2.0"
@@ -3294,6 +3321,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3314,6 +3342,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
       "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3361,6 +3390,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -3449,6 +3479,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3458,6 +3489,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3482,6 +3514,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3501,6 +3534,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3525,6 +3559,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3582,6 +3617,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3604,6 +3640,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3616,6 +3653,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3628,6 +3666,7 @@
       "version": "4.12.23",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
       "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3644,6 +3683,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
@@ -3664,6 +3704,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -3727,12 +3768,14 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -3742,6 +3785,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -3784,12 +3828,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -3835,6 +3881,7 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
       "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -3874,12 +3921,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -4016,6 +4065,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4025,6 +4075,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -4034,6 +4085,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4046,6 +4098,7 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4055,6 +4108,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -4131,6 +4185,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -4156,6 +4211,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4165,6 +4221,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4174,6 +4231,7 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4186,6 +4244,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -4198,6 +4257,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -4270,6 +4330,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -4289,6 +4350,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4315,6 +4377,7 @@
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -4362,6 +4425,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
@@ -4452,6 +4516,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -4475,6 +4540,7 @@
       "version": "6.15.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
       "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -4490,6 +4556,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4499,6 +4566,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -4538,6 +4606,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4602,6 +4671,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -4618,6 +4688,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -4637,6 +4708,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -4663,6 +4735,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -4682,6 +4755,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/sharp": {
@@ -4733,6 +4807,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -4745,6 +4820,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4754,6 +4830,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4773,6 +4850,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4789,6 +4867,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -4807,6 +4886,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -4849,6 +4929,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -4997,6 +5078,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -5613,6 +5695,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
       "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",
@@ -5699,6 +5782,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -5733,6 +5817,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -5742,6 +5827,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6332,6 +6418,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {
@@ -6451,6 +6538,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -6460,6 +6548,7 @@
       "version": "3.25.1",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
       "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "dev": true,
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25 || ^4"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scholar-feed-mcp",
   "mcpName": "io.github.YGao2005/scholar-feed-mcp",
-  "version": "3.7.1",
+  "version": "3.8.0",
   "description": "MCP server for Scholar Feed: search 600,000+ CS/AI/ML papers with LLM-powered analysis",
   "type": "module",
   "license": "MIT",
@@ -31,8 +31,8 @@
     "build"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts --clean --out-dir build",
-    "dev": "tsup src/index.ts --format esm --watch --out-dir build",
+    "build": "tsup",
+    "dev": "tsup --watch",
     "dev:http": "tsx src/server-http.ts",
     "worker:dev": "wrangler dev --define SF_WORKER_VERSION:\"\\\"$npm_package_version\\\"\"",
     "worker:deploy": "wrangler deploy --define SF_WORKER_VERSION:\"\\\"$npm_package_version\\\"\"",
@@ -46,28 +46,28 @@
     "coverage": "c8 node --import tsx --test src/__tests__/*.test.ts",
     "prepublishOnly": "npm run lint && npm run build && npm run coverage"
   },
-  "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
-    "cors": "^2.8.6",
-    "express": "^5.2.1",
-    "jose": "^6.2.3",
-    "zod": "^4.4.3"
-  },
+  "comment:dependencies": "Runtime deps are intentionally empty: the published bin (build/index.js) is a self-contained esbuild bundle (see tsup.config.ts), so `npx`/Docker consumers install ZERO transitive deps. The five former runtime deps (sdk/zod for the stdio bundle; express/cors/jose for the HTTP+Worker deploy targets) live in devDependencies — they are bundled in at build time by every deploy target and CI, never installed by consumers.",
+  "dependencies": {},
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/node": "^20.0.0",
     "c8": "^11.0.0",
+    "cors": "^2.8.6",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",
+    "express": "^5.2.1",
     "globals": "^17.6.0",
+    "jose": "^6.2.3",
     "prettier": "^3.8.3",
     "tsup": "^8.0.0",
     "tsx": "^4.22.3",
     "typescript": "^5.5.0",
     "typescript-eslint": "^8.60.0",
-    "wrangler": "^4.97.0"
+    "wrangler": "^4.97.0",
+    "zod": "^4.4.3"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/scripts/pack-mcpb.mjs
+++ b/scripts/pack-mcpb.mjs
@@ -2,13 +2,10 @@
 /**
  * Reproducibly pack the MCPB bundle (Claude Desktop one-click install).
  *
- * build/index.js is NOT self-contained — tsup leaves @modelcontextprotocol/sdk
- * and zod (and their prod closure) as external runtime imports, so the .mcpb must
- * ship a node_modules. But the repo's node_modules is the full ~300MB dev tree
- * (wrangler/workerd/typescript/esbuild/...), and `mcpb pack .` would bundle all of
- * it plus coverage/, dist-worker/, docs/, src/. Instead we stage a minimal tree
- * with a PRODUCTION-ONLY install and pack that — a lean (~3MB) bundle, without
- * touching the repo's node_modules.
+ * build/index.js is a SINGLE self-contained esbuild bundle (see tsup.config.ts):
+ * every runtime dep is inlined, so the .mcpb ships NO node_modules. We still stage
+ * a minimal tree (rather than `mcpb pack .`) so packing doesn't sweep in the repo's
+ * ~300MB dev node_modules plus coverage/, dist-worker/, docs/, src/.
  *
  * Usage: npm run mcpb:pack   ->  ./scholar-feed-mcp.mcpb (gitignored)
  */
@@ -32,13 +29,12 @@ run("npm", ["run", "build"], repo);
 
 const stage = await mkdtemp(join(tmpdir(), "sf-mcpb-"));
 try {
-  console.error(`[mcpb] staging a production-only tree at ${stage}`);
-  // Only what the bundle needs: the manifest, the stdio build, the branded icon,
-  // and the package files so a prod install resolves the runtime deps.
+  console.error(`[mcpb] staging a minimal tree at ${stage}`);
+  // Only what the bundle needs: the manifest, the self-contained stdio build, the
+  // branded icon, and package.json (the entry reads its version from it at runtime).
   const items = [
     "manifest.json",
     "package.json",
-    "package-lock.json",
     "build",
     "assets/icon-marketplace.png",
     "README.md",
@@ -51,11 +47,6 @@ try {
     await mkdir(dirname(dest), { recursive: true });
     await cp(src, dest, { recursive: true });
   }
-
-  console.error(
-    "[mcpb] installing PRODUCTION dependencies in the staging tree...",
-  );
-  run("npm", ["ci", "--omit=dev", "--ignore-scripts"], stage);
 
   console.error("[mcpb] packing...");
   run("npx", ["--yes", "@anthropic-ai/mcpb", "pack", stage, out], repo);

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.YGao2005/scholar-feed-mcp",
   "title": "Scholar Feed",
   "description": "Search 600,000+ CS/AI/ML papers with citation graph, full text, embeddings, and BibTeX.",
-  "version": "3.7.1",
+  "version": "3.8.0",
   "websiteUrl": "https://www.scholarfeed.org",
   "repository": {
     "url": "https://github.com/YGao2005/scholar-feed-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "scholar-feed-mcp",
-      "version": "3.7.1",
+      "version": "3.8.0",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,13 +1,13 @@
 /**
  * Interactive setup wizard for Scholar Feed MCP.
  *
- * Usage: npx scholar-feed-mcp init
+ * Usage: npx scholar-feed-mcp@latest init
  *
  * Prompts for an API key (optional) and an MCP client, then configures the
  * appropriate config file or prints the snippet to paste. No external
  * dependencies — uses Node.js built-ins only.
  *
- * Every client launches the same stdio server (`npx -y scholar-feed-mcp`); they
+ * Every client launches the same stdio server (`npx -y scholar-feed-mcp@latest`); they
  * differ only in config-file location and the wrapper key:
  *   - Most clients use `mcpServers` (Cursor, Claude Desktop, Windsurf, Gemini
  *     CLI, LM Studio) — handled by mergeMcpServersConfig.
@@ -149,7 +149,7 @@ function standardJsonSnippet(hasKey: boolean): string {
   "mcpServers": {
     "scholar-feed": {
       "command": "npx",
-      "args": ["-y", "scholar-feed-mcp"]${envLine}
+      "args": ["-y", "scholar-feed-mcp@latest"]${envLine}
     }
   }
 }`;
@@ -163,7 +163,7 @@ function continueYamlSnippet(hasKey: boolean): string {
     command: npx
     args:
       - "-y"
-      - scholar-feed-mcp${envBlock}`;
+      - scholar-feed-mcp@latest${envBlock}`;
 }
 
 export async function runInit(): Promise<void> {
@@ -214,7 +214,7 @@ export async function runInit(): Promise<void> {
   // Standard `mcpServers` server entry (Cursor, Claude Desktop, Windsurf, Gemini, LM Studio).
   const serverBlock: Record<string, unknown> = {
     command: "npx",
-    args: ["-y", "scholar-feed-mcp"],
+    args: ["-y", "scholar-feed-mcp@latest"],
   };
   if (hasKey) {
     serverBlock.env = env;
@@ -234,7 +234,7 @@ export async function runInit(): Promise<void> {
         "--",
         "npx",
         "-y",
-        "scholar-feed-mcp",
+        "scholar-feed-mcp@latest",
       ];
       try {
         execFileSync("claude", addArgs, { stdio: "inherit" });
@@ -250,7 +250,7 @@ export async function runInit(): Promise<void> {
         // scrollback, screen-shares, and bug reports.
         const keyHint = apiKey ? " -e SF_API_KEY=<your-key>" : "";
         console.error(
-          `  claude mcp add scholar-feed${keyHint} -- npx -y scholar-feed-mcp`,
+          `  claude mcp add scholar-feed${keyHint} -- npx -y scholar-feed-mcp@latest`,
         );
       }
       break;
@@ -278,7 +278,7 @@ export async function runInit(): Promise<void> {
       const vscodeBlock: Record<string, unknown> = {
         type: "stdio",
         command: "npx",
-        args: ["-y", "scholar-feed-mcp"],
+        args: ["-y", "scholar-feed-mcp@latest"],
       };
       if (hasKey) vscodeBlock.env = env;
       mergeKeyedConfig(filePath, "servers", vscodeBlock);
@@ -309,7 +309,7 @@ export async function runInit(): Promise<void> {
       const zedBlock: Record<string, unknown> = {
         source: "custom",
         command: "npx",
-        args: ["-y", "scholar-feed-mcp"],
+        args: ["-y", "scholar-feed-mcp@latest"],
       };
       if (hasKey) zedBlock.env = env;
       mergeKeyedConfig(filePath, "context_servers", zedBlock);
@@ -371,7 +371,9 @@ export async function runInit(): Promise<void> {
       break;
     }
     default: {
-      console.error("  Invalid choice. Run 'npx scholar-feed-mcp init' again.");
+      console.error(
+        "  Invalid choice. Run 'npx scholar-feed-mcp@latest init' again.",
+      );
       rl.close();
       process.exit(1);
     }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig } from "tsup";
+
+/**
+ * Build the published stdio bin (`build/index.js`) as a SINGLE self-contained
+ * file with every runtime dependency inlined and tree-shaken.
+ *
+ * Why bundle instead of leaving deps external (the old `--format esm` default):
+ * the stdio entry only touches the MCP SDK's stdio + server classes and zod, but
+ * shipping `@modelcontextprotocol/sdk` as a runtime dep dragged in its full
+ * Streamable-HTTP transport closure (express, cors, ajv, the hono tree, ...) —
+ * ~24 MB of node_modules that `npx scholar-feed-mcp` had to download on the first
+ * launch and again after every publish. On a slow link that cold install can
+ * outrun an MCP client's start-up timeout, and the server "fails silently".
+ *
+ * Bundling lets esbuild keep only the code the stdio path actually reaches, so
+ * the published package installs ZERO transitive deps (all five former runtime
+ * deps now live in devDependencies — present for the HTTP/Worker deploy targets
+ * and CI, absent for `npx`/Docker-runtime consumers, who only run this bundle).
+ */
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  outDir: "build",
+  clean: true,
+  // Inline everything that isn't a Node built-in. `platform: "node"` keeps
+  // `node:*` / bare builtins (fs, http, crypto, ...) external automatically.
+  noExternal: [/.*/],
+  splitting: false, // one file — the `await import("./init.js")` path is inlined
+  dts: false, // a CLI bin ships no types
+  minify: true, // shrink the single artifact
+  treeshake: true,
+  platform: "node",
+  target: "node18",
+  // src/index.ts already begins with `#!/usr/bin/env node`; tsup preserves it.
+});


### PR DESCRIPTION
## Why
The published stdio bin shipped `@modelcontextprotocol/sdk` as a **runtime dep**, which dragged in its full Streamable-HTTP closure (express/cors/ajv/hono) — **~24 MB of node_modules** that `npx scholar-feed-mcp` downloads on first launch and again after every publish. On a slow link that cold install outruns an MCP client's start-up timeout, so the server **"fails silently."** Compounding it, every install snippet used a bare, unpinned `scholar-feed-mcp`, which npx can pin to a stale cached build (old tool surface, pre-fencing).

## What
- **Self-contained bundle** (`tsup.config.ts`, `noExternal`): tree-shakes the SDK to just the stdio path + zod. All five former runtime deps → `devDependencies`; `dependencies` is now `{}`, so consumers install **zero transitive packages**.
  - Cold download **~24 MB → 160 KB tarball**; `npm i` adds 1 package in ~0.16 s, 0 dep dirs. Verified the bundle runs standalone with **no node_modules** (handshake + 25 tools + a live `search_papers` call + `--version`).
- **Pin `@latest`** in every README config block and the `init` wizard, so launches resolve the newest version instead of a stale npx cache.
- Troubleshooting: cold-start / `MCP_TIMEOUT` / `npm i -g` section. `pack-mcpb.mjs`: dropped the now-obsolete production-install step. Bumped package/manifest/server to **3.8.0** + CHANGELOG.

## Safety
Deploy targets unchanged — the HTTP/Worker builds bundle these deps at build time from `devDependencies` (verified `worker:dryrun` still builds). `typecheck` / `lint` / `format:check` / **228 tests** all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)