### PR TITLE
feat(mcp): output schemas on all 25 tools + collection "/" nesting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scholar-feed-mcp",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scholar-feed-mcp",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "license": "MIT",
       "bin": {
         "scholar-feed-mcp": "build/index.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scholar-feed-mcp",
   "mcpName": "io.github.YGao2005/scholar-feed-mcp",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "MCP server for Scholar Feed: search 600,000+ CS/AI/ML papers with LLM-powered analysis",
   "type": "module",
   "license": "MIT",

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -8,6 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export type ToolResult = {
   content: Array<{ type: string; text: string }>;
+  structuredContent?: Record<string, unknown>;
   isError?: boolean;
 };
 
@@ -25,6 +26,7 @@ export interface CapturedTool {
   title?: string;
   description: string;
   inputSchema: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
   annotations?: ToolAnnotations;
   handler: ToolHandler;
 }
@@ -46,6 +48,7 @@ export function makeFakeServer(): {
         title?: string;
         description: string;
         inputSchema: Record<string, unknown>;
+        outputSchema?: Record<string, unknown>;
         annotations?: ToolAnnotations;
       },
       handler: ToolHandler,
@@ -54,6 +57,7 @@ export function makeFakeServer(): {
         title: def.title,
         description: def.description,
         inputSchema: def.inputSchema,
+        outputSchema: def.outputSchema,
         annotations: def.annotations,
         handler,
       });

