### PR TITLE
docs(mcpb): declare privacy policy for the Connector directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,10 @@ v3.0.0 was a hard cutover with no deprecation window: the v1.x surface was conso
 
 </details>
 
+## Privacy
+
+See our [privacy policy](https://www.scholarfeed.org/privacy-policy).
+
 ## License
 
 [MIT](LICENSE)

--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,7 @@
     "type": "git",
     "url": "https://github.com/YGao2005/scholar-feed-mcp"
   },
+  "privacy_policies": ["https://www.scholarfeed.org/privacy-policy"],
   "license": "MIT",
   "keywords": [
     "research",


### PR DESCRIPTION
Adds the Scholar Feed privacy policy reference to the MCPB bundle so the Claude Connector/Extensions directory's privacy-policy requirement is satisfied.

## Changes
- `manifest.json`: add `privacy_policies` (the v0.3 MCPB manifest schema's array field for privacy URLs) pointing at https://www.scholarfeed.org/privacy-policy. Note: the singular `privacy_policy` is NOT a valid field (the schema is `additionalProperties: false`); `privacy_policies` is the correct field and `mcpb pack` validates cleanly.
- `README.md`: add a short `## Privacy` section linking the policy.

## Verification
- `npm run mcpb:pack` prints "Manifest schema validation passes!" and produces `scholar-feed-mcp.mcpb` (176945 bytes).
- Rebuilt bundle confirmed to contain both the manifest field and README line.
- The v3.8.0 GitHub Release asset has been re-shipped with the rebuilt bundle (download returns HTTP 200).

No version bump, no new tag, no npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)