### PR TITLE
chore(meta): discovery metadata resync (v3.9.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scholar-feed-mcp",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scholar-feed-mcp",
-      "version": "3.9.0",
+      "version": "3.9.1",
       "license": "MIT",
       "bin": {
         "scholar-feed-mcp": "build/index.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scholar-feed-mcp",
   "mcpName": "io.github.YGao2005/scholar-feed-mcp",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "MCP server for Scholar Feed: search 600,000+ CS/AI/ML papers with LLM-powered analysis",
   "type": "module",
   "license": "MIT",
@@ -16,13 +16,23 @@
   },
   "keywords": [
     "mcp",
+    "model-context-protocol",
     "scholar-feed",
-    "research",
-    "papers",
     "arxiv",
+    "research",
+    "research-papers",
+    "papers",
+    "citations",
+    "citation-graph",
+    "semantic-search",
+    "literature-review",
+    "embeddings",
+    "bibtex",
     "ai",
     "machine-learning",
-    "model-context-protocol"
+    "claude",
+    "claude-code",
+    "cursor"
   ],
   "bin": {
     "scholar-feed-mcp": "./build/index.js"

--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.YGao2005/scholar-feed-mcp",
   "title": "Scholar Feed",
-  "description": "Search 600,000+ CS/AI/ML papers with citation graph, full text, embeddings, and BibTeX.",
-  "version": "3.8.0",
+  "description": "600,000+ CS/AI/ML papers in your AI assistant: search, novelty scores, citations, daily watches.",
+  "version": "3.9.1",
   "websiteUrl": "https://www.scholarfeed.org",
   "repository": {
     "url": "https://github.com/YGao2005/scholar-feed-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "scholar-feed-mcp",
-      "version": "3.8.0",
+      "version": "3.9.1",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {


### PR DESCRIPTION
Metadata-only resync (no code/tool changes):
- **npm keywords** expanded (adds `claude`, `claude-code`, `cursor`, `citation-graph`, `semantic-search`, `literature-review`, `bibtex`, `embeddings`, `research-papers`) — salvaged from the otherwise-stale `feat/library-collections-watches` branch, which was the only unmerged content left in the repo.
- **server.json description** updated to the punchier directory copy.
- Bumped to **v3.9.1**; `server.json` version fields synced.

Tag `v3.9.1` will publish the new keywords to npm and the new description to the MCP Registry in one shot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)