--- a/src/__tests__/output_schema.test.ts
+++ b/src/__tests__/output_schema.test.ts
@@ -1,0 +1,393 @@
+/**
+ * Output-schema contract tests.
+ *
+ * Two guarantees, both aimed at the MCP SDK's `validateToolOutput`
+ * (server/mcp.js), which THROWS on a successful call when a tool declares an
+ * `outputSchema` but returns no `structuredContent`, or returns one that fails
+ * the schema:
+ *
+ *   1. every registered tool declares a non-empty `outputSchema`, and
+ *   2. each tool's SUCCESS path returns a `structuredContent` that validates
+ *      against that schema.
+ *
+ * We replicate the SDK's check exactly — `z.object(outputSchema).safeParse(...)`
+ * on the raw shape — so a green run here means the live server will not raise
+ * "Output validation error" for these shapes.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { z } from "zod";
+import { registerAllTools } from "../tools/index.js";
+import {
+  makeFakeServer,
+  stubFetch,
+  type CapturedTool,
+  type ToolResult,
+} from "./helpers.js";
+
+const TEST_BASE = "https://example.test/api/v1";
+const ENV_KEYS = ["SF_API_KEY", "SF_API_BASE_URL", "SF_API_TIMEOUT_MS"];
+
+function buildTools(): Map<string, CapturedTool> {
+  const { server, tools } = makeFakeServer();
+  registerAllTools(server);
+  return tools;
+}
+
+const TOOLS = buildTools();
+
+/** Run a tool handler with a stubbed fetch + clean env; return its result. */
+async function invoke(
+  name: string,
+  args: Record<string, unknown>,
+  opts?: Parameters<typeof stubFetch>[0],
+): Promise<ToolResult> {
+  const tool = TOOLS.get(name);
+  if (!tool) throw new Error(`tool not registered: ${name}`);
+  const snap: Record<string, string | undefined> = {};
+  for (const k of ENV_KEYS) {
+    snap[k] = process.env[k];
+    delete process.env[k];
+  }
+  process.env.SF_API_BASE_URL = TEST_BASE;
+  const f = stubFetch(opts);
+  try {
+    return (await tool.handler(args)) as ToolResult;
+  } finally {
+    f.restore();
+    for (const k of ENV_KEYS) {
+      const v = snap[k];
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+/** Validate structuredContent the way the SDK does: z.object(shape).safeParse. */
+function validate(name: string, sc: unknown): void {
+  const tool = TOOLS.get(name);
+  assert.ok(tool?.outputSchema, `${name} must declare an outputSchema`);
+  const schema = z.object(tool.outputSchema as z.ZodRawShape);
+  const parsed = schema.safeParse(sc);
+  assert.ok(
+    parsed.success,
+    `${name} structuredContent must satisfy its outputSchema: ${
+      parsed.success ? "" : JSON.stringify(parsed.error.issues)
+    }`,
+  );
+}
+
+describe("every tool declares a non-empty outputSchema", () => {
+  for (const [name, def] of TOOLS) {
+    it(`${name} has an outputSchema`, () => {
+      assert.strictEqual(
+        typeof def.outputSchema,
+        "object",
+        `${name} must declare an outputSchema`,
+      );
+      assert.ok(
+        Object.keys(def.outputSchema ?? {}).length > 0,
+        `${name} outputSchema must declare at least one field`,
+      );
+    });
+  }
+});
+
+/**
+ * One representative SUCCESS fixture per tool (and a few extra branches). Each
+ * exercises the path that returns structuredContent; we then assert the content
+ * is present and schema-valid. The JSON fixtures mirror the real API shapes.
+ */
+const PAPER = {
+  arxiv_id: "2407.15831",
+  title: "A paper",
+  authors: ["A. Author"],
+  year: 2024,
+  github_url: null,
+  venue_name: null,
+  llm_novelty_score: 0.7,
+};
+
+const CASES: Array<{
+  label: string;
+  name: string;
+  args: Record<string, unknown>;
+  opts?: Parameters<typeof stubFetch>[0];
+}> = [
+  {
+    label: "search_papers",
+    name: "search_papers",
+    args: { q: "x", page: 1, limit: 20 },
+    opts: {
+      json: { papers: [PAPER], total: 1, next_cursor: null, mode: "semantic" },
+    },
+  },
+  {
+    label: "get_paper json",
+    name: "get_paper",
+    args: { arxiv_ids: ["A"] },
+    opts: { json: { papers: [PAPER], total: 1, not_found: [] } },
+  },
+  {
+    label: "get_paper bibtex",
+    name: "get_paper",
+    args: { arxiv_ids: ["A"], format: "bibtex" },
+    opts: { json: { bibtex: "@article{x}", count: 1, not_found: [] } },
+  },
+  {
+    label: "get_citations",
+    name: "get_citations",
+    args: { arxiv_id: "A", direction: "cited_by", limit: 20 },
+    opts: { json: { papers: [PAPER], total: 1, direction: "cited_by" } },
+  },
+  {
+    label: "fetch_fulltext results",
+    name: "fetch_fulltext",
+    args: { arxiv_id: "A" },
+    opts: {
+      json: {
+        source: "arxiv",
+        arxiv_id: "A",
+        results_text: "r",
+        table_captions: [],
+      },
+    },
+  },
+  {
+    label: "fetch_fulltext sections",
+    name: "fetch_fulltext",
+    args: { arxiv_id: "A", sections: "all" },
+    opts: {
+      json: {
+        source: "arxiv",
+        arxiv_id: "A",
+        sections: { abstract: "a", method: null },
+        table_captions: ["t1"],
+      },
+    },
+  },
+  {
+    label: "find_author q-mode",
+    name: "find_author",
+    args: { q: "Hinton", limit: 20 },
+    opts: {
+      json: {
+        query: "Hinton",
+        search_type: "name",
+        authors: [{ id: 1, name: "G. Hinton", h_index: 9 }],
+        total: 1,
+      },
+    },
+  },
+  {
+    label: "find_author id-mode",
+    name: "find_author",
+    args: { id: 42 },
+    opts: {
+      json: { id: 42, name: "G. Hinton", h_index: 9, top_papers: [PAPER] },
+    },
+  },
+  {
+    label: "co_author_graph",
+    name: "co_author_graph",
+    args: { author_ids: [1], window_years: 10 },
+    opts: {
+      json: {
+        queried_author_ids: [1],
+        window_years: 10,
+        edge_count: 1,
+        edges: [{ from: 1, to: 2, papers_count: 3, last_collab_year: 2024 }],
+      },
+    },
+  },
+  {
+    label: "embed_text",
+    name: "embed_text",
+    args: { text: "x", task_type: "RETRIEVAL_DOCUMENT" },
+    opts: {
+      json: { embedding: [0.1, 0.2, 0.3], model: "gemini", dimensions: 768 },
+    },
+  },
+  {
+    label: "get_field_orientation",
+    name: "get_field_orientation",
+    args: { topic: "efficient attention", limit: 15 },
+    opts: {
+      json: {
+        topic: "efficient attention",
+        papers: [
+          { arxiv_id: "A", published_date: "2024-01-01", rank_score: 1.2 },
+        ],
+        total: 1,
+        note: "n",
+      },
+    },
+  },
+  {
+    label: "get_foundational_lineage",
+    name: "get_foundational_lineage",
+    args: {
+      anchor_paper_id: "2504.04704",
+      scope: "field",
+      generality_ceiling: true,
+      limit: 15,
+    },
+    opts: {
+      json: {
+        anchor: "2504.04704",
+        scope: "field",
+        niche_size: 200,
+        tiers: {
+          niche_roots: [{ arxiv_id: "A", lift: 1.2, cited_by_in_niche: ["B"] }],
+          field_level: [],
+          discipline: [],
+        },
+        note: null,
+      },
+    },
+  },
+  {
+    label: "save_paper",
+    name: "save_paper",
+    args: { arxiv_id: "A" },
+    opts: { json: { success: true, action: "added", paper_id: "A" } },
+  },
+  {
+    label: "unsave_paper",
+    name: "unsave_paper",
+    args: { arxiv_id: "A" },
+    opts: { json: { success: true, action: "removed", paper_id: "A" } },
+  },
+  {
+    label: "like_paper",
+    name: "like_paper",
+    args: { arxiv_id: "A" },
+    opts: { json: { ok: true } },
+  },
+  {
+    label: "list_library",
+    name: "list_library",
+    args: { limit: 10, page: 1 },
+    opts: { json: { papers: [PAPER], total: 1 } },
+  },
+  {
+    label: "list_collections",
+    name: "list_collections",
+    args: {},
+    opts: { json: { collections: [{ id: "c1", name: "n", paper_count: 2 }] } },
+  },
+  {
+    label: "create_collection (created)",
+    name: "create_collection",
+    args: { name: "new one" },
+    opts: { json: { collections: [] } },
+  },
+  {
+    label: "add_to_collection",
+    name: "add_to_collection",
+    args: { arxiv_id: "A", collection_id: "c1" },
+    opts: { json: { ok: true } },
+  },
+  {
+    label: "remove_from_collection",
+    name: "remove_from_collection",
+    args: { arxiv_id: "A", collection_id: "c1" },
+    opts: { json: { ok: true } },
+  },
+  {
+    label: "create_watch",
+    name: "create_watch",
+    args: { name: "w", novelty_min: 0.5, q: "x" },
+    opts: { json: { id: "w1", name: "w", novelty_min: 0.5 } },
+  },
+  {
+    label: "list_watches",
+    name: "list_watches",
+    args: {},
+    opts: { json: { watches: [{ id: "w1", name: "n", pending_hits: 0 }] } },
+  },
+  {
+    label: "check_watches (hits)",
+    name: "check_watches",
+    args: { watch_id: "w1", limit: 25 },
+    opts: { json: { papers: [PAPER], total: 1 } },
+  },
+  {
+    label: "check_watches (no watch found → text path)",
+    name: "check_watches",
+    args: { watch_name: "nope", limit: 50 },
+    opts: { json: { watches: [] } },
+  },
+  {
+    label: "update_watch",
+    name: "update_watch",
+    args: { watch_id: "w1", new_name: "r", novelty_min: 0.8 },
+    opts: { json: { id: "w1", name: "r" } },
+  },
+  {
+    label: "delete_watch",
+    name: "delete_watch",
+    args: { watch_id: "w1" },
+    opts: { json: { ok: true } },
+  },
+  {
+    label: "preview_watch",
+    name: "preview_watch",
+    args: { criteria: { categories: ["cs.SE"] }, recency_days: 7 },
+    opts: {
+      json: {
+        window_days: 7,
+        needs_similarity: false,
+        match_count: 1,
+        sample: [PAPER],
+      },
+    },
+  },
+  {
+    label: "find_gaps",
+    name: "find_gaps",
+    args: { topic: "rag", scope: "both", limit: 10 },
+    opts: { json: { foundational_gaps: [PAPER], frontier_gaps: [] } },
+  },
+  {
+    label: "ask_library",
+    name: "ask_library",
+    args: { question: "what is the consensus?", limit: 8 },
+    opts: { json: { answer: "a", citations: [], papers: [PAPER] } },
+  },
+];
+
+describe("tool success paths return schema-valid structuredContent", () => {
+  for (const { label, name, args, opts } of CASES) {
+    it(`${label} → structuredContent satisfies its outputSchema`, async () => {
+      const result = await invoke(name, args, opts);
+      assert.notStrictEqual(
+        result.isError,
+        true,
+        `${label} should be a success path, got an error: ${result.content?.[0]?.text}`,
+      );
+      assert.strictEqual(
+        typeof result.structuredContent,
+        "object",
+        `${label} must return structuredContent`,
+      );
+      validate(name, result.structuredContent);
+    });
+  }
+});
+
+describe("the bundled affordance text is preserved alongside structuredContent", () => {
+  it("search_papers still returns fenced text AND structuredContent", async () => {
+    const result = await invoke(
+      "search_papers",
+      { q: "x", page: 1, limit: 20 },
+      { json: { papers: [PAPER], total: 1 } },
+    );
+    assert.match(result.content[0].text, /BEGIN UNTRUSTED PAPER CONTENT/);
+    assert.deepStrictEqual(
+      (result.structuredContent as { papers?: unknown[] }).papers?.length,
+      1,
+    );
+  });
+});

--- a/src/tools/_output.ts
+++ b/src/tools/_output.ts
@@ -1,0 +1,370 @@
+/**
+ * Structured-output schemas + helpers for the MCP tools.
+ *
+ * Every tool declares an `outputSchema` and returns `structuredContent` next to
+ * the human-readable text. The schemas are deliberately PERMISSIVE — every field
+ * is optional and object schemas allow unknown keys (`.catchall(z.unknown())`) —
+ * because the backend response shape is owned by a separate service and evolves
+ * (lean vs verbose paper shapes, new extraction fields, paginated envelopes).
+ *
+ * Why permissive matters: the MCP SDK validates `structuredContent` against the
+ * declared schema on every SUCCESSFUL call (server/mcp.js `validateToolOutput`)
+ * and THROWS on a mismatch. Zod objects strip unknown keys instead of rejecting
+ * them, so the only way to fail is a DECLARED field present with the wrong type.
+ * Keeping every field optional + loosely typed means a benign backend addition
+ * can never turn into a hard tool error. The original `structuredContent` is sent
+ * on the wire unchanged (validation does not mutate it), so the stripping is a
+ * gate, not a filter — extra fields still reach the client.
+ *
+ * The text `content` is unchanged, so clients that ignore `structuredContent`
+ * see no difference; clients that read it get typed, machine-usable output.
+ *
+ * Shapes are exported as raw Zod shapes (plain objects of validators) — the same
+ * form `inputSchema` uses, and the form `registerTool` expects for `outputSchema`
+ * (mcp.js `getZodSchemaObject` → `objectFromShape`).
+ */
+
+import { z } from "zod";
+
+/**
+ * Coerce an arbitrary backend payload into a JSON object for `structuredContent`
+ * (MCP requires the top level to be an object). Objects pass through untouched;
+ * arrays / primitives / null are wrapped under `result` so the contract holds
+ * even if an endpoint returns a non-object.
+ */
+export function asStructuredObject(result: unknown): Record<string, unknown> {
+  if (result !== null && typeof result === "object" && !Array.isArray(result)) {
+    return result as Record<string, unknown>;
+  }
+  return { result };
+}
+
+/**
+ * The structured payload for a status / mutation tool: human text plus a small
+ * machine-readable object. Every non-error return MUST carry `structuredContent`
+ * once a tool declares an outputSchema, so the per-file `text()` helpers default
+ * to `{ ok: true, message }` via this.
+ */
+export function statusContent(
+  message: string,
+  fields: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return { ok: true, message, ...fields };
+}
+
+/**
+ * A paper record across the lean (12-field), search (+similarity), verbose
+ * (~18-field) and field-orientation variants. Loose + all-optional so it accepts
+ * every variant — and any future extraction field — without ever rejecting.
+ */
+const paperObject = z
+  .object({
+    arxiv_id: z.string().optional(),
+    title: z.string().optional(),
+    authors: z.array(z.string()).optional(),
+    year: z.number().optional(),
+    published_date: z.string().optional(),
+    categories: z.array(z.string()).optional(),
+    primary_category: z.string().optional(),
+    has_code: z.boolean().optional(),
+    github_url: z.string().nullable().optional(),
+    citation_count: z.number().optional(),
+    venue_name: z.string().nullable().optional(),
+    llm_summary: z.string().nullable().optional(),
+    llm_significance: z.string().nullable().optional(),
+    llm_novelty_score: z.number().nullable().optional(),
+    similarity: z.number().optional(),
+    rank_score: z.number().optional(),
+    arxiv_url: z.string().optional(),
+    pdf_url: z.string().optional(),
+    institution_tags: z.array(z.string()).optional(),
+  })
+  .catchall(z.unknown())
+  .describe(
+    "A paper record. Verbose calls add extraction fields (method_name, datasets, baselines, ...).",
+  );
+
+/**
+ * Shared envelope for every tool that returns a `papers` array:
+ * search_papers, get_citations, get_field_orientation, list_library,
+ * check_watches. Unknown top-level keys (e.g. an endpoint's own wrapper) are
+ * stripped, not rejected, so this fits all of them.
+ */
+export const papersOutput = {
+  papers: z
+    .array(paperObject)
+    .optional()
+    .describe("Matched / returned papers."),
+  total: z
+    .number()
+    .optional()
+    .describe("Total results available for the query."),
+  page: z.number().optional(),
+  limit: z.number().optional(),
+  mode: z.string().optional().describe("Search mode actually applied."),
+  direction: z
+    .string()
+    .optional()
+    .describe("Citation direction (get_citations: citing | cited_by)."),
+  topic: z.string().optional(),
+  note: z.string().nullable().optional(),
+  not_found: z
+    .array(z.string())
+    .optional()
+    .describe("Requested IDs that had no match."),
+  next_cursor: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Keyset cursor for the next page, or null when exhausted."),
+  hits: z
+    .array(paperObject)
+    .optional()
+    .describe("New watch matches (check_watches)."),
+  results: z.array(paperObject).optional(),
+};
+
+/** get_paper: the papers envelope, plus the bibtex / status keys for format='bibtex'. */
+export const getPaperOutput = {
+  ...papersOutput,
+  bibtex: z.string().optional().describe("BibTeX entry (format='bibtex')."),
+  count: z.number().optional(),
+  format: z.string().optional(),
+  ok: z.boolean().optional(),
+  message: z.string().optional(),
+};
+
+/** fetch_fulltext: lean `results_text` mode and the full `sections` object mode. */
+export const fulltextOutput = {
+  source: z
+    .string()
+    .optional()
+    .describe("Where the text came from (e.g. arxiv)."),
+  arxiv_id: z.string().optional(),
+  results_text: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Results/experiments excerpt (default 'results' mode)."),
+  sections: z
+    .object({
+      abstract: z.string().nullable().optional(),
+      introduction: z.string().nullable().optional(),
+      related_work: z.string().nullable().optional(),
+      method: z.string().nullable().optional(),
+      results: z.string().nullable().optional(),
+      conclusion: z.string().nullable().optional(),
+    })
+    .catchall(z.unknown())
+    .optional()
+    .describe("Per-section text (sections='all')."),
+  table_captions: z.array(z.string()).optional(),
+};
+
+const lineagePaper = z
+  .object({
+    id: z.string().optional(),
+    arxiv_id: z.string().optional(),
+    title: z.string().optional(),
+    authors: z.array(z.string()).optional(),
+    year: z.number().optional(),
+    global_citations: z.number().optional(),
+    niche_indegree: z.number().optional(),
+    lift: z.number().optional(),
+    cited_by_in_niche: z.array(z.string()).optional(),
+  })
+  .catchall(z.unknown());
+
+/** get_foundational_lineage: the three citation-graph tiers (nested under `tiers`). */
+export const lineageOutput = {
+  anchor: z.string().optional(),
+  scope: z.string().optional(),
+  niche_size: z.number().optional(),
+  tiers: z
+    .object({
+      niche_roots: z.array(lineagePaper).optional(),
+      field_level: z.array(lineagePaper).optional(),
+      discipline: z.array(lineagePaper).optional(),
+    })
+    .catchall(z.unknown())
+    .optional()
+    .describe("Foundational tiers: niche_roots → field_level → discipline."),
+  // Some shapes flatten the tiers to the top level — accept both.
+  niche_roots: z.array(lineagePaper).optional(),
+  field_level: z.array(lineagePaper).optional(),
+  discipline: z.array(lineagePaper).optional(),
+  note: z.string().nullable().optional(),
+};
+
+const authorObject = z
+  .object({
+    id: z.number().optional(),
+    name: z.string().optional(),
+    h_index: z.number().optional(),
+    total_papers: z.number().optional(),
+    primary_field: z.string().optional(),
+    research_topics: z.array(z.string()).optional(),
+    author_rank_score: z.number().optional(),
+    semantic_scholar_id: z.string().nullable().optional(),
+    years_active: z.number().optional(),
+  })
+  .catchall(z.unknown());
+
+/** find_author: polymorphic — q-mode list envelope OR id-mode flat profile. */
+export const authorOutput = {
+  // q-mode envelope
+  query: z.string().optional(),
+  search_type: z.string().optional(),
+  total: z.number().optional(),
+  authors: z
+    .array(authorObject)
+    .optional()
+    .describe("Matching authors (q-mode)."),
+  // id-mode flat profile
+  id: z.number().optional(),
+  name: z.string().optional(),
+  h_index: z.number().optional(),
+  total_papers: z.number().optional(),
+  total_citations: z.number().optional(),
+  primary_field: z.string().optional(),
+  research_topics: z.array(z.string()).optional(),
+  rank: z.number().optional(),
+  top_papers: z
+    .array(paperObject)
+    .optional()
+    .describe("Top papers by rank (id-mode profile)."),
+};
+
+/** co_author_graph: co-authorship edges. */
+export const coAuthorGraphOutput = {
+  queried_author_ids: z.array(z.number()).optional(),
+  window_years: z.number().optional(),
+  edge_count: z.number().optional(),
+  edges: z
+    .array(
+      z
+        .object({
+          from: z.number().optional(),
+          to: z.number().optional(),
+          papers_count: z.number().optional(),
+          last_collab_year: z.number().optional(),
+        })
+        .catchall(z.unknown()),
+    )
+    .optional()
+    .describe(
+      "Co-authorship edges {from, to, papers_count, last_collab_year}.",
+    ),
+};
+
+/** embed_text: the embedding vector + model metadata. */
+export const embedOutput = {
+  embedding: z
+    .array(z.number())
+    .optional()
+    .describe("The embedding vector (768-dim Gemini Flash)."),
+  model: z.string().optional(),
+  task_type: z.string().optional(),
+  dimensions: z.number().optional(),
+  dims: z.number().optional(),
+};
+
+/** preview_watch: dry-run summary of a structured filter. */
+export const previewWatchOutput = {
+  window_days: z.number().optional(),
+  needs_similarity: z.boolean().optional(),
+  match_count: z.number().optional(),
+  sample: z
+    .array(paperObject)
+    .optional()
+    .describe("A sample of matching papers."),
+  ok: z.boolean().optional(),
+  message: z.string().optional(),
+};
+
+/** list_collections: the user's named collections. */
+export const collectionsListOutput = {
+  collections: z
+    .array(
+      z
+        .object({
+          id: z.string().optional(),
+          name: z.string().optional(),
+          paper_count: z.number().optional(),
+        })
+        .catchall(z.unknown()),
+    )
+    .optional(),
+  ok: z.boolean().optional(),
+  message: z.string().optional(),
+};
+
+/** list_watches: the user's standing watches. */
+export const watchesListOutput = {
+  watches: z
+    .array(
+      z
+        .object({
+          id: z.string().optional(),
+          name: z.string().optional(),
+          novelty_min: z.number().optional(),
+          summary: z.string().optional(),
+          last_evaluated_at: z.string().nullable().optional(),
+          pending_hits: z.number().optional(),
+        })
+        .catchall(z.unknown()),
+    )
+    .optional(),
+  ok: z.boolean().optional(),
+  message: z.string().optional(),
+};
+
+/** find_gaps: the two gap buckets. */
+export const gapsOutput = {
+  foundational_gaps: z
+    .array(paperObject)
+    .optional()
+    .describe("Canonical anchors in the niche not in your library."),
+  frontier_gaps: z
+    .array(paperObject)
+    .optional()
+    .describe("Recent high-novelty work you haven't saved."),
+  ok: z.boolean().optional(),
+  message: z.string().optional(),
+};
+
+/** ask_library: the synthesized answer + grounding. */
+export const askLibraryOutput = {
+  answer: z
+    .string()
+    .optional()
+    .describe("The synthesized answer with inline [arXiv-ID] citations."),
+  citations: z.array(z.unknown()).optional(),
+  papers: z.array(paperObject).optional(),
+  ok: z.boolean().optional(),
+  message: z.string().optional(),
+};
+
+/** Shared shape for the status / mutation tools (save, like, watch/collection writes). */
+export const statusOutput = {
+  ok: z.boolean().optional().describe("True when the operation succeeded."),
+  message: z
+    .string()
+    .optional()
+    .describe("Human-readable summary of the outcome."),
+  action: z
+    .string()
+    .optional()
+    .describe(
+      "Machine label: saved | no_change | removed | liked | created | updated | deleted.",
+    ),
+  arxiv_id: z.string().optional(),
+  collection: z
+    .unknown()
+    .optional()
+    .describe("The created/affected collection, when applicable."),
+  watch: z
+    .unknown()
+    .optional()
+    .describe("The created/affected watch, when applicable."),
+};

--- a/src/tools/ask_library.ts
+++ b/src/tools/ask_library.ts
@@ -18,9 +18,13 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { client } from "../client.js";
 import { fencePaperContent } from "./_untrusted.js";
+import { asStructuredObject, askLibraryOutput } from "./_output.js";
 
-function text(t: string) {
-  return { content: [{ type: "text" as const, text: t }] };
+function text(t: string, structured?: Record<string, unknown>) {
+  return {
+    content: [{ type: "text" as const, text: t }],
+    structuredContent: structured ?? { ok: true, message: t },
+  };
 }
 
 function errorResult(error: unknown) {
@@ -37,6 +41,7 @@ export function register(server: McpServer): void {
     {
       title: "Ask Library",
       annotations: { readOnlyHint: true, destructiveHint: false },
+      outputSchema: askLibraryOutput,
       description:
         "Answer a question using ONLY the papers you've saved — a synthesis over your library (or one collection) with inline [arXiv-ID] citations. The inverse of find_gaps (which finds important work you're MISSING): ask_library reasons over what you HAVE. Optionally scope to one collection (collection_name OR collection_id); omit both to use your whole library. Read-only. Requires SF_API_KEY (it reads your saved set). Free accounts get 1 question/month; Pro raises this to 200/day.",
       inputSchema: {
@@ -87,7 +92,8 @@ export function register(server: McpServer): void {
         if (collection_name) params.collection_name = collection_name;
         if (collection_id) params.collection_id = collection_id;
         const result = await client.get<unknown>("/ask", params);
-        return text(fencePaperContent(result)); // answer synthesised over papers = untrusted
+        // answer synthesised over papers = untrusted
+        return text(fencePaperContent(result), asStructuredObject(result));
       } catch (error) {
         return errorResult(error);
       }

--- a/src/tools/citations.ts
+++ b/src/tools/citations.ts
@@ -8,6 +8,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { client } from "../client.js";
 import { fencedWithNextSteps } from "./_affordances.js";
+import { asStructuredObject, papersOutput } from "./_output.js";
 
 export function register(server: McpServer): void {
   server.registerTool(
@@ -15,6 +16,7 @@ export function register(server: McpServer): void {
     {
       title: "Get Citations",
       annotations: { readOnlyHint: true, destructiveHint: false },
+      outputSchema: papersOutput,
       description:
         "Get the citation graph for a paper, sorted by citing-paper rank_score (highest-impact first). 'citing' = outgoing references this paper cites; 'cited_by' = incoming citations from other papers. Default response is a lean 12-field shape per paper — pass verbose=true for the full 28-field shape.",
       inputSchema: {
@@ -74,6 +76,7 @@ export function register(server: McpServer): void {
               text: fencedWithNextSteps(result, "citations"),
             },
           ],
+          structuredContent: asStructuredObject(result),
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/src/tools/co_author_graph.ts
+++ b/src/tools/co_author_graph.ts
@@ -8,6 +8,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { client } from "../client.js";
+import { asStructuredObject, coAuthorGraphOutput } from "./_output.js";
 
 export function register(server: McpServer): void {
   server.registerTool(
@@ -15,6 +16,7 @@ export function register(server: McpServer): void {
     {
       title: "Co-Author Graph",
       annotations: { readOnlyHint: true, destructiveHint: false },
+      outputSchema: coAuthorGraphOutput,
       description:
         "Find the co-authorship neighborhood of one or more authors. Given a list of author_ids, returns edges {from, to, papers_count, last_collab_year} where 'from' is one of the input authors and 'to' is any co-author appearing on a shared paper within the window. Use for AC reviewer triage (find conflicts), disambiguating researchers (who do they actually work with?), or expanding an author seed into a research community. window_years defaults to 10. Result is capped at 500 edges, sorted by papers_count DESC.",
       inputSchema: {
@@ -50,6 +52,7 @@ export function register(server: McpServer): void {
           content: [
             { type: "text" as const, text: JSON.stringify(result, null, 2) },
           ],
+          structuredContent: asStructuredObject(result),
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/src/tools/collections_write.ts
+++ b/src/tools/collections_write.ts
@@ -10,6 +10,12 @@
  * collection add/remove path. Collections can be addressed by id OR by name
  * (get-or-create by name), so an agent never has to look up an id first.
  *
+ * Nesting: storage is flat, but a "/" in a name is the folder convention —
+ * "AgentOPA/Formal" is the collection "Formal" inside an "AgentOPA" folder.
+ * Folders are derived from the name (no parent row to create first), and the
+ * web UI renders them as a collapsible tree. list_collections surfaces the
+ * derived folder/depth per collection so an agent can reason about the tree.
+ *
  * Endpoints:
  *   GET    /collections                       (list, with paper counts)
  *   POST   /collections                       (create; body {name})
@@ -29,6 +35,27 @@ interface Collection {
 
 interface CollectionList {
   collections: Collection[];
+}
+
+/**
+ * Annotate each collection with its derived nesting, splitting the name on "/".
+ * Storage stays flat; this just exposes the folder path the "/" convention
+ * implies so an agent (and the operator reading raw output) can see the tree.
+ * Empty segments are dropped, so "A // B" collapses to folder "A", leaf "B".
+ */
+function withNesting(collections: Collection[]) {
+  return collections.map((c) => {
+    const segments = c.name
+      .split("/")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    return {
+      ...c,
+      leaf_name: segments[segments.length - 1] ?? c.name,
+      folder: segments.length > 1 ? segments.slice(0, -1).join("/") : null,
+      depth: Math.max(0, segments.length - 1),
+    };
+  });
 }
 
 function text(t: string) {
@@ -90,8 +117,18 @@ export function register(server: McpServer): void {
     },
     async () => {
       try {
-        const result = await client.get<unknown>("/collections");
-        return text(JSON.stringify(result, null, 2));
+        const data = await client.get<CollectionList>("/collections");
+        return text(
+          JSON.stringify(
+            {
+              nesting_hint:
+                'A "/" in a name is a folder: "AgentOPA/G1" is collection "G1" in folder "AgentOPA". Folders are derived (not stored) — to nest, just name a collection "Parent/Child".',
+              collections: withNesting(data.collections || []),
+            },
+            null,
+            2,
+          ),
+        );
       } catch (error) {
         return errorResult(error);
       }
@@ -104,13 +141,15 @@ export function register(server: McpServer): void {
       title: "Create Collection",
       annotations: { readOnlyHint: false, destructiveHint: false },
       description:
-        "Create a new named collection. MUTATES. If a collection with that name already exists, returns the existing one (get-or-create — never errors on duplicate). Requires SF_API_KEY.",
+        'Create a new named collection. MUTATES. If a collection with that name already exists, returns the existing one (get-or-create — never errors on duplicate). Use "/" to nest under a folder, e.g. "AgentOPA/Formal" — the folder is derived from the name, so there is no parent to create first. Requires SF_API_KEY.',
       inputSchema: {
         name: z
           .string()
           .min(1)
           .max(100)
-          .describe("Name for the collection, e.g. 'KV-cache compression'."),
+          .describe(
+            "Name for the collection, e.g. 'KV-cache compression'. Use '/' to nest: 'AgentOPA/Formal' files it under an 'AgentOPA' folder.",
+          ),
       },
     },
     async ({ name }) => {
@@ -137,7 +176,7 @@ export function register(server: McpServer): void {
       title: "Add to Collection",
       annotations: { readOnlyHint: false, destructiveHint: false },
       description:
-        "Add a paper to a collection, addressed by collection_id OR collection_name (get-or-create by name — no need to look up an id first). MUTATES: also auto-saves the paper to the library. Idempotent (adding a paper already in the collection is a no-op). Requires SF_API_KEY.",
+        'Add a paper to a collection, addressed by collection_id OR collection_name (get-or-create by name — no need to look up an id first). Nest with "/": collection_name "AgentOPA/Formal" files the paper under an "AgentOPA" folder. MUTATES: also auto-saves the paper to the library. Idempotent (adding a paper already in the collection is a no-op). Requires SF_API_KEY.',
       inputSchema: {
         arxiv_id: z
           .string()
@@ -148,7 +187,7 @@ export function register(server: McpServer): void {
           .min(1)
           .optional()
           .describe(
-            "Name of the collection. Created if it doesn't exist. Provide this OR collection_id.",
+            "Name of the collection. Created if it doesn't exist. Use '/' to nest, e.g. 'AgentOPA/Formal'. Provide this OR collection_id.",
           ),
         collection_id: z
           .string()

--- a/src/tools/collections_write.ts
+++ b/src/tools/collections_write.ts
@@ -26,6 +26,11 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { client } from "../client.js";
+import {
+  collectionsListOutput,
+  statusContent,
+  statusOutput,
+} from "./_output.js";
 
 interface Collection {
   id: string;
@@ -58,8 +63,11 @@ function withNesting(collections: Collection[]) {
   });
 }
 
-function text(t: string) {
-  return { content: [{ type: "text" as const, text: t }] };
+function text(t: string, structured?: Record<string, unknown>) {
+  return {
+    content: [{ type: "text" as const, text: t }],
+    structuredContent: structured ?? statusContent(t),
+  };
 }
 
 function errorResult(error: unknown) {
@@ -111,6 +119,7 @@ export function register(server: McpServer): void {
     {
       title: "List Collections",
       annotations: { readOnlyHint: true, destructiveHint: false },
+      outputSchema: collectionsListOutput,
       description:
         "List the authenticated user's collections (named groups of saved papers) with paper counts. Read-only. Use before add_to_collection to see existing collections. Requires SF_API_KEY.",
       inputSchema: {},
@@ -118,17 +127,12 @@ export function register(server: McpServer): void {
     async () => {
       try {
         const data = await client.get<CollectionList>("/collections");
-        return text(
-          JSON.stringify(
-            {
-              nesting_hint:
-                'A "/" in a name is a folder: "AgentOPA/G1" is collection "G1" in folder "AgentOPA". Folders are derived (not stored) — to nest, just name a collection "Parent/Child".',
-              collections: withNesting(data.collections || []),
-            },
-            null,
-            2,
-          ),
-        );
+        const payload = {
+          nesting_hint:
+            'A "/" in a name is a folder: "AgentOPA/G1" is collection "G1" in folder "AgentOPA". Folders are derived (not stored) — to nest, just name a collection "Parent/Child".',
+          collections: withNesting(data.collections || []),
+        };
+        return text(JSON.stringify(payload, null, 2), payload);
       } catch (error) {
         return errorResult(error);
       }
@@ -140,6 +144,7 @@ export function register(server: McpServer): void {
     {
       title: "Create Collection",
       annotations: { readOnlyHint: false, destructiveHint: false },
+      outputSchema: statusOutput,
       description:
         'Create a new named collection. MUTATES. If a collection with that name already exists, returns the existing one (get-or-create — never errors on duplicate). Use "/" to nest under a folder, e.g. "AgentOPA/Formal" — the folder is derived from the name, so there is no parent to create first. Requires SF_API_KEY.',
       inputSchema: {
@@ -158,12 +163,23 @@ export function register(server: McpServer): void {
         if (existing) {
           return text(
             `Collection already exists: ${JSON.stringify(existing, null, 2)}`,
+            {
+              ok: true,
+              action: "no_change",
+              collection: existing,
+              message: `Collection already exists: ${existing.name}`,
+            },
           );
         }
         const created = await client.post<Collection>("/collections", {
           name: name.trim(),
         });
-        return text(`Created collection: ${JSON.stringify(created, null, 2)}`);
+        return text(`Created collection: ${JSON.stringify(created, null, 2)}`, {
+          ok: true,
+          action: "created",
+          collection: created,
+          message: `Created collection: ${created.name}`,
+        });
       } catch (error) {
         return errorResult(error);
       }
@@ -175,6 +191,7 @@ export function register(server: McpServer): void {
     {
       title: "Add to Collection",
       annotations: { readOnlyHint: false, destructiveHint: false },
+      outputSchema: statusOutput,
       description:
         'Add a paper to a collection, addressed by collection_id OR collection_name (get-or-create by name — no need to look up an id first). Nest with "/": collection_name "AgentOPA/Formal" files the paper under an "AgentOPA" folder. MUTATES: also auto-saves the paper to the library. Idempotent (adding a paper already in the collection is a no-op). Requires SF_API_KEY.',
       inputSchema: {
@@ -207,7 +224,16 @@ export function register(server: McpServer): void {
           paper_id: arxiv_id,
         });
         const where = coll.name ? `"${coll.name}"` : coll.id;
-        return text(`Added ${arxiv_id} to collection ${where} (and saved it).`);
+        return text(
+          `Added ${arxiv_id} to collection ${where} (and saved it).`,
+          {
+            ok: true,
+            action: "added",
+            arxiv_id,
+            collection: coll.name || coll.id,
+            message: `Added ${arxiv_id} to collection ${where} (and saved it).`,
+          },
+        );
       } catch (error) {
         return errorResult(error);
       }
@@ -219,6 +245,7 @@ export function register(server: McpServer): void {
     {
       title: "Remove from Collection",
       annotations: { readOnlyHint: false, destructiveHint: true },
+      outputSchema: statusOutput,
       description:
         "Remove a paper from a collection, addressed by collection_id OR collection_name. MUTATES (the paper stays in your library; it's only removed from this collection). Idempotent. Requires SF_API_KEY.",
       inputSchema: {

--- a/src/tools/embed_text.ts
+++ b/src/tools/embed_text.ts
@@ -8,6 +8,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { client } from "../client.js";
+import { asStructuredObject, embedOutput } from "./_output.js";
 
 export function register(server: McpServer): void {
   server.registerTool(
@@ -15,6 +16,7 @@ export function register(server: McpServer): void {
     {
       title: "Embed Text",
       annotations: { readOnlyHint: true, destructiveHint: false },
+      outputSchema: embedOutput,
       description:
         "Embed a text string into a 768-dim Gemini Flash vector. Use for HyDE-style retrieval: (1) write a hypothetical short paper that would perfectly answer the user's query, (2) embed it with task_type='RETRIEVAL_DOCUMENT' (default — matches the corpus embedding side), (3) pass the resulting embedding back through search-style tools to find real papers nearest to the hypothetical. task_type='RETRIEVAL_QUERY' matches the query side and is useful for direct user-query embedding without HyDE. Pro-only — requires an SF_API_KEY on a Pro account; anonymous and free callers get a 403 pro_required. Cost: ~$0.0001/call; rate-limited at 30/minute per API key.",
       inputSchema: {
@@ -44,6 +46,7 @@ export function register(server: McpServer): void {
           content: [
             { type: "text" as const, text: JSON.stringify(result, null, 2) },
           ],
+          structuredContent: asStructuredObject(result),
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/src/tools/find_author.ts
+++ b/src/tools/find_author.ts
@@ -12,6 +12,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { client } from "../client.js";
 import { fencePaperContent } from "./_untrusted.js";
+import { asStructuredObject, authorOutput } from "./_output.js";
 
 export function register(server: McpServer): void {
   server.registerTool(
@@ -19,6 +20,7 @@ export function register(server: McpServer): void {
     {
       title: "Find Author",
       annotations: { readOnlyHint: true, destructiveHint: false },
+      outputSchema: authorOutput,
       description:
         "Two-mode author tool — replaces discover_authors and get_author. Provide exactly one of q or id. Q-MODE (q=...): search for researchers by topic or name — uses embedding similarity for topics ('efficient LLM inference'), fuzzy matching for names ('Yann LeCun'). Returns a list of matching authors with author_id, name, h_index, total_papers, primary_field, research_topics. ID-MODE (id=...): look up a single author profile by author_id (obtained from a previous q-mode call or from co_author_graph results). Returns h-index, total citations, global rank, primary field, novelty score distribution, research topics, code/venue scores, years active, and their top 10 papers by rank score.",
       inputSchema: {
@@ -87,6 +89,7 @@ export function register(server: McpServer): void {
             content: [
               { type: "text" as const, text: fencePaperContent(result) },
             ],
+            structuredContent: asStructuredObject(result),
           };
         } else {
           // id-mode: direct profile lookup
@@ -97,6 +100,7 @@ export function register(server: McpServer): void {
             content: [
               { type: "text" as const, text: fencePaperContent(result) },
             ],
+            structuredContent: asStructuredObject(result),
           };
         }
       } catch (error) {

--- a/src/tools/fulltext.ts
+++ b/src/tools/fulltext.ts
@@ -8,6 +8,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { client } from "../client.js";
 import { fencedWithNextSteps } from "./_affordances.js";
+import { asStructuredObject, fulltextOutput } from "./_output.js";
 
 export function register(server: McpServer): void {
   server.registerTool(
@@ -15,6 +16,7 @@ export function register(server: McpServer): void {
     {
       title: "Fetch Full Text",
       annotations: { readOnlyHint: true, destructiveHint: false },
+      outputSchema: fulltextOutput,
       description:
         "Extract paper content from an arXiv paper's LaTeX source. Two modes: 'results' (default) returns 800 chars of results/experiments + 3 table captions. 'all' returns full paper sections (abstract, introduction, related work, method, results, conclusion) at up to 3000 chars each + 5 table captions. ~62% of arXiv papers have LaTeX source. May take a few seconds.",
       inputSchema: {
@@ -43,6 +45,7 @@ export function register(server: McpServer): void {
               text: fencedWithNextSteps(result, "fulltext"),
             },
           ],
+          structuredContent: asStructuredObject(result),
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/src/tools/gaps.ts
+++ b/src/tools/gaps.ts
@@ -21,9 +21,13 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { client } from "../client.js";
 import { fencePaperContent } from "./_untrusted.js";
+import { asStructuredObject, gapsOutput } from "./_output.js";
 
-function text(t: string) {
-  return { content: [{ type: "text" as const, text: t }] };
+function text(t: string, structured?: Record<string, unknown>) {
+  return {
+    content: [{ type: "text" as const, text: t }],
+    structuredContent: structured ?? { ok: true, message: t },
+  };
 }
 
 function errorResult(error: unknown) {
@@ -40,6 +44,7 @@ export function register(server: McpServer): void {
     {
       title: "Find Research Gaps",
       annotations: { readOnlyHint: true, destructiveHint: false },
+      outputSchema: gapsOutput,
       description:
         "Find important work you HAVEN'T saved, for a collection or topic — a 'what am I missing?' analysis. Returns two buckets: foundational_gaps (canonical citation-graph anchors in the niche, not in your library) and frontier_gaps (recent high-novelty work in the niche, not yet saved). Provide exactly one seed: collection_name OR collection_id OR topic. The backend derives the niche, runs lineage + recent-novelty search, and subtracts your saved set. Read-only. Requires SF_API_KEY (it needs your library to subtract) and is a Pro feature — free accounts receive an upgrade prompt.",
       inputSchema: {
@@ -100,7 +105,8 @@ export function register(server: McpServer): void {
           limit: String(limit),
         };
         const result = await client.get<unknown>("/gaps", params);
-        return text(fencePaperContent(result)); // gap analysis over papers = untrusted
+        // gap analysis over papers = untrusted
+        return text(fencePaperContent(result), asStructuredObject(result));
       } catch (error) {
         return errorResult(error);
       }

--- a/src/tools/get_field_orientation.ts
+++ b/src/tools/get_field_orientation.ts
@@ -18,6 +18,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { client } from "../client.js";
 import { fencePaperContent } from "./_untrusted.js";
+import { asStructuredObject, papersOutput } from "./_output.js";
 
 export function register(server: McpServer): void {
   server.registerTool(
@@ -25,6 +26,7 @@ export function register(server: McpServer): void {
     {
       title: "Get Field Orientation",
       annotations: { readOnlyHint: true, destructiveHint: false },
+      outputSchema: papersOutput,
       description:
         "Returns CANDIDATE FOUNDATIONAL PAPERS for a research topic — cheap retrieval only, no synthesis. Ranks papers by a blend of citation count (0.6 weight, captures importance) and semantic similarity to your topic (0.4 weight). Use this to bootstrap a literature survey or get a fast sense of the landscape. For a synthesized orientation report (key concepts, open problems, reading order), use the /field-guide skill which calls this tool internally. Does not require a Pro API key — no LLM calls are made.",
       inputSchema: {
@@ -56,6 +58,7 @@ export function register(server: McpServer): void {
         );
         return {
           content: [{ type: "text" as const, text: fencePaperContent(result) }],
+          structuredContent: asStructuredObject(result),
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/src/tools/get_foundational_lineage.ts
+++ b/src/tools/get_foundational_lineage.ts
@@ -15,6 +15,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { client } from "../client.js";
 import { fencedWithNextSteps } from "./_affordances.js";
+import { asStructuredObject, lineageOutput } from "./_output.js";
 
 export function register(server: McpServer): void {
   server.registerTool(
@@ -22,6 +23,7 @@ export function register(server: McpServer): void {
     {
       title: "Get Foundational Lineage",
       annotations: { readOnlyHint: true, destructiveHint: false },
+      outputSchema: lineageOutput,
       description:
         "Returns the FOUNDATIONAL WORK FOR A PAPER'S NICHE via the citation graph — the relative question ('what is foundational for THIS paper's specific sub-field', often itself only modestly cited) rather than the obvious global landmarks. Anchors on the paper, takes its embedding neighbourhood as the niche, and ranks what the niche cites into three tiers: `niche_roots` (the niche-specific foundations, ranked by how specifically the neighbourhood builds on them — surfaces canonical anchors that semantic search misses), `field_level` (broader secondary foundations), and `discipline` (universal landmarks like Attention Is All You Need, collapsed out of the way). Each paper carries `cited_by_in_niche` evidence so the claim is grounded, not asserted. Use this to trace prior art / lineage for a paper, or to find the canonical methods a niche is built on. Complements get_field_orientation (which is topic-anchored and retrieval-only). No Pro key and no LLM calls required.",
       inputSchema: {
@@ -74,6 +76,7 @@ export function register(server: McpServer): void {
               text: fencedWithNextSteps(result, "lineage"),
             },
           ],
+          structuredContent: asStructuredObject(result),
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/src/tools/get_paper.ts
+++ b/src/tools/get_paper.ts
@@ -16,6 +16,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { client } from "../client.js";
 import { fencedWithNextSteps } from "./_affordances.js";
+import { asStructuredObject, getPaperOutput } from "./_output.js";
 
 export function register(server: McpServer): void {
   server.registerTool(
@@ -23,6 +24,7 @@ export function register(server: McpServer): void {
     {
       title: "Get Paper",
       annotations: { readOnlyHint: true, destructiveHint: false },
+      outputSchema: getPaperOutput,
       description:
         "Get full details for one or more papers by arXiv ID. Pass a single-element array for one paper; pass multiple IDs to batch-fetch up to 50 papers in one call (replaces the removed batch_lookup tool). Pass format='bibtex' to get a .bib citation entry (replaces the removed export_bibtex tool — bibtex is single-paper only; for multi-paper bibtex, call repeatedly). Default returns a lean 12-field shape (arxiv_id, title, authors, year, categories, has_code, github_url, citation_count, venue_name, llm_summary, llm_significance, llm_novelty_score). Pass verbose=true for the full 28-field shape with structured extraction (method_name, contribution_type, task_category, datasets, baselines) and institution_tags. Use fields='arxiv_id,title,abstract' to select an exact subset, or fetch_fulltext with sections='all' for the full paper.",
       inputSchema: {
@@ -67,6 +69,13 @@ export function register(server: McpServer): void {
           const bibText = result.bibtex ?? JSON.stringify(result, null, 2);
           return {
             content: [{ type: "text" as const, text: bibText }],
+            structuredContent: {
+              ok: true,
+              format: "bibtex",
+              bibtex: result.bibtex,
+              count: result.count,
+              not_found: result.not_found,
+            },
           };
         }
 
@@ -91,6 +100,7 @@ export function register(server: McpServer): void {
               text: fencedWithNextSteps(result, "paper"),
             },
           ],
+          structuredContent: asStructuredObject(result),
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/src/tools/library.ts
+++ b/src/tools/library.ts
@@ -24,6 +24,12 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { client } from "../client.js";
 import { fencePaperContent } from "./_untrusted.js";
+import {
+  asStructuredObject,
+  papersOutput,
+  statusContent,
+  statusOutput,
+} from "./_output.js";
 
 interface ToggleResult {
   success: boolean;
@@ -31,8 +37,11 @@ interface ToggleResult {
   paper_id: string;
 }
 
-function text(t: string) {
-  return { content: [{ type: "text" as const, text: t }] };
+function text(t: string, structured?: Record<string, unknown>) {
+  return {
+    content: [{ type: "text" as const, text: t }],
+    structuredContent: structured ?? statusContent(t),
+  };
 }
 
 function errorResult(error: unknown) {
@@ -49,6 +58,7 @@ export function register(server: McpServer): void {
     {
       title: "Save Paper",
       annotations: { readOnlyHint: false, destructiveHint: false },
+      outputSchema: statusOutput,
       description:
         "Save a paper to the authenticated user's Scholar Feed library (bookmark). MUTATES the library and feeds the user's personalization — saved papers are the strongest signal in the For You feed and the email digest. Idempotent: calling it again on an already-saved paper leaves it saved. Requires SF_API_KEY. To file it into a named collection in one step, use add_to_collection (that also saves).",
       inputSchema: {
@@ -68,9 +78,19 @@ export function register(server: McpServer): void {
           await client.post<ToggleResult>("/interactions/save", {
             paper_id: arxiv_id,
           });
-          return text(`Already in your library (no change): ${arxiv_id}`);
+          return text(`Already in your library (no change): ${arxiv_id}`, {
+            ok: true,
+            action: "no_change",
+            arxiv_id,
+            message: `Already in your library (no change): ${arxiv_id}`,
+          });
         }
-        return text(`Saved to your library: ${arxiv_id}`);
+        return text(`Saved to your library: ${arxiv_id}`, {
+          ok: true,
+          action: "saved",
+          arxiv_id,
+          message: `Saved to your library: ${arxiv_id}`,
+        });
       } catch (error) {
         return errorResult(error);
       }
@@ -82,6 +102,7 @@ export function register(server: McpServer): void {
     {
       title: "Unsave Paper",
       annotations: { readOnlyHint: false, destructiveHint: true },
+      outputSchema: statusOutput,
       description:
         "Remove a paper from the authenticated user's Scholar Feed library. MUTATES the library. Idempotent: removing a paper that isn't saved leaves it unsaved. Note: the saved library is a superset of all collections, so un-saving a paper ALSO removes it from every collection it was in. To keep it filed in a collection, use remove_from_collection instead (that leaves the paper saved). Requires SF_API_KEY.",
       inputSchema: {
@@ -101,9 +122,22 @@ export function register(server: McpServer): void {
           await client.post<ToggleResult>("/interactions/save", {
             paper_id: arxiv_id,
           });
-          return text(`Paper was not in your library (no change): ${arxiv_id}`);
+          return text(
+            `Paper was not in your library (no change): ${arxiv_id}`,
+            {
+              ok: true,
+              action: "no_change",
+              arxiv_id,
+              message: `Paper was not in your library (no change): ${arxiv_id}`,
+            },
+          );
         }
-        return text(`Removed from your library: ${arxiv_id}`);
+        return text(`Removed from your library: ${arxiv_id}`, {
+          ok: true,
+          action: "removed",
+          arxiv_id,
+          message: `Removed from your library: ${arxiv_id}`,
+        });
       } catch (error) {
         return errorResult(error);
       }
@@ -115,6 +149,7 @@ export function register(server: McpServer): void {
     {
       title: "Like Paper",
       annotations: { readOnlyHint: false, destructiveHint: false },
+      outputSchema: statusOutput,
       description:
         "Like a paper — a 'more like this' calibration signal that tunes the user's For You feed toward similar work. INSERT-only and idempotent (liking twice is a no-op, never un-likes). Distinct from save_paper: like expresses taste for ranking; save bookmarks for later reading. Requires SF_API_KEY.",
       inputSchema: {
@@ -126,6 +161,12 @@ export function register(server: McpServer): void {
         await client.post("/interactions/boost", { paper_id: arxiv_id });
         return text(
           `Liked ${arxiv_id} — your feed will lean toward similar papers.`,
+          {
+            ok: true,
+            action: "liked",
+            arxiv_id,
+            message: `Liked ${arxiv_id} — your feed will lean toward similar papers.`,
+          },
         );
       } catch (error) {
         return errorResult(error);
@@ -138,6 +179,7 @@ export function register(server: McpServer): void {
     {
       title: "List Library",
       annotations: { readOnlyHint: true, destructiveHint: false },
+      outputSchema: papersOutput,
       description:
         "List the authenticated user's saved papers (their library), newest first. Read-only. Use this to review a reading list or to see what's already saved before saving more. Requires SF_API_KEY.",
       inputSchema: {
@@ -162,7 +204,8 @@ export function register(server: McpServer): void {
           limit: String(limit),
           page: String(page),
         });
-        return text(fencePaperContent(result)); // saved papers = untrusted content
+        // saved papers = untrusted content
+        return text(fencePaperContent(result), asStructuredObject(result));
       } catch (error) {
         return errorResult(error);
       }

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -12,6 +12,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { client } from "../client.js";
 import { fencedWithNextSteps } from "./_affordances.js";
+import { asStructuredObject, papersOutput } from "./_output.js";
 
 export function register(server: McpServer): void {
   server.registerTool(
@@ -19,6 +20,7 @@ export function register(server: McpServer): void {
     {
       title: "Search Papers",
       annotations: { readOnlyHint: true, destructiveHint: false },
+      outputSchema: papersOutput,
       description:
         "Search Scholar Feed's 600k+ CS/AI/ML paper corpus. Defaults to semantic (embedding) search — finds conceptually related papers even when the user's wording doesn't match the paper's title/abstract. Pass mode='keyword' for exact-string full-text search. CAVEAT: semantic search often misses old high-citation CANONICAL papers (e.g. foundational anchors like H2O for KV eviction, GRIT for unified embedding+generation) because the ranker prefers recent stylistically-matched papers. If you're hunting the canonical anchor for an area, parse the top-5 result abstracts for baseline mentions ('we compare against X, Y, Z'), then look the most-mentioned name up directly. Returns papers with LLM-generated summaries, novelty scores, and structured extraction data. Default response is a lean 12-field shape (arxiv_id, title, authors, year, categories, has_code, github_url, citation_count, venue_name, llm_summary, llm_significance, llm_novelty_score) — pass verbose=true or fields=... for the full 28-field shape with method/task/dataset extraction. Supports filtering by category, novelty, recency, method, task, dataset, and contribution type. v3 ABSORPTIONS: pass sort='trending' to replicate whats_trending; pass anchor_paper_id to replicate find_similar (q is ignored in anchor mode, results carry similarity_score); pass scope_to_citations_of to restrict search to a paper's citation graph (replaces find_citations_about).",
       inputSchema: {
@@ -219,6 +221,7 @@ export function register(server: McpServer): void {
               text: fencedWithNextSteps(result, "search"),
             },
           ],
+          structuredContent: asStructuredObject(result),
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/src/tools/watches.ts
+++ b/src/tools/watches.ts
@@ -38,6 +38,14 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { client } from "../client.js";
 import { fencePaperContent } from "./_untrusted.js";
+import {
+  asStructuredObject,
+  papersOutput,
+  previewWatchOutput,
+  statusContent,
+  statusOutput,
+  watchesListOutput,
+} from "./_output.js";
 
 interface Watch {
   id: string;
@@ -52,8 +60,11 @@ interface WatchList {
   watches: Watch[];
 }
 
-function text(t: string) {
-  return { content: [{ type: "text" as const, text: t }] };
+function text(t: string, structured?: Record<string, unknown>) {
+  return {
+    content: [{ type: "text" as const, text: t }],
+    structuredContent: structured ?? statusContent(t),
+  };
 }
 
 function errorResult(error: unknown) {
@@ -196,6 +207,7 @@ export function register(server: McpServer): void {
     {
       title: "Create Watch",
       annotations: { readOnlyHint: false, destructiveHint: false },
+      outputSchema: statusOutput,
       description:
         "Create a standing watch — evaluated daily against newly-indexed papers, surfacing new matches via the email digest and via check_watches. MUTATES. Get-or-create by name (re-creating with an existing name returns it unchanged — never errors on duplicate). TWO forms: (1) the v2 STRUCTURED filter via `criteria` (collections/authors/categories/text/has_code/min_novelty/similar, AND-composed) — the composable, agent-tunable form, recommended; tune it with preview_watch first, and edit later with update_watch. Structured watches rank by 'rising' (forecasted breakout impact) by default, and tighten with min_impact_pct for an anti-noise watch that surfaces only the breakout papers in your niche. (2) a single legacy seed selector (q OR collection_name OR collection_id OR anchor_paper_id); if `criteria` is given it takes precedence. Requires SF_API_KEY.",
       inputSchema: {
@@ -291,7 +303,12 @@ export function register(server: McpServer): void {
             novelty_min,
             seed: { kind: "filter", criteria, match: "all", recency_days },
           });
-          return text(`Watch ready: ${JSON.stringify(created, null, 2)}`);
+          return text(`Watch ready: ${JSON.stringify(created, null, 2)}`, {
+            ok: true,
+            action: "created",
+            watch: created,
+            message: `Watch ready: ${created.name ?? name.trim()}`,
+          });
         }
         const seed = buildSeed({
           q,
@@ -314,7 +331,12 @@ export function register(server: McpServer): void {
           novelty_min,
           seed,
         });
-        return text(`Watch ready: ${JSON.stringify(created, null, 2)}`);
+        return text(`Watch ready: ${JSON.stringify(created, null, 2)}`, {
+          ok: true,
+          action: "created",
+          watch: created,
+          message: `Watch ready: ${created.name ?? name.trim()}`,
+        });
       } catch (error) {
         return errorResult(error);
       }
@@ -326,6 +348,7 @@ export function register(server: McpServer): void {
     {
       title: "List Watches",
       annotations: { readOnlyHint: true, destructiveHint: false },
+      outputSchema: watchesListOutput,
       description:
         "List the authenticated user's watches with name, a one-line definition summary, last_evaluated_at, and pending_hits (count of new matches since the last digest delivery). Read-only. Use before create_watch to see what's already tracked. Requires SF_API_KEY.",
       inputSchema: {},
@@ -333,7 +356,10 @@ export function register(server: McpServer): void {
     async () => {
       try {
         const result = await client.get<unknown>("/watches");
-        return text(JSON.stringify(result, null, 2));
+        return text(
+          JSON.stringify(result, null, 2),
+          asStructuredObject(result),
+        );
       } catch (error) {
         return errorResult(error);
       }
@@ -345,6 +371,7 @@ export function register(server: McpServer): void {
     {
       title: "Check Watches",
       annotations: { readOnlyHint: true, destructiveHint: false },
+      outputSchema: papersOutput,
       description:
         "Pull new matching papers since the last digest delivery, in the same shape as search_papers results. Optionally scope to one watch by watch_name OR watch_id; omit both for all watches. Read-only and idempotent — does NOT advance any watermark (only digest delivery does), so it is safe to call repeatedly (no mark-on-read). This is the in-session 'anything new on my watches?' pull. Requires SF_API_KEY.",
       inputSchema: {
@@ -383,7 +410,8 @@ export function register(server: McpServer): void {
         const params: Record<string, string> = { limit: String(limit) };
         if (id) params.watch_id = id;
         const result = await client.get<unknown>("/watches/hits", params);
-        return text(fencePaperContent(result)); // matched papers = untrusted
+        // matched papers = untrusted
+        return text(fencePaperContent(result), asStructuredObject(result));
       } catch (error) {
         return errorResult(error);
       }
@@ -395,6 +423,7 @@ export function register(server: McpServer): void {
     {
       title: "Delete Watch",
       annotations: { readOnlyHint: false, destructiveHint: true },
+      outputSchema: statusOutput,
       description:
         "Delete a watch, addressed by watch_id OR name. MUTATES. Idempotent: deleting a non-existent watch is a no-op (no error). To change a watch in place (rename / novelty_min / retarget criteria) use update_watch instead of delete-and-recreate. Requires SF_API_KEY.",
       inputSchema: {
@@ -423,7 +452,11 @@ export function register(server: McpServer): void {
           id = existing.id;
         }
         await client.del(`/watches/${encodeURIComponent(id)}`);
-        return text(`Deleted watch ${watch_id ? id : `"${name}"`}.`);
+        return text(`Deleted watch ${watch_id ? id : `"${name}"`}.`, {
+          ok: true,
+          action: "deleted",
+          message: `Deleted watch ${watch_id ? id : `"${name}"`}.`,
+        });
       } catch (error) {
         return errorResult(error);
       }
@@ -435,6 +468,7 @@ export function register(server: McpServer): void {
     {
       title: "Update Watch",
       annotations: { readOnlyHint: false, destructiveHint: false },
+      outputSchema: statusOutput,
       description:
         "Update an existing watch in place — rename, change novelty_min, or RETARGET its structured filter `criteria`. MUTATES. Address by watch_id OR name. Changing criteria replaces the definition and clears the watch's pending hits (so stale matches don't deliver); the next daily eval repopulates. Structured watches rank by 'rising' (forecasted breakout impact) by default, and tighten with min_impact_pct for an anti-noise watch that surfaces only the breakout papers in your niche. Tune the new criteria with preview_watch first. Requires SF_API_KEY.",
       inputSchema: {
@@ -508,7 +542,12 @@ export function register(server: McpServer): void {
           `/watches/${encodeURIComponent(id)}`,
           body,
         );
-        return text(`Watch updated: ${JSON.stringify(updated, null, 2)}`);
+        return text(`Watch updated: ${JSON.stringify(updated, null, 2)}`, {
+          ok: true,
+          action: "updated",
+          watch: updated,
+          message: `Watch updated: ${updated.name ?? id}`,
+        });
       } catch (error) {
         return errorResult(error);
       }
@@ -520,6 +559,7 @@ export function register(server: McpServer): void {
     {
       title: "Preview Watch",
       annotations: { readOnlyHint: true, destructiveHint: false },
+      outputSchema: previewWatchOutput,
       description:
         "Dry-run a structured filter over recent papers WITHOUT creating a watch — the tuning loop. Returns {window_days, needs_similarity, match_count, sample} so you can iterate (add a category, raise min_novelty, switch the collection relation) before saving with create_watch. Structured watches rank by 'rising' (forecasted breakout impact) by default, and tighten with min_impact_pct for an anti-noise watch that surfaces only the breakout papers in your niche. NOTE: for a similarity filter, match_count is capped at 200 (the cosine fetch window) and so saturates at 200 on broad/hot topics — tune by the `sample` scores and narrow with categories/min_novelty (or a higher similar floor) rather than relying on match_count alone. Read-only. Requires SF_API_KEY.",
       inputSchema: {
@@ -542,7 +582,8 @@ export function register(server: McpServer): void {
           match: "all",
           recency_days,
         });
-        return text(fencePaperContent(result)); // sample matched papers = untrusted
+        // sample matched papers = untrusted
+        return text(fencePaperContent(result), asStructuredObject(result));
       } catch (error) {
         return errorResult(error);
       }


### PR DESCRIPTION
## What

Two changes, shipping as **v3.9.0**:

1. **Output schemas + structured content on all 25 tools** (the headline). Closes Smithery's `Output schemas 0/25` quality gap. Every tool now declares an `outputSchema` (serialized into `tools/list`) and returns matching `structuredContent` alongside the unchanged human-readable text — text-only clients are unaffected; schema-aware clients/agents get typed, parseable output.
2. **Collection "/" nesting convention** (already on the branch) — collection tools expose a derived folder tree from `"/"`-delimited names.

## Design (output schemas)

- Permissive raw Zod shapes in `src/tools/_output.ts`: every field optional, objects `.catchall(z.unknown())`. The MCP SDK validates `structuredContent` on every successful call and **throws** on mismatch (`server/mcp.js` `validateToolOutput`); since the backend response shape is owned by a separate service and drifts, biasing toward "never reject" keeps a benign backend addition from becoming a tool error. Error paths are unchanged (`isError` skips output validation).
- 6 paper-list tools share one envelope; mutation tools return a small `{ok, action, message, …}` built client-side.

## Naming (deliberately not changed)

Smithery's naming bonus wants dot-notation (`papers.search`), but Anthropic/OpenAI reject tool names that don't match `^[a-zA-Z0-9_-]{1,128}$` (dots → `invalid_request_error`). claude.ai is the live surface, so renaming would trade a hard failure on the primary channel for a cosmetic directory point. Names left as flat snake_case.

## Verification

- typecheck + lint + `format:check` clean; **297 tests pass** (new `output_schema.test.ts` replicates the SDK's validation for all 25 tools).
- Real `tools/list` shows 25/25 `outputSchema`; live `tools/call` against the production backend returns schema-valid `structuredContent` for search / get_paper / citations / foundational_lineage / fulltext / find_author / field_orientation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)