### PR TITLE
fix(mcp): surface backend conversion prompts at the 403 paywall (activation leak)

### DIFF
--- a/docs/DISTRIBUTION-HANDOFF.md
+++ b/docs/DISTRIBUTION-HANDOFF.md
@@ -1,0 +1,66 @@
+# Distribution and docs handoff (scholar-feed-mcp)
+
+Prepared 2026-06-02 by a prior session (working from a different repo) to hand off to a session working directly in THIS repo. Two jobs: (1) improve the docs (professional, concise, humanized), and (2) execute MCP distribution. The submission artifacts are already built; this is the playbook.
+
+Internal working doc. Not published to npm (package.json `files` is `["build"]`). Delete before a public-polish pass if you do not want it in the repo.
+
+## What this product is
+
+scholar-feed-mcp is a stdio MCP server (Node/TypeScript, on npm) that gives an AI assistant a research copilot over 600,000+ CS/AI/ML papers: semantic search, citation graph, co-author graph, full-text extraction, foundational-lineage lookup, embeddings, BibTeX, plus saved libraries/collections/watches. Backend: api.scholarfeed.org. Site: scholarfeed.org. Auth is `SF_API_KEY` and is OPTIONAL (anonymous 100 calls/day, keyed 1,000/day, Pro 10,000/day).
+
+## State of the repo after the prior session
+
+Done:
+- `README.md`: humanized. Removed all 31 em dashes and AI tells, preserved every command, tool name, number, table row, and code block (verified: code blocks byte-identical, 36 headings / 80 table rows / 18 fences unchanged). Added a light/dark `<picture>` logo header.
+- Logos in `assets/`: `logo-light.{svg,png}`, `logo-dark.{svg,png}`, `icon.png`. Transparent 400x400 PNGs (background tile stripped) plus transparent SVG sources.
+- `package.json`: added `"mcpName": "io.github.YGao2005/scholar-feed-mcp"` (registry ownership marker) and removed an em dash from `description`.
+- New distribution artifacts at repo root:
+  - `.mcp.json`: Cursor auto-detect plus the canonical copy-paste config.
+  - `server.json`: official MCP Registry manifest (v3.7.0, npm/stdio, `SF_API_KEY` optional + secret).
+  - `manifest.json`: MCPB desktop-extension manifest (`manifest_version` 0.3, `icon` wired to assets/icon.png, 11 headline tools, key as optional keychain `user_config`).
+
+Not done:
+- Nothing was committed or pushed. Branch was `feat/library-collections-watches` with unrelated WIP. Land the README, package.json, `.mcp.json`, `server.json`, `manifest.json`, and `assets/` on `main` before publishing.
+
+## Operator hard rules
+
+- NO em or en dashes anywhere (README, code comments, docs, commit messages). Scan before shipping: `grep -rnP '\x{2014}|\x{2013}' README.md docs/` (or ripgrep: `rg '\x{2014}|\x{2013}'`). Apply the `/humanizer` skill methodology (de-AI, but keep technical accuracy).
+- Never invent a tool name, parameter, or number. Verify against `src/tools/*.ts` and the live API.
+
+## Docs improvement goals (the main ask)
+
+1. Make the README more professional and concise. It is comprehensive but long; tighten without losing the install matrix. Keep zero em dashes.
+2. Reconcile the tool count. The README header says "Available Tools (22)" but the tables list 24 and `src/tools/index.ts` registers ~24 (including `ask_library`, `update_watch`, `preview_watch`). The barrel comment also says "v3.5 surface (22 tools)". Pick the real number, fix the header, the barrel comment, and any CHANGELOG mention.
+3. Align all docs to the real tool surface: README tables, `CHANGELOG.md`, `CONTRIBUTING.md`, and the `docs/*-spec.md` files. Tool names and params must match `src/tools/*.ts` exactly.
+4. Consider collapsing the long "Manual Installation" section (about 12 clients) into the standard block plus a compact per-client note table.
+5. Add a short positioning line near the top aimed at the ICP (researchers doing literature review inside Claude Code or Cursor).
+
+## Distribution playbook (artifacts are ready; execute these)
+
+Full per-surface requirements also live at `ScholarFeed Vault/90 Reference/MCP Distribution Checklist.md` (may not be reachable from this workspace; essentials are below).
+
+Build-once assets status: LICENSE present (MIT), README humanized, `.mcp.json`, `server.json`, `manifest.json`, `mcpName`, and a 400x400 logo all done. Remaining shared prep: a privacy policy and terms page on scholarfeed.org (needed for the Cline directory and the Anthropic directory).
+
+Ship today (accept the npx/GitHub package as-is):
+1. Official MCP Registry. Bump npm to 3.7.1 so the published package carries `mcpName`, set `server.json` `version` to match, then `brew install mcp-publisher`, `mcp-publisher login github`, `mcp-publisher publish`. This feeds PulseMCP (auto-ingest) and the VS Code `@mcp` gallery downstream.
+2. Glama (glama.ai/mcp). Auto-indexes the repo (LICENSE is the gate, satisfied). Sign in with GitHub to claim. Optional `glama.json`: `{"$schema":"https://glama.ai/mcp/schemas/server.json","maintainers":["YGao2005"]}`.
+3. mcp.so. Form at mcp.so/submit: Type=MCP Server, Name, URL, optional Server Config (use `.mcp.json`).
+4. mcpservers.org/submit. The ONLY way into wong2/awesome-mcp-servers (they reject PRs). Fields: name, short description, link, category=Search, contact email.
+5. punkpeye/awesome-mcp-servers. PR, add to `### 🔬 Research`, alphabetical. Line:
+   `- [YGao2005/scholar-feed-mcp](https://github.com/YGao2005/scholar-feed-mcp) 📇 ☁️ - Semantic search over 600k+ CS/AI papers with citation-graph traversal, full-text extraction, embeddings, and BibTeX export. Install: ` + "`npx scholar-feed-mcp init`" + `.`
+6. Cursor Directory. cursor.directory/plugins/new, sign in with GitHub or Google, paste the repo URL (auto-detects via `.mcp.json`).
+7. Cline MCP Marketplace. Open an issue at github.com/cline/mcp-marketplace (the template), give the repo URL plus a 400x400 PNG (`assets/icon.png`), tick the two confirmation boxes. Cline installs from your README, so the README must be self-installable.
+
+This week (a little packaging):
+8. Smithery. Cheapest path that keeps stdio: build an MCPB bundle, then `smithery mcp publish ./<bundle>.mcpb -n @YGao2005/scholar-feed`. Hosting via `runtime: typescript` would need code changes to export a Smithery-shaped server.
+9. Claude Desktop Extension (MCPB). `npm i -g @anthropic-ai/mcpb`, `mcpb validate manifest.json`, `npm run build && npm install --production`, `mcpb pack .` (bundles `node_modules` plus `build/`). Test by dragging the `.mcpb` into Claude Desktop. The curated directory listing also needs a privacy policy.
+10. Docker MCP Catalog. Needs a Dockerfile wrapping the stdio server; PR to docker/mcp-registry via `task wizard`. Optional.
+
+Later (real work):
+11. Anthropic Connectors Directory. Requires a remote HTTPS MCP server plus OAuth 2.0 (the `SF_API_KEY` paste model does not qualify), plus `readOnlyHint` on every tool and a privacy policy and terms. Not viable until a remote and OAuth deployment exists. It is the highest-value audience, so worth planning toward.
+
+## Open items and caveats
+
+- `assets/icon.png` is a transparent BLACK mark, so it reads on light cards (npm, Glama, mcp.so) but is faint on dark UIs like the Cline panel. When finalizing branding, consider a branded tile or a theme-aware icon. The transparent `logo-light.png` and `logo-dark.png` already cover the README via the `<picture>` swap.
+- Privacy policy and terms pages are still needed (Cline directory and Anthropic).
+- Reconcile the "22 vs 24" tool count across the README, the barrel comment, and the CHANGELOG.

--- a/docs/handoff/2026-06-06-mcp-impact-surfacing-handoff.md
+++ b/docs/handoff/2026-06-06-mcp-impact-surfacing-handoff.md
@@ -1,0 +1,58 @@
+# Handoff: surface `impact_pct` / `impact_tier` in the MCP (scoring-consolidation slice 1)
+
+**Date:** 2026-06-06 · **Status:** PART A DONE + DEPLOYED (prod Heroku v427, merged master via PR #30); PART B (MCP client) NEXT · **Owner:** next session
+
+> **Update 2026-06-06:** Part A shipped. `api/routers/public.py` now returns `impact_pct`+`impact_tier` on every lean paper (all 14 serializer-fed SELECTs, not just search), accepts `impact_min` (0-100), and `sort='trending'`→`impact_pct DESC NULLS LAST`. Live-verified. Caveats: (a) `sort='trending'` on BROAD keyword queries times out (pre-existing — composite did too; now fixable with an index on `impact_pct` since it's a column — deferred follow-up); (b) `impact_pct`/`impact_tier` are NULL on papers outside the recent scoring window (older/canonical papers) — for those, `citation_count` is the signal. Bugs found+fixed during deploy: keyword `impact_min` indentation-nesting, test callers + test-DB schema. See memory `scholar-feed-scoring-consolidation.md`.
+
+## Why this exists
+Consolidating Scholar Feed's **three** overlapping paper scores into one coherent system:
+- `llm_novelty_score` — LLM judge from title+abstract ONLY, venue-independent → genuinely orthogonal "is this a *new idea*". Saturated by construction (37% of papers = exactly 0.55). **Keep as a secondary dimension/filter, not a headline.**
+- `rank_score` — legacy hand-weighted blend (recency/h-index/citations/has_code/institution). **Retire** (impact_pct subsumes it via ML). Currently on the paper-detail RankScoreBadge + default search sort.
+- `impact_pct` — ML forecaster (12-mo citations), true per-category percentile; already eats novelty+author-pedigree+has_code. **This is the single headline signal.** `impact_tier` = derived A+/A/B/C/D.
+
+**Decision:** impact_pct (+ tier) = the one headline everywhere; novelty = orthogonal filter; retire rank_score. Venue reality-check: no paper-level venue signal exists and can't for fresh papers (arXiv venue lags acceptance) — don't chase it; impact_pct is already the empirical one.
+
+See memory `scholar-feed-scoring-consolidation.md`.
+
+## What already shipped (2026-06-06, don't redo)
+- **v422** — fixed `impact_pct` coverage: the nightly percentile pass (`recompute_impact_scores`, `nightly_rank_refresh.py:~984`) was spilling its 55k-row `cume_dist` sort to disk under default `work_mem`, blowing the 180s timeout, failing *non-fatal* → raw `impact_score` landed but `impact_pct` was NULL on fresh papers while the step read `ok`. Fix = `SET work_mem` (env `IMPACT_PCT_WORK_MEM=256MB`) + `degraded` step status + new `impact_pct_coverage` SLO. Coverage backfilled live. **Merged to master via PR #26.**
+- **v423/v424** — restored PR #25 (streaming scraper OOM fix + INCR-01 `internal_citations`) which an earlier mcp-oauth deploy had silently clobbered.
+- Coverage is healthy (`/health/freshness` → `impact_pct_coverage: ok 100`).
+
+## The work (THREE parts, in order)
+
+### Part A — Backend: expose impact in the public API (PREREQUISITE; do first)
+The public search/get API does **not** return `impact_pct`/`impact_tier` today — only `home.py` (Rising rail) and watches do. File: `backend/api/routers/public.py`.
+1. **Pydantic model** (`~line 187`, next to `llm_novelty_score: Optional[float]`): add `impact_pct: Optional[int]` and `impact_tier: Optional[str]`.
+2. **`LEAN_FIELDS`** (`~line 264`): add `"impact_pct"`, `"impact_tier"` so they're in the default lean shape.
+3. **Row serializer** (`~line 328`, where `"llm_novelty_score": row.get(...)`): add `impact_pct` and a derived `impact_tier`.
+   - `impact_tier` is **derived from the raw `impact_score`**, not stored. Reuse `tier_for(score, spec)` in `backend/scripts/impact_scoring.py:~63` with `tier_cutoffs`/`tier_labels` from `backend/data/impact_forecaster_spec.json:~230`. So the SQL must also SELECT `p.impact_score`. (Consistent with `nightly_rank_refresh.py:1119` `tier_for(float(sc), spec)`.) Load the spec once at module import.
+4. **SQL SELECTs**: every path selects `p.llm_novelty_score` — add `p.impact_pct, p.impact_score` alongside at `~690, 790, 816, 923, 1061, 1089`.
+5. **`impact_min` filter**: mirror `novelty_min` (param `~line 565`; filter applied `~894/999` as `p.llm_novelty_score >= $N`). Add `impact_min: Optional[int] = Query(None, ge=0, le=100)` → `p.impact_pct >= $N`. NOTE `impact_pct` is NULL on unscored papers so `>=` naturally excludes them (good).
+6. **`sort='trending'`**: currently a composite (`~line 1032`: `0.5*paper_quality + 0.3*novelty + 0.2*citation_velocity`). Change it (or add `sort='rising'`) to `ORDER BY p.impact_pct DESC NULLS LAST`. Decide: repurpose 'trending' vs add 'rising'. The default sort is still `rank_score DESC` (`~line 1021`) — leave that for now; flipping the default headline to impact is a later slice (it touches web hero/detail too).
+7. Tests: `backend/tests/` (note `test #24` referenced a "watch-preview impact_pct" test — check `test_public.py`/`test_watches.py` for shape assertions to update). Run `pytest -q --cov=api --cov-fail-under=50` + `ruff check --select E9,F63,F7,F82 .` (the backend-ci gate).
+8. **Deploy backend** via the SAFE pattern (see memory `scholar-feed-backend-deploy.md` — the local `heroku-deploy` branch is STALE): `git fetch heroku main`; `git worktree add --detach /tmp/sf-deploy $(git rev-parse FETCH_HEAD)`; apply your change at root paths (a `git diff` of your dev commit applies with `git apply -p2`); py_compile + ruff; commit; `git -C /tmp/sf-deploy push heroku HEAD:main`; verify `/health`; `git worktree remove`. Also land it on master via PR (don't deploy from a stale branch — that's what clobbered PR #25).
+
+### Part B — MCP client: pass through + document
+Repo: `scholar-feed-mcp`. The MCP forwards params to the backend and returns its JSON, so once Part A lands, impact fields flow automatically — but:
+1. `src/tools/search.ts`: add an `impact_min` zod param (mirror `novelty_min` at `~line 54`, pass-through at `~line 190`). Update the tool description (`~line 23`, `~143`) to list `impact_pct`/`impact_tier` in the lean shape and document `sort='trending'/'rising'`→impact.
+2. `src/tools/get_paper.ts`: update the lean-shape description (`~line 27`) to include `impact_pct`/`impact_tier`.
+3. Confirm no client-side field allow-listing strips the new fields (check how `fields`/lean is enforced — likely server-side, so fine).
+4. Tests + `npm run build`.
+5. **Publish**: npm is tag-triggered OIDC CI (no local login) — bump version, tag, push (see memory `distribution-discovery-prep.md` / `scholar-feed-build-state-and-signals.md`). The hosted MCP (Vercel, `mcp.scholarfeed.org/mcp`, entrypoint `src/server.ts`) auto-deploys from main.
+
+### Part C — (later, separate slices, not this one)
+- Web: hero `NoveltyBadge` → impact tier; paper-detail retire `RankScoreBadge`; personalized feed → impact tier.
+- Email already leads with Rising (`unified_email.html`).
+- Retire `rank_score` once nothing reads it.
+- Optional: recalibrate novelty (feed `llm_novelty_percentile` into the forecaster to de-saturate the 0.55 pile).
+
+## Open decisions for the next session
+1. `sort`: repurpose `'trending'` → impact, or add `'rising'` and leave 'trending' as the composite? (Recommend: make `'trending'` = impact_pct for one clear knob; the old composite is half-novelty anyway.)
+2. Expose raw `impact_score` in the API or only `impact_pct`+`impact_tier`? (Recommend: only pct+tier; keep score internal.)
+3. Flip the **default** search sort from `rank_score` → `impact_pct` now, or defer with the web work? (Recommend defer — keep blast radius small; this slice just *adds* impact, doesn't remove rank_score yet.)
+
+## Verification when done
+- `curl '.../public/papers/search?q=...'` returns `impact_pct`+`impact_tier` in lean results; `&impact_min=80` filters; `&sort=trending` orders by impact.
+- MCP `search_papers` (via the connected server) returns the fields; `impact_min` works.
+- `/health/freshness` still green for `impact_pct_coverage`.

--- a/docs/handoff/README.md
+++ b/docs/handoff/README.md
@@ -1,0 +1,33 @@
+# Discovery prep handoff
+
+Staging drafts for three discovery workstreams, produced 2026-06-03. These are NOT
+committed plugin/site files; they are reviewable drafts. Move each into place when
+you act on it. Nothing here touches `main`, tags, or publishing.
+
+All files were checked for the house rules: zero em or en dashes, no invented tool
+names or numbers, product facts verified against the repo (25 tools, 600,000+
+papers, anonymous 100/day, free key 1,000/day, Pro 10,000/day).
+
+## 1. Claude Code plugin + skills (`plugin-prep/`)
+
+- `plugin.json`, `marketplace.json` = the proposed `.claude-plugin/` manifests; the plugin ships the MCP server (inline `mcpServers`, `npx -y scholar-feed-mcp`).
+- `README.md` = the plugin's install/usage page.
+- `NOTES.md` = exact activation steps (`claude plugin validate`, `claude --plugin-dir .`, `/plugin marketplace add YGao2005/scholar-feed-mcp`, `/plugin install scholar-feed@scholar-feed`), plus the GAP list.
+
+**Decision you owe this workstream:** the repo has no `skills/` directory. The MCP-only plugin is valid and shippable as-is, but the `/field-guide`, `/compare-methods`, and `scholar-feed` skills referenced on scholarfeed.org/skills are not in version control here. To bundle them, supply each `SKILL.md` under `skills/<name>/` at the plugin root (see `NOTES.md` GAP list). Ship MCP-only now, add skills in a later version bump.
+
+## 2. SEO + AEO (`seo-aeo/`)
+
+- `developers-page.draft.md` = a scholarfeed.org/developers landing page targeting the five target queries, with install, a tool overview, and an FAQ.
+- `llms.txt.draft` = a proposed `/llms.txt` for scholarfeed.org (llmstxt.org format) pointing agents at the MCP server and docs.
+- `seo-aeo-checklist.md` = on-page actions plus paste-ready JSON-LD (SoftwareApplication, FAQPage, Organization), llms.txt placement, and answer-engine citation steps.
+
+**Next:** publish the `/developers` page and `/llms.txt` on scholarfeed.org; paste the JSON-LD into the relevant pages.
+
+## 3. Socials (`socials/`)
+
+- `social-preview-spec.md` = the 1280x640 GitHub social-preview spec (layout, copy, which `assets/` files to use, and the Settings path to upload it).
+- `demo-cast-script.md` = a 15 to 30 second asciinema/VHS storyboard (exact commands plus captions).
+- `launch-posts.md` = ready-to-post drafts: an X thread, an r/LocalLLaMA post, a Show HN title plus first comment, and a Discord showcase blurb.
+
+**Next:** upload the social preview in GitHub Settings, record the cast, and hold the posts for your launch moment.

--- a/docs/handoff/distribution-packets.md
+++ b/docs/handoff/distribution-packets.md
@@ -1,0 +1,232 @@
+# Distribution submission packets (paste-ready)
+
+Local working draft, generated 2026-06-03. Turns the DISTRIBUTION-HANDOFF playbook
+into copy-paste submissions. Every fact is verified against the repo: 25 tools,
+600,000+ CS/AI/ML papers, anonymous 100/day, free key 1,000/day, Pro 10,000/day,
+install `npx scholar-feed-mcp init`. Zero em or en dashes. Not committed (drafts
+stay local per the current plan).
+
+Order: do the GATE first, then ship-today 1 to 7, then this-week 8 to 10, then 11.
+
+----------------------------------------------------------------------
+
+## GATE (do this first): publish npm 3.7.1
+
+Verified state: npm has 3.7.0 published and it does NOT carry `mcpName`. The local
+package.json is 3.7.1 with `mcpName: io.github.YGao2005/scholar-feed-mcp`, and
+server.json already targets 3.7.1. The Official MCP Registry (packet 1) verifies
+ownership by reading `mcpName` from the PUBLISHED npm package, so it cannot succeed
+until 3.7.1 is live on npm. PulseMCP and the VS Code `@mcp` gallery also ingest from
+the registry downstream, so this one publish unblocks several listings.
+
+```bash
+npm run build                      # refresh build/ (package.json files = ["build"])
+npm pack --dry-run 2>&1 | grep -i mcpName   # optional: confirm mcpName ships in the tarball metadata
+npm publish                        # publishes 3.7.1; needs npm login + 2FA
+```
+
+Verify after publishing:
+
+```bash
+npm view scholar-feed-mcp version    # expect 3.7.1
+npm view scholar-feed-mcp mcpName    # expect io.github.YGao2005/scholar-feed-mcp
+```
+
+----------------------------------------------------------------------
+
+## Shared metadata (reuse across every form below)
+
+- Display name: `Scholar Feed`
+- npm package / slug: `scholar-feed-mcp`
+- Registry name: `io.github.YGao2005/scholar-feed-mcp`
+- Repository: `https://github.com/YGao2005/scholar-feed-mcp`
+- Homepage: `https://www.scholarfeed.org`
+- npm URL: `https://www.npmjs.com/package/scholar-feed-mcp`
+- Category: Search (or Research, where a research label exists)
+- Transport: `stdio`
+- Auth: optional API key `SF_API_KEY` (secret, not required)
+- Contact email: `hello@scholarfeed.org`
+- Icon: `assets/icon.png` (400x400). Caveat: it is a transparent BLACK mark, so it
+  is faint on dark UIs (the Cline panel). Reads fine on light cards (npm, Glama,
+  mcp.so).
+
+One-line description (under ~160 chars, dash-free):
+
+> Search 600,000+ CS/AI/ML papers with citation-graph traversal, full-text
+> extraction, embeddings, and BibTeX export, inside Claude Code, Cursor, and other
+> MCP clients.
+
+Server config block (the repo `.mcp.json`, paste where a form asks for config):
+
+```json
+{
+  "mcpServers": {
+    "scholar-feed": {
+      "command": "npx",
+      "args": ["-y", "scholar-feed-mcp"]
+    }
+  }
+}
+```
+
+----------------------------------------------------------------------
+
+## 1. Official MCP Registry (registry.modelcontextprotocol.io)
+
+Prereq: the GATE above (npm 3.7.1 live with mcpName). server.json is ready
+(version 3.7.1, npm/stdio, SF_API_KEY optional secret).
+
+```bash
+brew install mcp-publisher
+mcp-publisher login github       # opens a browser GitHub auth for io.github.YGao2005/*
+mcp-publisher publish            # reads ./server.json
+```
+
+Verify: search for `scholar-feed` at registry.modelcontextprotocol.io, and confirm
+the version reads 3.7.1. Downstream, PulseMCP auto-ingests and the VS Code `@mcp`
+gallery picks it up; no separate submission needed for those two.
+
+## 2. Glama (glama.ai/mcp)
+
+Auto-indexes any public repo with a LICENSE (satisfied: MIT). The repo already has
+`glama.json` (`{"$schema":"https://glama.ai/mcp/schemas/server.json","maintainers":["YGao2005"]}`).
+
+- Sign in at glama.ai with GitHub.
+- Find `YGao2005/scholar-feed-mcp` (search if not yet indexed) and click Claim.
+- No form fields beyond the claim; Glama reads the repo and glama.json.
+
+## 3. mcp.so (mcp.so/submit)
+
+Form fields to paste:
+
+- Type: `MCP Server`
+- Name: `Scholar Feed`
+- URL: `https://github.com/YGao2005/scholar-feed-mcp`
+- Description: the one-line description above.
+- Server Config: the server config block above.
+
+Confirm any extra fields against the live form before submitting.
+
+## 4. mcpservers.org (mcpservers.org/submit)
+
+This is the ONLY route into wong2/awesome-mcp-servers (they reject PRs). Fields:
+
+- Name: `Scholar Feed`
+- Short description: `MCP server for searching 600,000+ CS/AI/ML papers: semantic search, citation graph, full text, embeddings, and BibTeX, inside Claude Code and Cursor.`
+- Link: `https://github.com/YGao2005/scholar-feed-mcp`
+- Category: `Search`
+- Contact email: `hello@scholarfeed.org`
+
+## 5. punkpeye/awesome-mcp-servers (GitHub PR)
+
+Fork, add ONE line under `### 🔬 Research` in alphabetical order, open a PR.
+Exact line (legend: 📇 = TypeScript, ☁️ = cloud service):
+
+```markdown
+- [YGao2005/scholar-feed-mcp](https://github.com/YGao2005/scholar-feed-mcp) 📇 ☁️ - Semantic search over 600k+ CS/AI/ML papers with citation-graph traversal, full-text extraction, embeddings, and BibTeX export. Install: `npx scholar-feed-mcp init`.
+```
+
+PR title: `Add YGao2005/scholar-feed-mcp under Research`. Re-check the legend emojis
+in the repo's current README before submitting; awesome lists tweak their legend.
+
+## 6. Cursor Directory (cursor.directory/plugins/new)
+
+- Sign in with GitHub or Google.
+- Paste the repo URL: `https://github.com/YGao2005/scholar-feed-mcp`.
+- It auto-detects via `.mcp.json`. Confirm the parsed name (`scholar-feed`) and the
+  description, then submit.
+
+## 7. Cline MCP Marketplace (GitHub issue at cline/mcp-marketplace)
+
+Open a new issue using their submission template. Body to paste:
+
+```
+GitHub Repo URL: https://github.com/YGao2005/scholar-feed-mcp
+
+Logo (400x400 PNG): assets/icon.png in the repo
+  (https://raw.githubusercontent.com/YGao2005/scholar-feed-mcp/main/assets/icon.png)
+
+Short description:
+Scholar Feed is an open-source MCP server that searches 600,000+ CS/AI/ML papers
+from arXiv, traces the citation graph, pulls full text from LaTeX, and exports
+BibTeX, without leaving your editor. Anonymous access is 100 calls/day; a free key
+raises it to 1,000/day. 25 tools.
+
+Why it is useful:
+It runs a literature review where you already work (Claude Code, Cursor, Claude
+Desktop). Each paper carries an LLM summary and a 0 to 1 novelty score, so an agent
+can filter for genuinely new work, trace what cites a key result, and draft a
+related-work section in one session.
+
+[x] I have tested that the MCP server installs and runs from the README.
+[x] The README contains clear, self-installable setup instructions.
+```
+
+Cline installs from your README, so confirm the README is self-installable before
+filing. Note: `assets/icon.png` is faint on Cline's dark panel; consider supplying a
+light-on-dark or branded-tile 400x400 PNG instead if you want it to pop.
+
+----------------------------------------------------------------------
+
+## 8. Smithery (this week, small packaging)
+
+Cheapest path that keeps stdio: build an MCPB bundle (see packet 9), then:
+
+```bash
+smithery mcp publish ./scholar-feed-mcp.mcpb -n @YGao2005/scholar-feed
+```
+
+Hosting via Smithery `runtime: typescript` would need code changes to export a
+Smithery-shaped server; skip unless you want a hosted option.
+
+## 9. Claude Desktop Extension (MCPB bundle)
+
+manifest.json is ready (manifest_version 0.3, icon wired to assets/icon.png).
+
+```bash
+npm i -g @anthropic-ai/mcpb
+mcpb validate manifest.json
+npm run build && npm install --production
+mcpb pack .                         # bundles node_modules + build/ into a .mcpb
+```
+
+Test by dragging the resulting `.mcpb` into Claude Desktop. The curated directory
+listing additionally needs a published privacy policy (see docs/legal drafts).
+
+## 10. Docker MCP Catalog (optional)
+
+A Dockerfile now exists at the repo root (wraps the stdio server). Submit a PR to
+docker/mcp-registry via their wizard:
+
+```bash
+# in a clone of docker/mcp-registry
+task wizard
+```
+
+Point it at `https://github.com/YGao2005/scholar-feed-mcp`. Optional; lower
+priority than 1 to 7.
+
+----------------------------------------------------------------------
+
+## 11. Anthropic Connectors Directory (later, real work)
+
+Not viable yet. Requires a REMOTE HTTPS MCP server plus OAuth 2.0 (the SF_API_KEY
+paste model does not qualify), `readOnlyHint` on every read tool, and published
+privacy + terms pages. Highest-value audience, so worth planning toward once a
+remote + OAuth deployment exists. No paste-ready packet until then.
+
+----------------------------------------------------------------------
+
+## Suggested order and dependencies
+
+1. GATE: npm publish 3.7.1 (unblocks 1, and downstream PulseMCP + VS Code gallery).
+2. Packet 1 (MCP Registry), then 2 (Glama), 3 (mcp.so), 4 (mcpservers.org),
+   6 (Cursor): all quick, no packaging.
+3. Packet 5 (punkpeye PR) and 7 (Cline issue): need a few minutes each.
+4. Packets 9 then 8 (MCPB bundle, then Smithery): one build, two listings.
+5. Packet 10 (Docker) when convenient.
+6. Packet 11 (Anthropic) is gated on a remote + OAuth backend, plus legal pages.
+
+Cross-cutting blockers you still own: a published privacy policy and terms page on
+scholarfeed.org (needed for Cline's curated listing and for Anthropic). Drafts are
+in docs/legal.

--- a/docs/handoff/plugin-prep/NOTES.md
+++ b/docs/handoff/plugin-prep/NOTES.md
@@ -1,0 +1,147 @@
+# Activation notes and gap list
+
+This directory holds DRAFT plugin files. They are not loaded by Claude Code yet. To activate them, you move them into the layout Claude Code expects, then commit and push. Everything below is verified against the official docs (code.claude.com/docs/en/plugins, /plugin-marketplaces, /plugins-reference) as of 2026-06.
+
+## File layout Claude Code requires
+
+For a marketplace and a plugin hosted in the SAME repo (the simplest setup here), you need two manifests:
+
+```
+scholar-feed-mcp/                         (repo root = marketplace root)
+  .claude-plugin/
+    marketplace.json                      <- the marketplace catalog
+    plugin.json                           <- the plugin manifest
+  skills/                                 <- (optional) bundled skills, see GAP list
+    <skill-name>/SKILL.md
+```
+
+Important rule from the docs: ONLY `plugin.json` goes inside `.claude-plugin/`. Component
+directories (`skills/`, `commands/`, `agents/`, `hooks/`) and `.mcp.json` must live at the
+plugin ROOT, not inside `.claude-plugin/`.
+
+Because the plugin and the marketplace share the repo root, the marketplace entry uses
+`"source": "./"` (the plugin root is the repo root). Relative-path sources resolve against the
+marketplace root and only work when users add the marketplace via git (which they will:
+`/plugin marketplace add YGao2005/scholar-feed-mcp`).
+
+## Exact steps to activate
+
+1. Create the manifest directory at the repo root:
+   `mkdir -p .claude-plugin`
+
+2. Move the two draft manifests into it:
+   - `docs/handoff/plugin-prep/plugin.json`      -> `.claude-plugin/plugin.json`
+   - `docs/handoff/plugin-prep/marketplace.json` -> `.claude-plugin/marketplace.json`
+
+   The `README.md` and this `NOTES.md` stay here as handoff docs; they are not part of the
+   loaded plugin. (You may instead use the repo's existing top-level README.md as the plugin's
+   shareable README; the docs only require "a README.md" for distribution, not a specific one.)
+
+3. Decide on the MCP declaration. Two equivalent options; pick ONE:
+   - Inline (what the draft `plugin.json` does): the `mcpServers` object is embedded in the
+     manifest. Nothing else to add.
+   - External file: drop the `mcpServers` block from `plugin.json` and instead add a `.mcp.json`
+     at the repo root containing the SAME standard MCP config. The repo already has a `.mcp.json`
+     (`{ "mcpServers": { "scholar-feed": { "command": "npx", "args": ["-y","scholar-feed-mcp"] } } }`),
+     which the plugin loader reads automatically from the plugin root. If you keep that file AND
+     leave `mcpServers` inline in the manifest, both are merged. To avoid confusion, keep exactly
+     one source of truth. Recommended: inline in `plugin.json`, and confirm the existing root
+     `.mcp.json` does not double-register the server.
+
+4. Validate before pushing:
+   `claude plugin validate .`            (checks marketplace.json + referenced plugin.json)
+   `claude plugin validate ./`           (against the plugin dir, checks plugin.json + any skills)
+   Optionally `claude plugin validate . --strict` to treat warnings as errors in CI.
+
+5. Test locally without publishing:
+   `claude --plugin-dir .`               (loads the plugin from the working tree for one session)
+   Then confirm the 25 tools appear and a `search_papers` call works.
+
+6. Commit and push to `main` (or a release branch). Users can then run:
+   `/plugin marketplace add YGao2005/scholar-feed-mcp`
+   `/plugin install scholar-feed@scholar-feed`
+   followed by `/reload-plugins`.
+
+## Versioning behavior to know
+
+- `version` in `plugin.json` PINS the plugin. Existing users only get an update when you bump it.
+  The draft sets `"version": "3.7.1"` to track the npm package version. Bump it on every release,
+  or remove it to let the git commit SHA drive updates (every commit = new version).
+- The `version` also appears in the marketplace entry as `3.7.1`. The docs warn: do NOT rely on
+  both at once, because the `plugin.json` value always wins silently. Keep them in sync, or set
+  `version` in only one place. Simplest: keep it in `plugin.json` only and drop it from the
+  marketplace entry.
+- The plugin `version` does NOT control which server version runs. `npx -y scholar-feed-mcp`
+  resolves the latest published npm version at launch. The two are independent.
+
+## Schema fields: confident vs. uncertain
+
+Confident (verified in the official schema tables):
+- plugin.json: `name` (only required field), `displayName`, `version`, `description`, `author`
+  (object with `name`/`email`/`url`), `homepage`, `repository` (string URL), `license`,
+  `keywords` (array), `mcpServers` (string path | array | inline object).
+- marketplace.json: `name` (required), `owner` (object, `name` required, `email` optional),
+  `plugins` (array). Each plugin entry: `name` + `source` required; may also carry any
+  plugin-manifest field plus `category`, `tags`, `strict`, `displayName`, `defaultEnabled`.
+- `source: "./"` (relative path) is valid and resolves to the marketplace root.
+- MCP config uses standard keys: `command`, `args`, `env`, `cwd`. `${CLAUDE_PLUGIN_ROOT}` is only
+  needed when referencing files bundled inside the plugin. Our server runs from npm via npx, so
+  no path variable is required.
+
+Uncertain / left out on purpose:
+- Whether the marketplace `name` "scholar-feed" collides with anything. It is NOT on the reserved
+  list (claude-plugins-official, anthropic-*, etc.), so it should be fine, but each user can
+  register only one marketplace per name, so the name is effectively a public identifier. If you
+  later want a clearer split, rename the marketplace (e.g. "scholar-feed-tools") and keep the
+  plugin name "scholar-feed".
+- `category` value: the docs describe `category` as free-form ("for organization") with no
+  enumerated list, so "research" is a guess at a sensible label, not a validated enum.
+- Community-marketplace submission (the `anthropics/claude-plugins-community` catalog) is a
+  separate, reviewed process via claude.ai/settings/plugins/submit. Not required for self-hosting;
+  noted only if you later want public discovery.
+
+## GAP LIST: skills are referenced but not present in this repo
+
+This repo currently has NO `skills/` directory and NO `commands/` directory. The plugin as drafted
+ships the MCP server ONLY. That is a complete, working plugin on its own. But the product already
+references skills that are NOT in this repo, and a plugin is the natural place to bundle them. To
+ship any of them, the OWNER must supply the source files. Specifics:
+
+1. `/field-guide`
+   - Referenced in README.md (the v1 `field_guide` tool was "demoted to a skill") and in
+     src/tools/index.ts ("Demoted to skills: compare_methods, field_guide").
+   - Source files: NOT in this repo. The README points to https://www.scholarfeed.org/skills as
+     the canonical location.
+   - To bundle: create `skills/field-guide/SKILL.md` at the plugin root, with YAML frontmatter
+     (`description:` so Claude knows when to invoke it) and the skill body. Supporting files
+     (reference.md, scripts/) may sit alongside it in `skills/field-guide/`.
+   - Installed name will be namespaced: `/scholar-feed:field-guide`.
+
+2. `/compare-methods`
+   - Referenced in README.md migration table ("compare_methods -> use the /compare-methods skill,
+     see scholarfeed.org/skills") and in src/tools/index.ts.
+   - Source files: NOT in this repo. Same canonical location (scholarfeed.org/skills).
+   - To bundle: `skills/compare-methods/SKILL.md` at the plugin root, same shape as above.
+   - Installed name: `/scholar-feed:compare-methods`.
+
+3. The "scholar-feed" skill at scholarfeed.org/skills
+   - The product hosts a Scholar Feed skill (the same description that exists in the user's local
+     skill set: "Search, explore, and read CS/AI/ML research papers via the Scholar Feed MCP
+     server"). It is NOT in this repo.
+   - To bundle: `skills/scholar-feed/SKILL.md` at the plugin root. Note: namespacing would make it
+     `/scholar-feed:scholar-feed`, which is awkward. Consider a clearer folder name such as
+     `skills/literature-review/SKILL.md` -> `/scholar-feed:literature-review`, or `skills/research/`.
+
+What the owner must do for skills, concretely:
+- Obtain the canonical SKILL.md source for each skill from scholarfeed.org/skills (or wherever the
+  authoritative copy lives; it is not in version control here).
+- Place each under `skills/<name>/SKILL.md` at the plugin ROOT (NOT inside `.claude-plugin/`, and
+  NOT inside docs/).
+- Ensure each SKILL.md has a `description:` frontmatter field; that string is what triggers
+  model invocation.
+- Re-run `claude plugin validate ./` to confirm the frontmatter parses, then `/reload-plugins`.
+- No change to plugin.json is needed to pick up `skills/` at the default location. Only add a
+  `skills` path field to the manifest if you store them somewhere non-default.
+
+Until those source files are supplied, ship the MCP-only plugin (the draft as-is). It is valid and
+useful on its own; skills can be added in a later version bump.

--- a/docs/handoff/plugin-prep/README.md
+++ b/docs/handoff/plugin-prep/README.md
@@ -1,0 +1,56 @@
+# Scholar Feed plugin for Claude Code
+
+This is the proposed Claude Code plugin packaging for the Scholar Feed MCP server. It ships the same stdio server that `npx scholar-feed-mcp init` installs, but distributes it through the Claude Code plugin and marketplace system so users install with two slash commands instead of editing a config file.
+
+These files are a handoff draft. They are NOT yet wired into the repo. See NOTES.md for the exact steps to activate them and for the gap list (this repo has no skills yet).
+
+## What the plugin is
+
+A single plugin named `scholar-feed` that bundles the Scholar Feed MCP server. Once enabled, Claude Code starts the server automatically and the 25 Scholar Feed tools appear in Claude's toolkit:
+
+- Core search and discovery: `search_papers`, `get_paper`, `get_citations`, `fetch_fulltext`
+- Authors: `find_author`, `co_author_graph`
+- Embeddings: `embed_text`
+- Research: `get_field_orientation`, `get_foundational_lineage`
+- Library: `save_paper`, `unsave_paper`, `like_paper`, `list_library`
+- Collections: `list_collections`, `create_collection`, `add_to_collection`, `remove_from_collection`
+- Watches: `create_watch`, `list_watches`, `check_watches`, `update_watch`, `preview_watch`, `delete_watch`
+- Gap analysis and synthesis: `find_gaps`, `ask_library`
+
+The server is the same one published to npm as `scholar-feed-mcp`. The plugin runs it via `npx -y scholar-feed-mcp`, so an install always pulls the published version.
+
+## Auth and limits
+
+No API key is required. Anonymous access gives 100 calls/day, enough for a typical research session. A free key raises that to 1,000/day per account; Pro is 10,000/day. A few tools (`embed_text`, `find_gaps`) are Pro-only, and `ask_library` is 1/month free then 200/day on Pro.
+
+To use a key with the plugin, set `SF_API_KEY` in your environment before starting Claude Code. The bundled MCP config calls `npx`, which inherits the environment, so an exported `SF_API_KEY` is picked up by the server. Get a free key at https://www.scholarfeed.org/settings.
+
+## How users install it
+
+The marketplace lives in the same repo as the plugin (`YGao2005/scholar-feed-mcp`). Once the activation steps in NOTES.md are done and pushed:
+
+```
+/plugin marketplace add YGao2005/scholar-feed-mcp
+/plugin install scholar-feed@scholar-feed
+```
+
+`scholar-feed@scholar-feed` reads as `<plugin-name>@<marketplace-name>`. Both are named `scholar-feed` here.
+
+CLI equivalents (for scripting):
+
+```
+claude plugin marketplace add YGao2005/scholar-feed-mcp
+claude plugin install scholar-feed@scholar-feed
+```
+
+After install, run `/reload-plugins` (or restart Claude Code) so the MCP server starts. Then try:
+
+> Search for recent papers on test-time compute scaling
+
+## Plugin vs. the npx init path
+
+The existing `npx scholar-feed-mcp init` wizard still works and remains the recommended path for Cursor, Claude Desktop, and other MCP clients. The plugin is a Claude-Code-specific convenience: it adds marketplace discovery, versioning, and one-command install for Claude Code users, and it is where any bundled Scholar Feed skills would ship.
+
+## Relationship to the published npm package
+
+The plugin does not vendor the server code. It declares an MCP server that runs `npx -y scholar-feed-mcp`, so the npm package stays the single source of truth. Bumping the plugin `version` field controls when Claude Code offers an update to plugin users; it does not change which server version runs (npx resolves that at launch).

--- a/docs/handoff/plugin-prep/marketplace.json
+++ b/docs/handoff/plugin-prep/marketplace.json
@@ -1,0 +1,31 @@
+{
+  "name": "scholar-feed",
+  "owner": {
+    "name": "Scholar Feed",
+    "email": "hello@scholarfeed.org"
+  },
+  "description": "Scholar Feed: research-paper search and literature-review tools for Claude Code.",
+  "plugins": [
+    {
+      "name": "scholar-feed",
+      "source": "./",
+      "description": "Search 600,000+ CS/AI/ML papers with LLM novelty analysis, citation graph, full-text extraction, and BibTeX. Ships the scholar-feed MCP server (25 tools).",
+      "version": "3.7.1",
+      "author": {
+        "name": "Scholar Feed",
+        "email": "hello@scholarfeed.org"
+      },
+      "homepage": "https://www.scholarfeed.org",
+      "repository": "https://github.com/YGao2005/scholar-feed-mcp",
+      "license": "MIT",
+      "keywords": [
+        "research",
+        "arxiv",
+        "literature-review",
+        "citations",
+        "semantic-search"
+      ],
+      "category": "research"
+    }
+  ]
+}

--- a/docs/handoff/plugin-prep/plugin.json
+++ b/docs/handoff/plugin-prep/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "scholar-feed",
+  "displayName": "Scholar Feed",
+  "version": "3.7.1",
+  "description": "Search 600,000+ CS/AI/ML papers with LLM novelty analysis, citation graph, full-text extraction, and BibTeX, without leaving Claude Code. Built for literature reviews.",
+  "author": {
+    "name": "Scholar Feed",
+    "email": "hello@scholarfeed.org",
+    "url": "https://www.scholarfeed.org"
+  },
+  "homepage": "https://www.scholarfeed.org",
+  "repository": "https://github.com/YGao2005/scholar-feed-mcp",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "research",
+    "research-papers",
+    "arxiv",
+    "citations",
+    "citation-graph",
+    "semantic-search",
+    "literature-review",
+    "embeddings",
+    "bibtex",
+    "ai",
+    "machine-learning"
+  ],
+  "mcpServers": {
+    "scholar-feed": {
+      "command": "npx",
+      "args": ["-y", "scholar-feed-mcp"]
+    }
+  }
+}

--- a/docs/handoff/seo-aeo/comparison-pages-build-handoff.md
+++ b/docs/handoff/seo-aeo/comparison-pages-build-handoff.md
@@ -1,0 +1,134 @@
+# Handoff: build the /compare comparison pages on the site
+
+Paste the block below into a fresh Claude Code session **opened in the frontend
+repo** (`/Users/yang/discord-bots-workspace/scholar-feed/frontend`). It's
+self-contained; it points at the already-written page copy rather than inlining
+it.
+
+---
+
+## PROMPT (paste this)
+
+You are working in the Scholar Feed frontend repo
+(`/Users/yang/discord-bots-workspace/scholar-feed/frontend`), a Next.js App
+Router app deployed on Vercel (auto-deploys on merge to `master`; the founder
+deploys, never you). Your job: publish 6 hand-authored "comparison / alternative"
+marketing pages for AEO — pages that get cited by AI answer engines and rank for
+"X alternative" / "X vs Y" queries.
+
+**The page copy is already written. Do not rewrite it.** Read these two files from
+the *other* repo and use them as the source of truth:
+- Page content (all 6 pages, with title/meta tags, answer-first openers,
+  comparison tables, "when NOT to use" blocks):
+  `/Users/yang/discord-bots-workspace/scholar-feed-mcp/docs/handoff/seo-aeo/comparison-pages.md`
+- JSON-LD blocks + on-page AEO conventions (SoftwareApplication, FAQPage):
+  `/Users/yang/discord-bots-workspace/scholar-feed-mcp/docs/handoff/seo-aeo/seo-aeo-checklist.md`
+
+The 6 routes (slug → page):
+1. `/compare/arxiv-sanity-alternative`
+2. `/compare/semantic-scholar-mcp`
+3. `/compare/research-rabbit-alternative`
+4. `/compare/connected-papers-alternative`
+5. `/compare/scholar-inbox-alternative`
+6. `/compare/paper-digest-vs-scholar-feed`
+
+### Before touching anything
+- `git fetch origin`, then create a branch off `origin/master` (e.g.
+  `feat/compare-pages`). **Do not build on the current checkout's branch** — per
+  project history the main checkout has sometimes sat on a stale/diverged branch
+  with unrelated WIP. Check `git status` / `git branch`; if diverged, use a
+  worktree off `origin/master`.
+- All work on the branch. The founder reviews and deploys. Do not deploy.
+
+### Build
+1. **Content module:** port the 6 pages from `comparison-pages.md` into a typed
+   data module (e.g. `app/compare/_content.ts`) — slug, title tag, meta
+   description, h1, the answer-first opener, the comparison table rows, the body
+   sections, the "when NOT to use" list, FAQ Q&A pairs.
+2. **Route:** `app/compare/[slug]/page.tsx` as a **server component**.
+   - `export async function generateStaticParams()` returning all 6 slugs.
+     **This is required** — a `[slug]` route renders fully dynamic
+     (`private, no-store`, no edge cache) unless `generateStaticParams` is
+     present; with it the route flips to `● (SSG)` in the `next build` table.
+     Confirm it shows SSG, not `ƒ (Dynamic)`.
+   - `export async function generateMetadata({ params })` per slug: title tag,
+     meta description, **self-canonical** (`alternates.canonical`), Open Graph.
+     (Mirror how `app/explore` / `app/developers` do metadata + canonical — the
+     PR #18 server-page pattern. Those pages were fixed precisely because a
+     client page inherited the root canonical → don't repeat that.)
+   - Render: real `<h1>`, the opener, the comparison table, the body, the CTA.
+     These pages are **fully static — no backend/API fetches.** Keep them that
+     way; do not call the FastAPI backend from them (avoids the egress-throttle
+     class of bug entirely).
+   - JSON-LD via `<script type="application/ld+json">`: `SoftwareApplication`
+     (from the checklist), `FAQPage` (built from each page's Q&A — text MUST
+     match visible copy), and `BreadcrumbList` (Home → Compare → page).
+3. **Optional but nice:** an `app/compare/page.tsx` index listing all 6 (internal
+   linking hub). Link each comparison page to `/developers` and to 1–2 sibling
+   comparison pages.
+
+### Three wiring tasks (easy to miss)
+1. **middleware.ts** (repo root): `/compare` currently falls through to the
+   Supabase `auth.getUser()` cookie refresh, which marks responses
+   `private,no-store` and defeats the edge cache. Add a short-circuit for
+   `pathname.startsWith("/compare")` that returns `NextResponse.next()` with
+   `Cache-Control: public, s-maxage=3600, stale-while-revalidate=86400` —
+   mirror the existing `PUBLIC_CACHEABLE_PREFIXES` block (keep it AFTER the
+   `BLOCKED_PATTERN` bot block so scrapers still 403).
+2. **app/sitemap.xml/route.ts**: the Storage-backed sitemap worker only
+   enumerates papers/authors. Add the 6 `/compare` URLs (and the optional
+   `/compare` index) to the **static fallback / static-pages** section so they
+   appear in the sitemap. Verify after build.
+3. **IndexNow (post-deploy, note for the founder):** once the pages are live
+   (200), submit the 6 URLs once so Bing → ChatGPT Search / Perplexity pick them
+   up fast. Key is `50473d11c4d99e9569d0fe676fde83f2` (already hosted at
+   `/<key>.txt`). One-off:
+   ```
+   curl -X POST https://api.indexnow.org/indexnow -H "Content-Type: application/json" -d '{
+     "host":"www.scholarfeed.org",
+     "key":"50473d11c4d99e9569d0fe676fde83f2",
+     "keyLocation":"https://www.scholarfeed.org/50473d11c4d99e9569d0fe676fde83f2.txt",
+     "urlList":[
+       "https://www.scholarfeed.org/compare/arxiv-sanity-alternative",
+       "https://www.scholarfeed.org/compare/semantic-scholar-mcp",
+       "https://www.scholarfeed.org/compare/research-rabbit-alternative",
+       "https://www.scholarfeed.org/compare/connected-papers-alternative",
+       "https://www.scholarfeed.org/compare/scholar-inbox-alternative",
+       "https://www.scholarfeed.org/compare/paper-digest-vs-scholar-feed"
+     ]
+   }'
+   ```
+   (The repo's `scripts/ping_indexnow.py` is papers-only; this is a manual one-off.)
+
+### Accuracy gate (do before committing)
+Re-verify every product claim in the copy against the live README at
+`/Users/yang/discord-bots-workspace/scholar-feed-mcp/README.md`: corpus is
+**600,000+** CS/AI/ML, install is `npx scholar-feed-mcp init`, quotas are
+**100 / 1,000 / 10,000** (anon / free key / Pro), and the named capabilities
+(watches, novelty score, citation tracing, full-text extraction, BibTeX) are
+real. The drafts were written against the README but confirm nothing drifted.
+
+### Verify
+- `npm run build` passes (tsc + lint + build). The `/compare/[slug]` route shows
+  `● (SSG)` with 6 prerendered paths. **Known false-fail:** local prerender of
+  `/` may error on missing backend/Supabase env — that's repo-wide and fine; the
+  TS + page-data compile is what matters.
+- Validate the JSON-LD in validator.schema.org and Google's Rich Results Test
+  (expect zero errors; FAQ text matches visible text).
+- After the founder deploys: `curl` a page and confirm `cache-control: public,
+  s-maxage=3600` + `x-vercel-cache: HIT` on the second hit, the `<h1>` and
+  JSON-LD present in raw HTML, and a 200 to a ClaudeBot/GPTBot UA.
+
+### Suggested order
+Build `arxiv-sanity-alternative` end-to-end first (route + metadata + JSON-LD +
+the middleware + sitemap changes), run `next build`, confirm it's SSG and
+cacheable — that's the template. Then fill the other 5 from the content file.
+Commit on the branch, open a PR, summarize what to verify, and hand it to the
+founder. The IndexNow ping happens after deploy.
+
+---
+
+*Source drafts and rationale: `comparison-pages.md` (copy),
+`directory-submissions.md` (related AEO worklist), `seo-aeo-checklist.md`
+(JSON-LD + conventions), all in
+`scholar-feed-mcp/docs/handoff/seo-aeo/`.*

--- a/docs/handoff/seo-aeo/comparison-pages.md
+++ b/docs/handoff/seo-aeo/comparison-pages.md
@@ -1,0 +1,456 @@
+# AEO comparison pages (the PapersFlow play)
+
+`seo-aeo-checklist.md` §1 suggests an on-page "vs Semantic Scholar" *section*.
+This is the bigger move: **standalone comparison/alternative URLs**, one per
+competitor query, the way papersflow.ai manufactured
+`/blog/connected-papers-vs-research-rabbit` and got itself into every "best
+research tools 2026" listicle. These pages are the exact shape answer engines
+quote for "what's a good X alternative" and "X vs Y" queries.
+
+Honesty is the strategy, not a constraint. Each page has a "When NOT to use
+Scholar Feed" block. Balanced comparison content ranks better, converts better,
+and — critically — gets *quoted* by Claude/Perplexity because it reads as
+trustworthy rather than as a sales page. Never claim a capability the tool lacks
+(no graph visualization, CS/ML-only coverage, hosted not local).
+
+## Pages to ship (priority order)
+
+| URL | Target query | Honest fit | Notes |
+|---|---|---|---|
+| `/compare/arxiv-sanity-alternative` | "arxiv sanity alternative", "modern arxiv sanity" | ★★★ Strong | arxiv-sanity is semi-abandoned; clean vacuum. **Draft below.** |
+| `/compare/semantic-scholar-mcp` | "semantic scholar alternative mcp", "semantic scholar in claude" | ★★★ Strong | Checklist's named keyword. You're an MCP; they're a REST API. |
+| `/compare/research-rabbit-alternative` | "research rabbit alternative" | ★★ Partial | RR is discovery+graph; you overlap on discovery, not viz. Be explicit. |
+| `/compare/connected-papers-alternative` | "connected papers alternative" | ★ Weak | CP is graph viz; you're not. Position as complement, not replacement. High volume, so worth an honest page. |
+| `/compare/scholar-inbox-alternative` | "scholar inbox alternative" | ★★ Partial | Both do "keep up". You're agentic/in-editor; they're a web digest. |
+| `/compare/paper-digest-vs-scholar-feed` | "paper digest alternative" | ★★ Partial | They summarize/digest; you're queryable in-agent. |
+
+Build the top two first. Each page: ~600–900 words, one H1, question-style H2s,
+a comparison table, a 30–60 word answer-first opener (that's the quotable bit),
+and the JSON-LD `SoftwareApplication` block from the checklist. Cross-link them
+to `/developers`.
+
+## Reusable positioning matrix (feed every page from this)
+
+| Axis | Scholar Feed | Where it loses |
+|---|---|---|
+| Surface | Runs **inside** Claude Code / Cursor (MCP) — no separate tab | Web tools (CP, RR, Scholar Inbox) are nicer if you *don't* live in an editor |
+| Core verb | Query + watch + trace, agentically | Connected Papers/Litmaps are better at *visual* neighborhood maps |
+| Keep-up | Daily structured "watches" on a lab/technique | Scholar Inbox / paperparrot have polished email digests |
+| Coverage | 600k+ CS/AI/ML (arXiv, daily) | Semantic Scholar (200M+, all fields) wins on breadth/non-CS |
+| Per-paper signal | LLM summary + 0–1 novelty score | — |
+| Hosting | Hosted API + thin MCP client | arxiv-sanity can be self-hosted; SF cannot |
+| Price | Free anon (100/day), free key (1k/day), Pro | Most web tools have free tiers too |
+
+---
+
+## DRAFT — `/compare/arxiv-sanity-alternative`
+
+**Title tag:** A modern arxiv-sanity alternative that runs inside Claude & Cursor
+**Meta:** Scholar Feed is an arxiv-sanity-style similarity feed for new CS/AI/ML papers, as an MCP server inside your AI assistant — with citation tracing, novelty scores, and daily watches. Free to try.
+
+# A modern arxiv-sanity alternative for keeping up with CS/AI/ML papers
+
+**Short answer (quotable):** Scholar Feed is the closest modern alternative to
+arxiv-sanity for staying current with CS/AI/ML research. Like arxiv-sanity it
+ranks new arXiv papers by relevance to your interests instead of raw recency,
+but it runs as an MCP server inside Claude Code or Cursor, adds an LLM summary
+and a 0–1 novelty score per paper, and lets you set daily "watches" on a lab or
+technique. Install with `npx scholar-feed-mcp init`; the search tools work
+anonymously, no account.
+
+## Why people look for an arxiv-sanity alternative
+
+arxiv-sanity (Andrej Karpathy's paper-recommendation tool) pioneered the idea
+that you shouldn't read arXiv by date — you should read it ranked by similarity
+to what you care about. The hosted version is no longer actively maintained, and
+self-hosting it means running your own indexer and SVM recommender. Most people
+just want the core experience — "show me new papers like the ones I like" —
+without the upkeep.
+
+## How Scholar Feed compares
+
+| | arxiv-sanity | Scholar Feed |
+|---|---|---|
+| Ranking | Similarity to your saved/liked papers | Semantic search + a multi-signal rank (recency, citation velocity, code, institution) |
+| Where it runs | A website (or self-hosted) | Inside Claude Code / Cursor / any MCP client |
+| Per-paper signal | tf-idf similarity | LLM summary + 0–1 novelty score |
+| Keep-up mechanism | Recommendations feed | Daily **watches** on a saved filter (lab, technique, author, citation scope) |
+| Citation tracing | No | Yes, both directions |
+| Full text | Abstracts | Extracts results/experiments from LaTeX source |
+| Maintenance | Self-host or use the static site | Hosted; `npx` install, nothing to run |
+| Coverage | arXiv (broad) | 600,000+ CS/AI/ML papers, indexed daily |
+
+## What you actually do with it
+
+Ask your assistant "find recent high-novelty work on test-time compute scaling"
+and get ranked papers with summaries, in the same window you're writing in. Then
+"trace what cites 2401.04088" or "set a watch on new sparse-attention papers from
+DeepMind" and it keeps surfacing matches daily. The arxiv-sanity instinct —
+relevance over recency — but queryable in natural language and wired into the
+tool you already work in.
+
+## When NOT to use Scholar Feed
+
+- You want a **fully local / self-hosted** setup with no external API. arxiv-sanity
+  (self-hosted) or a local RSS+embedding pipeline fits better; Scholar Feed's
+  corpus and ranking live behind a hosted API.
+- You work **outside CS/AI/ML**. Coverage is 600k+ CS/AI/ML papers, not all of
+  arXiv and not other fields. Semantic Scholar (200M+ papers, all fields) is the
+  better breadth play.
+- You want a **visual citation map** to explore a neighborhood. That's Connected
+  Papers or Litmaps; Scholar Feed traces citations as data, not as a graph you
+  pan around.
+
+## Try it
+
+```bash
+npx scholar-feed-mcp init
+```
+
+Free anonymous access is 100 calls/day (no account); a free key raises it to
+1,000/day. Open source (MIT): github.com/YGao2005/scholar-feed-mcp
+
+---
+
+## DRAFT — `/compare/semantic-scholar-mcp`
+
+**Title tag:** A Semantic Scholar alternative for MCP (Claude & Cursor)
+**Meta:** Scholar Feed is a Semantic Scholar alternative that runs as an MCP server inside Claude Code and Cursor: 600k CS/AI/ML papers with novelty scores, citations, and daily watches. Free anonymous tier.
+
+# Scholar Feed: a Semantic Scholar alternative your AI assistant can call directly
+
+**Short answer (quotable):** Scholar Feed is a focused alternative to the Semantic
+Scholar API for CS/AI/ML, built as an MCP server your assistant calls with no glue
+code. Semantic Scholar is the better choice for breadth — 200M+ papers across every
+field, with a free REST API for building your own app. Scholar Feed trades that
+breadth for a curated 600,000+ CS/AI/ML corpus, an LLM novelty score on every
+paper, daily "watches" for new work, and zero-code use inside Claude Code or
+Cursor. Install with `npx scholar-feed-mcp init`.
+
+## Why people search "Semantic Scholar alternative for MCP"
+
+Semantic Scholar (from the Allen Institute for AI) is the default free citation
+graph for a lot of researchers, and its Academic Graph API is genuinely excellent.
+Two things send people looking for an MCP-shaped alternative:
+
+1. The API is something you wire up in code. If you just want your AI assistant to
+   search papers mid-conversation, you either write a wrapper or install someone
+   else's. An MCP server is that, out of the box.
+2. Coverage is broad but general. If you live in CS/AI/ML you want ranking and
+   signals tuned to that firehose (novelty, code availability, citation velocity)
+   rather than an all-fields graph.
+
+Note: thin MCP wrappers over the Semantic Scholar API do exist. Scholar Feed isn't
+one of those — it's a separate corpus and ranking, described below.
+
+## How Scholar Feed compares
+
+| | Semantic Scholar | Scholar Feed |
+|---|---|---|
+| Access shape | REST API (write code) or website | MCP server (assistant calls it directly, no code) |
+| Coverage | 200M+ papers, all fields | 600,000+ CS/AI/ML papers, indexed daily from arXiv |
+| Per-paper signal | TLDR summary | LLM summary + 0–1 **novelty score** |
+| Keep-up | Email alerts (follow authors/papers on the site) | Daily **watches** on a saved filter (lab, technique, author, citation scope) |
+| Citation graph | Authoritative, very large | Both directions, scoped to the CS/ML corpus |
+| Full text | Some, via API | Extracts results/experiments from LaTeX source |
+| Ranking | General relevance | Multi-signal (recency, citation velocity, code, institution), tuned for CS/ML |
+| Build-your-own app | Free API is purpose-built for it | Not a general data API; it's an assistant tool |
+
+## What you actually do with it
+
+You ask your assistant, in plain language, "find recent high-novelty work on
+test-time compute scaling," and get ranked CS/ML papers with summaries in the
+window you're already working in — no API calls to write. Then "set a watch on new
+retrieval-augmented-generation papers above 0.5 novelty" and it surfaces matches
+daily. The Semantic Scholar instinct (a real citation graph behind your search),
+delivered as a tool your agent uses, with a novelty filter to skip the incremental
+flood.
+
+## When NOT to use Scholar Feed
+
+- You work **outside CS/AI/ML**, or you need the **full 200M-paper graph**.
+  Semantic Scholar's breadth and authoritative citation graph win clearly; Scholar
+  Feed is a 600k CS/AI/ML corpus.
+- You're **building an application** and want a free, general-purpose data API. The
+  Semantic Scholar Academic Graph API is built for that. Scholar Feed is an
+  assistant tool (MCP), not a data backend.
+- You specifically want a **thin MCP wrapper over Semantic Scholar's own data**.
+  Those exist; Scholar Feed is a different corpus and ranking, not an S2 proxy.
+
+## Try it
+
+```bash
+npx scholar-feed-mcp init
+```
+
+Free anonymous access is 100 calls/day (no account); a free key raises it to
+1,000/day. Open source (MIT): github.com/YGao2005/scholar-feed-mcp
+
+---
+
+## DRAFT — `/compare/research-rabbit-alternative`
+
+**Title tag:** A Research Rabbit alternative that runs in Claude & Cursor
+**Meta:** Scholar Feed is a Research Rabbit alternative for CS/AI/ML that runs as an MCP server inside Claude Code and Cursor: search, novelty scores, citation tracing, and daily watches. Free anonymous tier.
+
+# Scholar Feed: a Research Rabbit alternative for people who live in their editor
+
+**Short answer (quotable):** Scholar Feed is an alternative to Research Rabbit for
+CS/AI/ML researchers who would rather query papers inside their AI assistant than
+explore a visual web app. Research Rabbit is the better pick if you want free,
+interactive citation maps to explore a topic's neighborhood. Scholar Feed trades
+the visual map for in-editor MCP access, an LLM novelty score on every paper, and
+daily "watches", over a 600,000+ CS/AI/ML corpus. Install with
+`npx scholar-feed-mcp init`.
+
+## Why people search "Research Rabbit alternative"
+
+Research Rabbit is a genuinely good, free discovery tool — you start from a seed
+paper and it maps similar work, earlier and later work, and author networks. Two
+reasons people look for something different:
+
+1. It's a separate web app you browse. If your actual work happens in Claude Code
+   or Cursor, you want discovery in that workflow, not in another tab.
+2. It's built for *exploring a neighborhood once*, visually. It's less suited to
+   "keep telling me what's new in this narrow area every day," and it doesn't put
+   a novelty signal on each paper to help you skip incremental work.
+
+## How Scholar Feed compares
+
+| | Research Rabbit | Scholar Feed |
+|---|---|---|
+| Form | Visual web app (citation maps, author graphs) | MCP server (your assistant queries it, no UI to learn) |
+| Best at | Exploring a topic's neighborhood visually | Querying + watching a narrow area from inside your editor |
+| Per-paper signal | None on the node itself | LLM summary + 0–1 **novelty score** |
+| Keep-up | Notifies on new related work in a collection | Daily **watches** on a saved filter (lab, technique, author, citation scope) |
+| Coverage | All fields (Semantic Scholar data) | 600,000+ CS/AI/ML papers, indexed daily from arXiv |
+| Full text | Links out | Extracts results/experiments from LaTeX source |
+| Price | Free | Free anonymous (100/day), free key (1,000/day) |
+
+## What you actually do with it
+
+Instead of opening a map and panning around, you ask your assistant "what's new
+and high-novelty on retrieval-augmented generation this month?" and get ranked
+CS/ML papers with summaries, in the window you're already in. Then "watch new
+sparse-attention work above 0.5 novelty" and it surfaces matches daily. It's the
+keep-an-eye-on-this-area job, done as a tool your agent calls, rather than a
+canvas you explore.
+
+## When NOT to use Scholar Feed
+
+- You want the **visual citation map** to explore how a field connects. That's
+  Research Rabbit's whole strength, it's free, and Scholar Feed doesn't render
+  graphs you pan around. Use Research Rabbit (or Connected Papers / Litmaps).
+- You work **outside CS/AI/ML**. Research Rabbit covers all fields; Scholar Feed
+  is a 600k CS/AI/ML corpus.
+- You want a **polished standalone app** with no setup. Research Rabbit is a
+  click-and-go website; Scholar Feed lives inside an MCP client you already use.
+
+## Try it
+
+```bash
+npx scholar-feed-mcp init
+```
+
+Free anonymous access is 100 calls/day (no account); a free key raises it to
+1,000/day. Open source (MIT): github.com/YGao2005/scholar-feed-mcp
+
+---
+
+## DRAFT — `/compare/connected-papers-alternative`
+
+**Title tag:** Connected Papers alternative for Claude & Cursor (honest take)
+**Meta:** Connected Papers and Scholar Feed solve different problems. Connected Papers maps a paper's neighborhood visually; Scholar Feed searches, watches, and reads CS/AI/ML papers inside your AI assistant. Often used together.
+
+# Scholar Feed vs Connected Papers: different tools, and that's the honest answer
+
+**Short answer (quotable):** If you're looking for a Connected Papers alternative,
+the honest take is that Scholar Feed solves a different problem. Connected Papers
+builds a one-shot visual graph of papers related to a seed paper — excellent for
+getting the lay of the land in a new area. Scholar Feed is an MCP server that
+searches, watches, and reads CS/AI/ML papers inside Claude Code or Cursor. If you
+specifically want the visual map, Connected Papers (or Litmaps) is the tool. If
+you want queryable, in-editor research with novelty scores and daily watches,
+that's Scholar Feed. Plenty of people use both.
+
+## Why people search "Connected Papers alternative"
+
+Connected Papers is the go-to for "show me the neighborhood of this paper" as a
+picture. People look for alternatives when:
+
+1. They want **ongoing** awareness, not a one-shot graph. Connected Papers builds
+   a map and you're done; it doesn't keep telling you what's new in that area.
+2. They want research **in their workflow** (Claude/Cursor) rather than a separate
+   browser tool, with a relevance/novelty signal to filter the incremental flood.
+
+## How Scholar Feed compares
+
+| | Connected Papers | Scholar Feed |
+|---|---|---|
+| Core job | Visual graph of a seed paper's neighborhood | Search + watch + read from inside your editor |
+| Shape | One-shot exploration (build a graph) | Ongoing querying and daily watches |
+| Per-paper signal | Graph position | LLM summary + 0–1 **novelty score** |
+| Keep-up | Not really its job | Daily **watches** on a saved filter |
+| Coverage | All fields | 600,000+ CS/AI/ML papers, indexed daily |
+| Form | Web app | MCP server (no UI to learn) |
+
+## What you actually do with it
+
+You don't get a graph from Scholar Feed. You ask your assistant "find recent
+high-novelty work related to 2401.04088 and summarize the top three," trace its
+citations both directions, pull the results section, and set a watch so new
+related work shows up daily. It's the verbs around a paper (search, trace, read,
+monitor) as agent tools, where Connected Papers gives you the map.
+
+## When NOT to use Scholar Feed
+
+- You want the **visual graph** of how papers connect. That is exactly what
+  Connected Papers (and Litmaps) do well, and Scholar Feed does not render it. This
+  is the common case — use Connected Papers, and reach for Scholar Feed for the
+  search/watch/read side.
+- You work **outside CS/AI/ML**. Connected Papers covers all fields.
+- You want a **zero-setup web tool**. Connected Papers is click-and-go; Scholar
+  Feed runs inside an MCP client.
+
+## Try it
+
+```bash
+npx scholar-feed-mcp init
+```
+
+Free anonymous access is 100 calls/day. Open source (MIT): github.com/YGao2005/scholar-feed-mcp
+
+---
+
+## DRAFT — `/compare/scholar-inbox-alternative`
+
+**Title tag:** A Scholar Inbox alternative that lives in your AI assistant
+**Meta:** Scholar Feed is a Scholar Inbox alternative for CS/AI/ML: instead of a daily email digest, you query and watch papers inside Claude Code or Cursor, with novelty scores and citation tracing. Free anonymous tier.
+
+# Scholar Feed: a Scholar Inbox alternative you can query, not just skim
+
+**Short answer (quotable):** Scholar Feed and Scholar Inbox both help you keep up
+with new arXiv CS/AI/ML work, but in opposite styles. Scholar Inbox is a polished
+personalized digest you read (web and email), learned from papers you rate.
+Scholar Feed is an MCP server you query and direct from inside Claude Code or
+Cursor: define structured watches, trace citations, pull full text, and filter by
+an LLM novelty score. If you want a curated digest delivered to you, Scholar Inbox
+is great. If you want to interrogate the literature inside your workflow, that's
+Scholar Feed. Install with `npx scholar-feed-mcp init`.
+
+## Why people search "Scholar Inbox alternative"
+
+Scholar Inbox does the personalized-digest job well. People look for an
+alternative when:
+
+1. They want research that's **actionable in their agent**, not just readable in
+   an inbox. A digest tells you what's new; an MCP tool lets your assistant search,
+   compare, and pull the results section in the same session.
+2. They want **control over the filter** — a structured watch on a specific lab,
+   technique, author, or citation scope — rather than a learned recommendation
+   they can't fully steer.
+
+## How Scholar Feed compares
+
+| | Scholar Inbox | Scholar Feed |
+|---|---|---|
+| Style | Personalized digest (web + email), learned from ratings | Queryable + watchable from inside your AI assistant |
+| You read vs you ask | Read what it sends | Ask, then act on it |
+| Keep-up control | Recommendation tuned by likes | Structured **watches** you define explicitly |
+| Per-paper signal | Relevance to you | LLM summary + 0–1 **novelty score** |
+| Beyond keep-up | Digest | Citation tracing, full-text extraction, BibTeX, author graphs |
+| Coverage | arXiv CS/ML focus | 600,000+ CS/AI/ML papers |
+
+## What you actually do with it
+
+Rather than skimming a morning digest, you ask "anything above 0.5 novelty on
+test-time compute this week?" mid-task, then "trace what cites the top one" and
+"pull its experiments section", without leaving your editor. The keep-up is a
+watch you set and check on your terms, not a feed you have to open daily.
+
+## When NOT to use Scholar Feed
+
+- You want a **zero-effort digest curated for you** and delivered by email. Scholar
+  Inbox is purpose-built for that and does it well; Scholar Feed is pull-based and
+  lives in an MCP client.
+- You don't use an MCP client (Claude Code, Cursor, etc.). Then a web/email digest
+  fits your workflow better.
+
+## Try it
+
+```bash
+npx scholar-feed-mcp init
+```
+
+Free anonymous access is 100 calls/day. Open source (MIT): github.com/YGao2005/scholar-feed-mcp
+
+---
+
+## DRAFT — `/compare/paper-digest-vs-scholar-feed`
+
+**Title tag:** Paper Digest alternative: research papers inside Claude & Cursor
+**Meta:** Scholar Feed is a Paper Digest alternative for CS/AI/ML: a queryable corpus inside your AI assistant with novelty scores, citation tracing, and daily watches, instead of a web digest and report generator. Free anonymous tier.
+
+# Scholar Feed vs Paper Digest: a queryable corpus vs a daily digest
+
+**Short answer (quotable):** Paper Digest and Scholar Feed both fight information
+overload, differently. Paper Digest is a web platform that produces daily digests,
+AI summaries, and literature-review reports across many fields. Scholar Feed is an
+MCP server that puts a 600,000+ CS/AI/ML corpus inside Claude Code or Cursor, where
+your assistant searches, traces citations, reads full text, and runs daily watches,
+with an LLM novelty score on each paper. If you want generated digests and review
+reports, Paper Digest fits. If you want to query and act on the literature in your
+editor, that's Scholar Feed. Install with `npx scholar-feed-mcp init`.
+
+## Why people search "Paper Digest alternative"
+
+Paper Digest is strong at summarization and automated review reports. People look
+elsewhere when:
+
+1. They want the corpus to be **callable by their AI assistant**, not just browsed
+   on a website, so search and reading happen where they write.
+2. They want **CS/ML-tuned ranking and a novelty filter** plus structured watches,
+   rather than broad multi-field digests.
+
+## How Scholar Feed compares
+
+| | Paper Digest | Scholar Feed |
+|---|---|---|
+| Form | Web platform (digests, summaries, report generation) | MCP server your assistant calls |
+| Core job | Summarize and generate review reports | Search, watch, trace, and read in-editor |
+| Per-paper signal | Summary | LLM summary + 0–1 **novelty score** |
+| Keep-up | Daily digest | Structured daily **watches** |
+| Coverage | Many fields and venues | 600,000+ CS/AI/ML papers, indexed daily |
+| Where it runs | A website | Inside Claude Code / Cursor |
+
+## What you actually do with it
+
+You don't get a generated report. You ask your assistant to search the corpus,
+filter by novelty, trace citations, and extract the experiments section, then set
+a watch for new work in that niche, all in the session where you're already
+working. Paper Digest hands you a digest; Scholar Feed hands your agent the tools.
+
+## When NOT to use Scholar Feed
+
+- You want **automated literature-review reports** or daily digests generated for
+  you. Paper Digest is built for that; Scholar Feed gives your assistant tools, not
+  finished reports.
+- You need **broad, multi-field** coverage. Scholar Feed is CS/AI/ML only.
+- You'd rather browse a **website** than work through an MCP client.
+
+## Try it
+
+```bash
+npx scholar-feed-mcp init
+```
+
+Free anonymous access is 100 calls/day. Open source (MIT): github.com/YGao2005/scholar-feed-mcp
+
+---
+
+*All six comparison pages are now drafted. Ship in priority order
+(arxiv-sanity → semantic-scholar → research-rabbit → the rest). Before
+publishing each: one H1, question-style H2s, paste the SoftwareApplication
+JSON-LD from `seo-aeo-checklist.md`, keep the "when NOT to use" block, and
+re-verify every claim against the live README (corpus 600,000+, install command,
+quotas, tool list). Cross-link them all to /developers.*

--- a/docs/handoff/seo-aeo/developers-page.draft.md
+++ b/docs/handoff/seo-aeo/developers-page.draft.md
@@ -1,0 +1,230 @@
+# Developers page draft: scholarfeed.org/developers
+
+Status: draft copy for the public developers/landing page. Targets the keywords
+"arxiv mcp", "research papers in Claude Code", "literature review mcp",
+"semantic scholar alternative mcp", and "mcp server for citations". All facts
+here are pulled from the repo README. Verify version numbers and limits against
+the live README before publishing.
+
+Page route: `https://www.scholarfeed.org/developers`
+
+----------------------------------------------------------------------
+
+## Page title (browser tab / SEO title)
+
+Scholar Feed MCP: arXiv research papers in Claude Code and Cursor
+
+## Meta description
+
+An MCP server that searches 600,000+ CS/AI/ML arXiv papers, traces citations,
+and pulls full text without leaving Claude Code or Cursor. Install with
+`npx scholar-feed-mcp init`. No API key required.
+
+----------------------------------------------------------------------
+
+## H1
+
+Scholar Feed MCP server: search arXiv research papers inside Claude Code and Cursor
+
+## Lead paragraph (answer-first, ~50 words)
+
+Scholar Feed is an open-source MCP server that gives an AI assistant access to
+600,000+ computer science, AI, and machine learning papers from arXiv. Run a
+literature review inside Claude Code or Cursor: search by topic, trace
+citations, read full text, and export BibTeX in one session. Install with one
+command, no API key required.
+
+## Install (put this above the fold, copy-button on the code block)
+
+```bash
+npx scholar-feed-mcp init
+```
+
+The wizard detects your client (Claude Code, Cursor, or Claude Desktop), writes
+the config, and verifies the connection. Anonymous access gives you 100 calls a
+day. A free API key raises that to 1,000 a day.
+
+Claude Code users can skip the wizard:
+
+```bash
+claude mcp add scholar-feed -- npx -y scholar-feed-mcp
+```
+
+----------------------------------------------------------------------
+
+## H2: What is Scholar Feed MCP?
+
+Scholar Feed MCP is a stdio MCP (Model Context Protocol) server, written in
+TypeScript and published on npm as `scholar-feed-mcp`. It connects any
+MCP-compatible client to the Scholar Feed corpus: 600,000+ CS/AI/ML papers
+indexed daily from arXiv. Every paper carries an LLM-generated summary and a
+novelty score from 0.0 to 1.0, plus citation counts, code links, and a
+multi-signal rank score (recency, citation velocity, institutional reputation,
+code availability).
+
+It is built for one job: running a literature review where you already work. No
+browser tabs, no copy-paste between a search engine and your editor.
+
+## H2: Why use an MCP server instead of a web search?
+
+A web search returns links you then have to open, read, and summarize by hand.
+An MCP server returns structured paper data directly to your AI assistant, so
+the assistant can chain steps: find papers, pull the ones that cite a key
+result, extract the experiments section, and draft a related-work paragraph,
+all in one conversation. Scholar Feed also ranks and scores papers, which a raw
+arXiv or Google Scholar query does not.
+
+## H2: How is this different from the Semantic Scholar API?
+
+Semantic Scholar is a citation database with a REST API you call from code.
+Scholar Feed is an MCP server: your AI assistant calls it directly, with no glue
+code to write. The Scholar Feed corpus is focused on CS/AI/ML arXiv papers and
+adds an LLM-generated summary and novelty score per paper, plus full-text
+extraction from LaTeX source. If you want a citation graph your agent can
+traverse from inside Claude Code or Cursor, Scholar Feed is built for that.
+
+## H2: Tool overview
+
+Scholar Feed exposes 25 tools. The most used ones:
+
+**Search and discovery**
+
+- `search_papers`: semantic and keyword search with filters. Also does
+  similar-paper discovery, citation-scoped search, and trending.
+- `get_paper`: full paper details by arXiv ID. Handles batch lookup and BibTeX
+  export.
+- `get_citations`: the citation graph, outgoing references or incoming
+  citations.
+- `fetch_fulltext`: extracts results and experiments from the LaTeX source.
+
+**Authors**
+
+- `find_author`: find researchers by topic or name, or fetch a profile by ID.
+- `co_author_graph`: the co-authorship neighborhood for an author.
+
+**Research orientation**
+
+- `get_field_orientation`: top papers, subfields, and open problems for a
+  research area.
+- `get_foundational_lineage`: the foundational work behind a paper's niche, via
+  the citation graph.
+- `embed_text`: a 768-dimension embedding for custom similarity (Pro only).
+
+**Library, collections, and watches (need a free API key)**
+
+- `save_paper`, `unsave_paper`, `like_paper`, `list_library`: bookmark and
+  calibrate.
+- `list_collections`, `create_collection`, `add_to_collection`,
+  `remove_from_collection`: organize saved papers.
+- `create_watch`, `list_watches`, `check_watches`, `update_watch`,
+  `preview_watch`, `delete_watch`: standing saved searches evaluated daily.
+- `find_gaps`: foundational and frontier work you have not saved yet (Pro).
+- `ask_library`: a cited synthesis grounded only in papers you have saved.
+
+The full tool reference, with parameters, is in the
+[README on GitHub](https://github.com/YGao2005/scholar-feed-mcp).
+
+## H2: What can I ask it to do?
+
+- Technology scouting: "What novel research on retrieval-augmented generation
+  was published this month?"
+- Literature review: "Find papers similar to 2401.04088 and export their
+  BibTeX."
+- Trend monitoring: "What's trending in cs.CV this week? Summarize the top 3."
+- Author discovery: "Who are the top researchers working on efficient LLM
+  inference?"
+- Field orientation: "Give me an orientation report on sparse mixture-of-experts
+  architectures."
+
+## H2: Pricing and rate limits
+
+Scholar Feed MCP is free to install and use. The API key (`SF_API_KEY`) is
+optional and controls your daily call quota:
+
+| Tier | Daily quota | Cost |
+|------|-------------|------|
+| Anonymous (no key) | 100 calls/day | Free |
+| Free key | 1,000 calls/day | Free |
+| Pro | 10,000 calls/day | Paid |
+
+A few tools have their own limits: `ask_library` is 1/month free then 200/day on
+Pro; `find_gaps` and `embed_text` are Pro only. Get a free key at
+[scholarfeed.org/settings](https://www.scholarfeed.org/settings).
+
+----------------------------------------------------------------------
+
+## H2: FAQ
+
+(These questions map 1:1 to the FAQPage JSON-LD in seo-aeo-checklist.md. Keep
+the answers in sync.)
+
+### What is the Scholar Feed MCP server?
+
+Scholar Feed MCP is an open-source stdio MCP server that lets an AI assistant
+search 600,000+ CS/AI/ML research papers from arXiv, trace citations, and read
+full text. It runs inside Claude Code, Cursor, Claude Desktop, and other
+MCP-compatible clients.
+
+### How do I install the Scholar Feed MCP server?
+
+Run `npx scholar-feed-mcp init`. The wizard detects your MCP client, writes the
+config, and verifies the connection. Claude Code users can instead run
+`claude mcp add scholar-feed -- npx -y scholar-feed-mcp`.
+
+### Do I need an API key?
+
+No. Anonymous access gives you 100 calls a day, enough for a typical research
+session. A free API key raises that to 1,000 calls a day, and Pro raises it to
+10,000. The core search and read tools work without any key.
+
+### Which clients does it work with?
+
+Any MCP-compatible client. The repo has setup blocks for Claude Code, Cursor,
+Claude Desktop, Windsurf, Cline, Roo Code, Gemini CLI, LM Studio, JetBrains,
+VS Code (GitHub Copilot), Zed, and Continue.
+
+### Is Scholar Feed a good Semantic Scholar alternative for MCP?
+
+Yes, if you want a CS/AI/ML literature tool your AI assistant can call directly.
+Unlike a REST API you wire up in code, Scholar Feed is an MCP server your
+assistant uses with no glue code. It adds an LLM summary and novelty score to
+each paper and extracts full text from LaTeX source.
+
+### Can it trace citations and export BibTeX?
+
+Yes. `get_citations` returns the citation graph (incoming citations or outgoing
+references) for any arXiv paper. `get_paper` exports BibTeX, including batch
+lookups, with `format: "bibtex"`.
+
+### What papers are in the corpus?
+
+600,000+ CS/AI/ML papers indexed daily from arXiv. Each paper has an
+LLM-generated summary, a novelty score from 0.0 to 1.0, citation counts, code
+links where available, and a multi-signal rank score.
+
+### Is it open source?
+
+Yes, MIT licensed. The source is at
+[github.com/YGao2005/scholar-feed-mcp](https://github.com/YGao2005/scholar-feed-mcp)
+and the package is on npm as
+[scholar-feed-mcp](https://www.npmjs.com/package/scholar-feed-mcp).
+
+----------------------------------------------------------------------
+
+## Internal links to place on this page
+
+- Link to the npm package: https://www.npmjs.com/package/scholar-feed-mcp
+- Link to the GitHub repo: https://github.com/YGao2005/scholar-feed-mcp
+- Link to settings/key page: https://www.scholarfeed.org/settings
+- Link to the skills page: https://www.scholarfeed.org/skills
+- Link back to the homepage: https://www.scholarfeed.org
+
+## Suggested H1/H2 keyword coverage map
+
+- "arxiv mcp" -> H1, lead paragraph, "What is Scholar Feed MCP?"
+- "research papers in Claude Code" -> page title, H1, lead, install section
+- "literature review mcp" -> lead paragraph, "What can I ask it to do?"
+- "semantic scholar alternative mcp" -> "How is this different from the
+  Semantic Scholar API?", FAQ
+- "mcp server for citations" -> "Can it trace citations and export BibTeX?",
+  tool overview

--- a/docs/handoff/seo-aeo/directory-submissions.md
+++ b/docs/handoff/seo-aeo/directory-submissions.md
@@ -1,0 +1,105 @@
+# Directory submissions (presence-audited worklist)
+
+The actionable extension of `seo-aeo-checklist.md` §4. That section says "get
+listed in registries"; this file says **which ones already have you, which
+don't, and the exact copy to paste** — plus the non-MCP research-tool
+directories the checklist omits, which are what rank for the generic queries
+real users type ("best research paper tool", "Connected Papers alternative").
+
+Why this matters more than it looks: when someone asks ChatGPT/Claude/Perplexity
+"what's a good MCP server for arXiv papers" or "alternatives to Research Rabbit",
+the model retrieves **these directories**, not your homepage. A name-search finds
+you on Glama; a *generic* search finds your competitors. Closing that gap is a
+form-filling afternoon, not a campaign.
+
+## Presence audit (verified live 2026-06-04)
+
+> **Lesson that reorders everything below:** the official MCP Registry is the
+> source of truth, but downstream propagation is NOT reliable. Scholar Feed is
+> correctly in the registry, yet PulseMCP shows "No servers found" for it. So
+> "we're in the registry" ≠ "we're in the directories." Fix the registry entry
+> (it's the upstream), then **still manually submit** to the curated directories
+> that don't auto-ingest.
+
+| Directory | Ranks for | Status (verified) | Action |
+|---|---|---|---|
+| Official MCP Registry | upstream for many directories | ✅ Listed as `io.github.YGao2005/scholar-feed-mcp` | **Fix the description (done in server.json, needs republish) — see below. Highest leverage.** |
+| Glama (glama.ai/mcp) | name lookups | ✅ Listed | Verify it picked up the new description after republish |
+| mcp.so | largest community directory | ✅ Listed (`mcp.so/server/scholar-feed-mcp/YGao2005`, 200 OK) | Eyeball the live page; confirm description |
+| **mcpservers.org** (punkpeye/awesome-mcp-servers) | "best mcp servers", "mcp for research" — **heavily AI-cited** | ⏳ **PR #7329 OPEN, not merged** | Backlog closes many research PRs (#5377/#3514/#1942/#3614 all closed). Verify the PR matches CONTRIBUTING format exactly (alphabetical, exact line shape), then ping. May not land — don't count on it. |
+| **PulseMCP** (pulsemcp.com) | "mcp server" discovery | ❌ **Absent despite registry** | Registry auto-ingest didn't work → use `/submit` form directly. Competitor `afrise-academic-search` is here. |
+| **lobehub.com/mcp** | "mcp server" + LobeChat users | ❓ Unchecked (assume absent) | Submit (PR/form) |
+| **Smithery** (smithery.ai) | one-click MCP install | ⏳ Built, not submitted | Submit the `smithery.yaml` on PR #13 |
+| **mcpmarket.com** | "mcp market" discovery | ❓ Unchecked | Submit |
+| **AlternativeTo** (alternativeto.net) | "Connected Papers alternative", "Research Rabbit alternative" | ❌ Absent | Add as an alternative to Connected Papers, Research Rabbit, Semantic Scholar, Elicit |
+| **There's An AI For That** (theresanaiforthat.com) | "AI tool for research papers" — huge AEO surface | ❌ Absent | Submit (paid fast-track optional; free queue works) |
+| **Futurepedia** / **Toolify.ai** / **SaaSHub** | "best AI research tools" roundups | ❌ Absent | Submit to each (low effort, long tail) |
+
+### #1 action — fix the registry description (propagates to ingesters)
+The published description was *"Search 600,000+ CS/AI/ML papers with citation
+graph, full text, embeddings, and BibTeX."* — it omits the two differentiators
+(**daily watches**, **novelty scores**). `server.json` is now updated to (≤100
+char registry limit):
+
+> `600,000+ CS/AI/ML papers in your AI assistant: search, novelty scores, citations, daily watches.`
+
+This only goes live on **republish** to the registry (the same tag-triggered
+OIDC / `mcp-publisher` flow used for releases; a republish may want a version
+bump). Do that, then the registry → Glama → other ingesters carry the better
+copy.
+
+Priority order (revised): **fix+republish registry description → PulseMCP /submit
+→ verify/ping awesome-mcp PR #7329 → lobehub → Smithery → AlternativeTo →
+There's An AI For That → long tail.** The registry already covers the
+auto-propagating slice; spend manual effort only where propagation demonstrably
+fails (PulseMCP) and on the non-MCP research directories.
+
+## Paste-ready copy
+
+Reuse verbatim so every listing agrees with the README and the JSON-LD (that
+cross-source consistency is itself an AEO trust signal — see checklist §4).
+
+**Name:** Scholar Feed MCP Server
+**Slug / npm:** `scholar-feed-mcp`
+**Repo:** https://github.com/YGao2005/scholar-feed-mcp
+**Homepage:** https://www.scholarfeed.org/developers
+**License:** MIT · **Transport:** stdio · **Auth:** optional API key (anonymous works)
+
+**One-liner (≤80 chars):**
+> 600k+ arXiv CS/AI/ML papers inside Claude Code & Cursor — search, citations, watches.
+
+**Tagline (≤160 chars, for AlternativeTo / TAAFT):**
+> An MCP server that gives your AI assistant 600,000+ CS/AI/ML research papers from arXiv: semantic search, citation tracing, full text, BibTeX, and daily watches.
+
+**Short description (~50 words, for registries):**
+> Scholar Feed is an open-source stdio MCP server that connects any MCP client (Claude Code, Cursor, Claude Desktop, and others) to 600,000+ CS/AI/ML papers indexed daily from arXiv. Each paper has an LLM summary and a 0–1 novelty score. 25 tools: search, citations, full text, BibTeX, authors, library, and daily watches. Free anonymous tier (100 calls/day).
+
+**Long description (~110 words, for mcp.so / lobehub / TAAFT):**
+> Scholar Feed puts a research corpus inside the AI assistant you already use, so literature review happens in the same session as your writing or code. Semantic and keyword search over 600,000+ CS/AI/ML arXiv papers (indexed daily), each with an LLM-generated summary and a 0–1 novelty score so you can filter past incremental work. Beyond search: trace citations both directions, extract results/experiments from LaTeX source, export BibTeX, search authors and co-author graphs, keep a library and collections, and set daily "watches" that surface new papers matching a saved filter. Install with `npx scholar-feed-mcp init`. Open source (MIT), 25 tools, free anonymous access at 100 calls/day.
+
+**Categories / tags:** `research`, `academic`, `arxiv`, `literature-review`,
+`citations`, `papers`, `machine-learning`, `developer-tools`
+
+**Install:** `npx scholar-feed-mcp init`
+
+**Standard config block** (for directories that show one):
+```json
+{
+  "mcpServers": {
+    "scholar-feed": { "command": "npx", "args": ["-y", "scholar-feed-mcp@latest"] }
+  }
+}
+```
+
+### AlternativeTo specifics
+Add Scholar Feed as an alternative on these pages (one submission each):
+- Connected Papers · Research Rabbit · Semantic Scholar · Elicit · Litmaps
+- Pick tags: `Free`, `Open Source`, `Mac/Windows/Linux`, `AI`, `Command Line`
+- Use the tagline above; the differentiator line that converts there is:
+  *"Unlike the web tools, it runs inside your AI assistant (Claude/Cursor) so search + reading happen where you already work, and it adds an LLM novelty score per paper."*
+
+## After listing
+Re-run the checklist §4 "Measure" step in ~2 weeks: ask each assistant "what's a
+good MCP server for arXiv papers" and "Connected Papers alternative that works in
+Claude" and confirm Scholar Feed now surfaces. Perplexity reflects directory
+changes in days; Claude/Google AI Overviews in a few weeks.

--- a/docs/handoff/seo-aeo/llms.txt.draft
+++ b/docs/handoff/seo-aeo/llms.txt.draft
@@ -1,0 +1,24 @@
+# Scholar Feed
+
+> Scholar Feed is an open-source MCP (Model Context Protocol) server that lets an AI assistant search 600,000+ CS/AI/ML research papers from arXiv, trace citations, read full text, and export BibTeX, without leaving Claude Code, Cursor, or any MCP-compatible client. Built for researchers running a literature review where they already work.
+
+Install with one command: `npx scholar-feed-mcp init`. The wizard detects your MCP client, writes the config, and verifies the connection. No API key required: anonymous access is 100 calls/day, a free key is 1,000/day, and Pro is 10,000/day. The npm package is `scholar-feed-mcp`; the MCP server name is `io.github.YGao2005/scholar-feed-mcp`. Site: https://www.scholarfeed.org. API: https://api.scholarfeed.org.
+
+The server exposes 25 tools. Core read and search tools work anonymously. Key tools: search_papers, get_paper, get_citations, fetch_fulltext, find_author, co_author_graph, get_field_orientation, get_foundational_lineage, embed_text, plus library, collections, watches, find_gaps, and ask_library (these require a free API key).
+
+## Get started
+
+- [Install and quick start](https://www.scholarfeed.org/developers): One-command install (`npx scholar-feed-mcp init`), client setup, and a tool overview.
+- [Get a free API key](https://www.scholarfeed.org/settings): Optional. Raises the daily quota from 100 to 1,000 calls.
+- [npm package](https://www.npmjs.com/package/scholar-feed-mcp): The published `scholar-feed-mcp` package. Run via `npx -y scholar-feed-mcp`.
+
+## Documentation
+
+- [README and full tool reference](https://github.com/YGao2005/scholar-feed-mcp): The 25 tools with parameters, install blocks for every supported client, rate limits, and an example response.
+- [Skills](https://www.scholarfeed.org/skills): Higher-level workflows built on the MCP tools (for example field-guide and compare-methods).
+
+## Optional
+
+- [GitHub repository](https://github.com/YGao2005/scholar-feed-mcp): Source code, MIT licensed.
+- [Changelog](https://github.com/YGao2005/scholar-feed-mcp/blob/main/CHANGELOG.md): Version history, including the v3 tool consolidation.
+- [Contributing guide](https://github.com/YGao2005/scholar-feed-mcp/blob/main/CONTRIBUTING.md): How to contribute.

--- a/docs/handoff/seo-aeo/seo-aeo-checklist.md
+++ b/docs/handoff/seo-aeo/seo-aeo-checklist.md
@@ -1,0 +1,313 @@
+# SEO + AEO checklist for scholarfeed.org
+
+Concrete actions to rank for the target keywords and to get the MCP server
+recommended by AI assistants and cited by answer engines. Ordered roughly by
+impact-to-effort. JSON-LD blocks below are valid and factual; paste them as-is
+(adjust only the noted placeholders). Validate every block in Google's Rich
+Results Test and the Schema Markup Validator (validator.schema.org) before
+shipping.
+
+Target keywords: "arxiv mcp", "research papers in Claude Code",
+"literature review mcp", "semantic scholar alternative mcp",
+"mcp server for citations".
+
+----------------------------------------------------------------------
+
+## 1. On-page SEO
+
+### Title and meta (developers page)
+
+- Title tag (under ~60 chars):
+  `Scholar Feed MCP: arXiv research papers in Claude Code and Cursor`
+- Meta description (under ~155 chars):
+  `An MCP server that searches 600,000+ CS/AI/ML arXiv papers, traces citations, and pulls full text in Claude Code or Cursor. Install: npx scholar-feed-mcp init.`
+- Canonical tag: `<link rel="canonical" href="https://www.scholarfeed.org/developers" />`
+- Open Graph: set `og:title`, `og:description`, `og:url`, and an `og:image`
+  (use the existing logo asset, 1200x630 ideally).
+
+### Headings
+
+- Exactly one H1 per page. On /developers use:
+  `Scholar Feed MCP server: search arXiv research papers inside Claude Code and Cursor`
+- Use natural-language, question-style H2s. Answer engines extract from these.
+  Use: "What is Scholar Feed MCP?", "How is this different from the Semantic
+  Scholar API?", "Can it trace citations and export BibTeX?". These mirror the
+  five target keywords.
+
+### Answer-first content (this is what LLMs quote)
+
+- Lead each section with a direct 30 to 60 word answer in the first one or two
+  sentences, then add detail. AI engines pull a large share of citations from
+  the opening portion of a page.
+- Write standalone, quotable definition sentences. Example, already in the
+  draft: "Scholar Feed MCP is a stdio MCP server, written in TypeScript and
+  published on npm as scholar-feed-mcp, that connects any MCP-compatible client
+  to 600,000+ CS/AI/ML papers indexed daily from arXiv."
+- Keep the concrete number (600,000+), the install command, and the daily
+  quotas (100 / 1,000 / 10,000) in plain text near the top. Numbers and
+  specifics raise citation rate.
+- Put the install command (`npx scholar-feed-mcp init`) in a real `<code>` block
+  above the fold, with a copy button.
+
+### Internal links
+
+- Link /developers from the homepage nav and footer.
+- Cross-link /developers <-> /skills <-> /settings.
+- Link out to the GitHub repo and the npm package (these are authority signals
+  and they back up the factual claims).
+- Add the npm and GitHub links with descriptive anchor text ("scholar-feed-mcp
+  on npm", "Scholar Feed MCP on GitHub"), not "click here".
+
+### Technical
+
+- Make sure /developers is server-rendered or pre-rendered so crawlers and AI
+  fetchers get the full HTML, not an empty JS shell.
+- Confirm robots.txt does not block AI crawlers you want citations from
+  (GPTBot, PerplexityBot, ClaudeBot, Google-Extended). Decide deliberately;
+  blocking them removes you from those answer engines.
+- Add /developers and the homepage to sitemap.xml.
+- Keep the page fast (Core Web Vitals); AI Overviews favor pages already
+  ranking in the organic top 10.
+- Refresh the page date when you update it. Freshness correlates strongly with
+  AI citation for evaluation-stage queries.
+
+----------------------------------------------------------------------
+
+## 2. JSON-LD to paste
+
+Place each block in a `<script type="application/ld+json">` tag in the page
+`<head>` or end of `<body>`. The SoftwareApplication block goes on /developers
+(and can also go on the homepage). The FAQPage block goes on /developers and
+must match visible on-page FAQ text word for word.
+
+### 2a. SoftwareApplication (put on /developers)
+
+```html
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "Scholar Feed MCP Server",
+  "alternateName": "scholar-feed-mcp",
+  "applicationCategory": "DeveloperApplication",
+  "applicationSubCategory": "MCP Server",
+  "operatingSystem": "macOS, Windows, Linux",
+  "description": "An open-source MCP (Model Context Protocol) server that lets an AI assistant search 600,000+ CS/AI/ML research papers from arXiv, trace citations, read full text, and export BibTeX inside Claude Code, Cursor, and other MCP clients.",
+  "url": "https://www.scholarfeed.org/developers",
+  "downloadUrl": "https://www.npmjs.com/package/scholar-feed-mcp",
+  "installUrl": "https://www.npmjs.com/package/scholar-feed-mcp",
+  "softwareHelp": "https://github.com/YGao2005/scholar-feed-mcp",
+  "license": "https://opensource.org/licenses/MIT",
+  "isAccessibleForFree": true,
+  "softwareRequirements": "Node.js 18 or later",
+  "featureList": [
+    "Search 600,000+ CS/AI/ML arXiv papers by topic or keyword",
+    "Trace the citation graph (incoming citations and outgoing references)",
+    "Extract results and experiments from LaTeX full text",
+    "Export BibTeX, including batch lookups",
+    "Find authors and co-authorship neighborhoods",
+    "Field orientation and foundational-lineage reports",
+    "LLM-generated summary and novelty score per paper"
+  ],
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "author": {
+    "@type": "Organization",
+    "name": "Scholar Feed",
+    "url": "https://www.scholarfeed.org"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Scholar Feed",
+    "url": "https://www.scholarfeed.org"
+  }
+}
+</script>
+```
+
+Notes:
+- No `aggregateRating`: do not add one until you have real, displayed reviews.
+  Fabricated ratings are a structured-data policy violation.
+- `price: "0"` is factual: the server is free to install and use; the optional
+  key/Pro tier is a separate API offering, not the price of this application.
+- If you publish a tagged version you want to advertise, you may add
+  `"softwareVersion": "x.y.z"`, but keep it in sync with npm or omit it.
+
+### 2b. FAQPage (put on /developers, must mirror visible FAQ)
+
+```html
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is the Scholar Feed MCP server?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Scholar Feed MCP is an open-source stdio MCP server that lets an AI assistant search 600,000+ CS/AI/ML research papers from arXiv, trace citations, and read full text. It runs inside Claude Code, Cursor, Claude Desktop, and other MCP-compatible clients."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I install the Scholar Feed MCP server?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Run npx scholar-feed-mcp init. The wizard detects your MCP client, writes the config, and verifies the connection. Claude Code users can instead run claude mcp add scholar-feed -- npx -y scholar-feed-mcp."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need an API key?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Anonymous access gives you 100 calls a day, enough for a typical research session. A free API key raises that to 1,000 calls a day, and Pro raises it to 10,000. The core search and read tools work without any key."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Which clients does it work with?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Any MCP-compatible client. The repo has setup blocks for Claude Code, Cursor, Claude Desktop, Windsurf, Cline, Roo Code, Gemini CLI, LM Studio, JetBrains, VS Code (GitHub Copilot), Zed, and Continue."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Scholar Feed a good Semantic Scholar alternative for MCP?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, if you want a CS/AI/ML literature tool your AI assistant can call directly. Unlike a REST API you wire up in code, Scholar Feed is an MCP server your assistant uses with no glue code. It adds an LLM summary and novelty score to each paper and extracts full text from LaTeX source."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can it trace citations and export BibTeX?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. get_citations returns the citation graph (incoming citations or outgoing references) for any arXiv paper. get_paper exports BibTeX, including batch lookups, with format: \"bibtex\"."
+      }
+    }
+  ]
+}
+</script>
+```
+
+Notes:
+- Every Question name and Answer text must appear in visible page copy. If you
+  trim the on-page FAQ, trim this block to match.
+- Google has narrowed FAQ rich-result eligibility, but FAQPage markup still
+  helps AI engines extract clean question/answer pairs, which is the AEO win
+  here.
+
+### 2c. Optional: Organization (put on the homepage)
+
+```html
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "Scholar Feed",
+  "url": "https://www.scholarfeed.org",
+  "description": "Scholar Feed indexes 600,000+ CS/AI/ML research papers from arXiv with LLM-generated summaries and novelty scores, accessible through an open-source MCP server.",
+  "sameAs": [
+    "https://github.com/YGao2005/scholar-feed-mcp",
+    "https://www.npmjs.com/package/scholar-feed-mcp"
+  ]
+}
+</script>
+```
+
+----------------------------------------------------------------------
+
+## 3. llms.txt
+
+- Publish the file from llms.txt.draft (in this folder) at
+  `https://www.scholarfeed.org/llms.txt` (site root, plain text, served as
+  `text/plain` or `text/markdown`).
+- Do not redirect it and do not gate it behind JS. It must return raw markdown
+  on a direct GET.
+- Optional: also publish `llms-full.txt` with the full README and developers
+  page inlined, so agents can ingest everything in one fetch.
+- Keep it short and curated: install, key, docs, repo. Update it whenever the
+  install command, quotas, or tool count change. Agents and coding assistants
+  cache it, so stale copies linger.
+- Reference it from the page footer and from robots.txt as a comment
+  (`# llms.txt: https://www.scholarfeed.org/llms.txt`) so it is discoverable.
+
+----------------------------------------------------------------------
+
+## 4. AEO and agent discoverability (get recommended by AI assistants)
+
+### Get listed in MCP registries
+
+List the same server in each, since each has a different audience. Prepare the
+metadata once (name, transport=stdio, tool list, auth=optional API key,
+homepage, repo, short description):
+
+- Official MCP Registry (registry.modelcontextprotocol.io): publish via the OSS
+  community registry. The repo already has a server.json; use it.
+- GitHub MCP Registry: self-published servers in the OSS community registry flow
+  through here automatically.
+- mcp.so, glama.ai/mcp, smithery.ai: submit per each site's mechanism (form,
+  self-register, or PR).
+- punkpeye/awesome-mcp-servers on GitHub: open a PR adding scholar-feed under
+  the research/academic category.
+
+### Serve a discoverable server card
+
+- Consider publishing the server descriptor at
+  `https://www.scholarfeed.org/.well-known/mcp/server.json` (mirror the repo's
+  server.json). Registries and crawlers use well-known URLs to auto-discover
+  capabilities. Confirm the exact schema against the official registry docs
+  before relying on auto-discovery.
+
+### Content patterns that get cited
+
+- Answer-first sections with question H2s (covered in section 1).
+- Standalone definition sentences the model can quote without surrounding
+  context.
+- Comparison content: a short "Scholar Feed vs Semantic Scholar API" section
+  targets "semantic scholar alternative mcp" and is exactly the shape answer
+  engines quote for "what's a good X alternative" queries.
+- Concrete numbers and the literal install command. Models prefer copy-pasteable
+  specifics.
+- Keep the README and the /developers page consistent. When an assistant reads
+  the GitHub README, the package on npm, and the developers page and they all
+  agree, that consistency is itself a trust signal.
+
+### Off-site presence (where assistants and answer engines look)
+
+- npm and GitHub are already strong; keep the README current (it is the primary
+  source most assistants will quote).
+- Get listed in third-party "best MCP servers" and "MCP servers for research"
+  roundups; these are heavily cited by ChatGPT and Perplexity for
+  recommendation queries.
+- A short Show HN or dev.to / Reddit r/MachineLearning post with the install
+  command creates fresh, datable, citable mentions.
+
+### Measure
+
+- Track AI referral traffic in analytics by referrer (chat.openai.com,
+  perplexity.ai, gemini, claude).
+- Periodically ask the major assistants the target queries ("what's a good MCP
+  server for arXiv papers", "literature review MCP", "semantic scholar
+  alternative MCP") and check whether Scholar Feed is recommended and described
+  accurately. Re-run monthly; structural fixes show up in Perplexity in days and
+  in Claude / Google AI Overviews in a few weeks.
+
+----------------------------------------------------------------------
+
+## 5. Pre-publish validation
+
+- Run both JSON-LD blocks through validator.schema.org and Google's Rich Results
+  Test. Expect zero errors.
+- Confirm the FAQ JSON-LD text matches visible page text exactly.
+- Confirm `https://www.scholarfeed.org/llms.txt` returns raw markdown (curl it).
+- Re-check every fact against the live README before publishing: tool count
+  (25), corpus size (600,000+), quotas (100 / 1,000 / 10,000), install command,
+  and the Pro-only / metered tools.

--- a/docs/handoff/socials/demo-cast-script.md
+++ b/docs/handoff/socials/demo-cast-script.md
@@ -1,0 +1,84 @@
+# Demo Cast Script (15 to 30 seconds)
+
+A short terminal demo for the README, the launch posts, and the docs. The goal: show that install is one command and that the first real query returns ranked papers with novelty scores, all inside an MCP client. Keep it under 30 seconds; people scrub away after that.
+
+## Tooling
+
+Two good options:
+
+- VHS (charmbracelet/vhs): a `.tape` script renders a deterministic GIF/MP4 in CI. Best for a repeatable, captioned GIF that stays in sync. Requires `ttyd` and `ffmpeg`. A `.tape` skeleton is below.
+- asciinema + agg: record a real session (`asciinema rec demo.cast`), then convert to GIF with `agg`. Best if you want a real, slightly-imperfect human cadence and an embeddable player.
+
+For a launch, render BOTH a GIF (for X, Reddit, README, Discord, which autoplay GIFs) and keep the `.cast`/MP4 for the docs site player. GIF is the workhorse because it autoplays inline everywhere.
+
+## What the viewer sees (storyboard)
+
+Total target: ~22 seconds. Captions appear as on-screen text overlaid on the terminal (VHS can type them as comments, or add them in post). Keep the terminal font large (>=22px) so it is legible on a phone.
+
+| Time | On screen | Caption overlay |
+|------|-----------|-----------------|
+| 0.0s | Clean prompt, blinking cursor. | `Add a 600k-paper research index to Claude Code` |
+| 1.5s | Type `npx scholar-feed-mcp init` and run it. | `One command. No API key needed.` |
+| 3.0s | Wizard runs: detects the client, offers to skip the key, writes config, verifies the connection. Let the real output scroll. | `Auto-detects your MCP client and verifies the connection` |
+| 9.0s | Wizard prints success. Brief pause. | `Now ask, in plain language` |
+| 11.0s | Switch to the client (or simulate a prompt line). Type the query: `Search for recent high-novelty papers on test-time compute scaling` | (no caption, let the query read) |
+| 13.0s | Results stream: 3 to 4 papers, each with title, arXiv id, a one-line LLM summary, and a novelty score. | `Ranked by an LLM novelty score, with summaries` |
+| 20.0s | Hold on the result list. | `25 tools: search, citations, full text, BibTeX, watches` |
+| 22.0s | Final frame: the repo URL. | `github.com/YGao2005/scholar-feed-mcp` |
+
+Notes on accuracy:
+- The result rows must reflect real fields the tool returns: `arxiv_id`, `title`, `llm_summary`, `llm_novelty_score` (0.0 to 1.0). Do not fabricate a score format the tool does not use.
+- The init wizard genuinely (1) optionally asks for a key or lets you skip for anonymous access, (2) detects Claude Code / Cursor / Claude Desktop, (3) writes config and verifies. Keep the captions matched to that.
+- "anonymous" is accurate: anonymous access is 100 calls/day, enough for the demo. Do not imply a key is required.
+
+## Exact commands to run
+
+```bash
+# 1. Install + configure (the whole pitch is that this is one command)
+npx scholar-feed-mcp init
+# (choose: skip the API key -> anonymous; let it auto-detect the client)
+
+# 2. Then, inside Claude Code / Cursor, ask in natural language:
+#    Search for recent high-novelty papers on test-time compute scaling
+```
+
+The second step is a natural-language prompt to the agent, not a shell command. In the recording, show it as a message typed into the client. If you want a pure-terminal version (no client UI), you can show the equivalent by letting the agent call `search_papers` with `q: "test-time compute scaling"`, `sort: "trending"` (or `novelty_min: 0.5`), and `days` set to a recent window, then render the returned papers. Use only real parameter names from the README: `q`, `category`, `novelty_min`, `days`, `sort`, `limit`.
+
+## VHS `.tape` skeleton
+
+Save as `assets/demo.tape`, then `vhs assets/demo.tape` to produce the GIF. Tune `Sleep` values against a real run so the pacing matches actual latency.
+
+```tape
+Output assets/demo.gif
+Output assets/demo.mp4
+
+Set FontSize 24
+Set Width 1200
+Set Height 700
+Set Theme "Catppuccin Mocha"
+Set TypingSpeed 60ms
+Set Padding 24
+
+Type "npx scholar-feed-mcp init"
+Enter
+Sleep 7s        # let the real wizard run: detect client, skip key, write config, verify
+
+Sleep 1s
+Type "# now ask in plain language inside your MCP client:"
+Enter
+Type "Search for recent high-novelty papers on test-time compute scaling"
+Enter
+Sleep 6s        # results stream in with novelty scores
+
+Sleep 3s        # hold on the final result list
+```
+
+If the wizard is interactive (prompts for key/client), VHS needs the keystrokes for those prompts too: after `Enter`, add the responses, e.g. `Enter` to accept the default "skip key," then `Enter` again to accept the detected client. Do a dry run, watch the prompts, and insert the matching `Type`/`Enter` lines.
+
+## Post-production / publishing
+
+- Trim dead air so the whole thing lands at 15 to 25 seconds.
+- Loop the GIF cleanly (end frame should rest on the repo URL).
+- Burn captions in (do not rely on a separate caption track) since most surfaces autoplay muted with no captions.
+- Output sizes: keep the GIF reasonably small (under ~8 MB) so it autoplays on Reddit and Discord without a click-to-load. If it is too big, lower FPS in agg/VHS or shorten it.
+- Drop the GIF into the README right under the badges, and reuse it as the media on the X launch post and the Reddit post.

--- a/docs/handoff/socials/launch-posts.md
+++ b/docs/handoff/socials/launch-posts.md
@@ -1,0 +1,117 @@
+# Launch Posts (ready to post)
+
+Drafts for X, r/LocalLLaMA, Show HN, and a Discord #showcase. Every number here is verified against the repo: 25 tools, 600,000+ CS/AI/ML papers, anonymous access at 100 calls/day or a free key at 1,000/day. Install is `npx scholar-feed-mcp init`. Repo: github.com/YGao2005/scholar-feed-mcp. Site: scholarfeed.org.
+
+Channel-specific tone is the whole game: HN wants flat and factual, X wants a tight hook, Reddit wants a builder talking to builders (and is sensitive about hosted-vs-local), Discord wants short and friendly. Same facts, four registers.
+
+Attach the demo GIF to the X post, the Reddit post, and the Discord blurb. Show HN gets no image (text only).
+
+---
+
+## X / Twitter thread (4 posts)
+
+Post all four within a minute of each other so they unroll as one card. Put the demo GIF on post 1.
+
+**1/**
+I built an MCP server that puts 600,000+ CS/AI/ML papers inside Claude Code and Cursor.
+
+Ask "find recent high-novelty work on test-time compute scaling" and get ranked papers with summaries, without leaving your editor.
+
+One command to install:
+`npx scholar-feed-mcp init`
+
+[demo GIF]
+
+**2/**
+It is a literature-review toolkit, not just search. 25 tools: search and trace citations, pull full text from LaTeX, export BibTeX, map co-authors, build a library and collections, and set daily watches for new work in your niche.
+
+**3/**
+No signup to try it. Anonymous access is 100 calls/day, enough for a real session. A free key bumps you to 1,000/day. The papers come from arXiv, indexed daily, each with an LLM summary and a 0 to 1 novelty score so you can filter for genuinely new results.
+
+**4/**
+It is open source (MIT) and a standard stdio MCP server, so it also works in Claude Desktop, Windsurf, Cline, Zed, and the rest.
+
+Repo, docs, and the full tool list:
+github.com/YGao2005/scholar-feed-mcp
+
+---
+
+## r/LocalLLaMA post
+
+Before posting: check the current subreddit rules in the sidebar and flair the post correctly (Resources/Tutorial or similar). This community is sharp about self-promotion and about the local-vs-hosted distinction, so be upfront that the corpus and ranking run on a hosted API. Reply to comments fast; that is what carries a Reddit post.
+
+**Title:**
+I built an open-source MCP server that gives your agent a 600k-paper arXiv research index (search, citations, full text, BibTeX)
+
+**Body:**
+I do a lot of literature review and kept bouncing between arXiv, Google Scholar, and my editor. So I wrote an MCP server that exposes a research corpus to whatever agent you already use.
+
+What it does:
+- Semantic + keyword search over 600,000+ CS/AI/ML papers (arXiv, indexed daily)
+- Each paper has an LLM-generated summary and a 0 to 1 novelty score, so you can filter for actually-novel work instead of yet another incremental paper
+- Trace citations both directions, pull results/experiments out of the LaTeX source, export BibTeX
+- Author search and co-author graphs
+- A personal library, collections, and daily "watches" that surface new papers matching a saved filter
+- 25 tools total
+
+Install is one command: `npx scholar-feed-mcp init`. It auto-detects your client (Claude Code, Cursor, Claude Desktop, and others) and writes the config.
+
+Honest about the architecture: this is a thin stdio MCP client. The corpus, embeddings, and ranking live behind a hosted API, not on your machine, so it is not a fully local setup. The model you point it at is yours, local or not; this just feeds it papers. You can use it anonymously (100 calls/day, no account) or with a free key for 1,000/day.
+
+MIT licensed. Repo: github.com/YGao2005/scholar-feed-mcp
+
+Happy to answer anything, and genuinely want feedback on the tool design (what is missing for your review workflow).
+
+---
+
+## Show HN
+
+Keep the title plain. No superlatives, no exclamation points, no numbers-as-hype in the title. The first comment carries the backstory and the honest caveats.
+
+**Title:**
+Show HN: An MCP server that puts 600k arXiv papers inside Claude Code and Cursor
+
+**URL:** https://github.com/YGao2005/scholar-feed-mcp
+
+**First comment:**
+Author here. I do a fair amount of literature review and was tired of switching between arXiv, Scholar, and my editor and losing the thread. This is an MCP server that gives an agent a research corpus to work from, so the search, citation tracing, and reading happen in the same session as the writing.
+
+What it actually does: semantic and keyword search over 600,000+ CS/AI/ML papers from arXiv (indexed daily), with an LLM summary and a 0 to 1 novelty score on each paper so you can filter past incremental work. Beyond search there are tools to trace citations in both directions, extract the results/experiments section from a paper's LaTeX source, export BibTeX, search authors and co-author graphs, keep a library and collections, and set daily "watches" for new matches. 25 tools in total.
+
+Install is `npx scholar-feed-mcp init`; it detects your client (Claude Code, Cursor, Claude Desktop, and the usual others) and writes the config. You can run it anonymously at 100 calls/day with no account, or use a free key for 1,000/day.
+
+A few honest caveats: it is a thin stdio MCP client (TypeScript, MIT). The corpus, embeddings, and ranking live behind a hosted API, so it is not self-hosted, and coverage is CS/AI/ML, not all of arXiv. The novelty score is LLM-generated and imperfect; I treat it as a filter, not ground truth.
+
+I would especially like feedback on the tool surface: whether the split between search, citations, full text, and watches matches how you actually do a review, and what is missing. Repo and full tool list are in the link.
+
+---
+
+## Discord #showcase blurb
+
+For MCP, Claude, Cursor, and AI-dev servers. Short, friendly, link-forward. Lead with the GIF.
+
+[demo GIF]
+
+Built **Scholar Feed MCP**: an open-source MCP server that gives your agent 600,000+ CS/AI/ML papers to work from, right inside Claude Code, Cursor, or Claude Desktop.
+
+Search and trace citations, pull full text from LaTeX, export BibTeX, and set daily watches for new work in your area. 25 tools total. Each paper has an LLM summary and a novelty score so you can filter for genuinely new results.
+
+One command to try it, no account needed (anonymous is 100 calls/day):
+`npx scholar-feed-mcp init`
+
+MIT licensed, standard stdio server: github.com/YGao2005/scholar-feed-mcp
+
+Feedback very welcome, especially on the tool design.
+
+---
+
+## Accuracy checklist (apply to every post before sending)
+
+- [ ] Tool count is 25.
+- [ ] Corpus is 600,000+ CS/AI/ML papers (not "all of arXiv," not a different number).
+- [ ] Anonymous = 100/day, free key = 1,000/day. Never claim a key is required.
+- [ ] Install command is exactly `npx scholar-feed-mcp init`.
+- [ ] Only real tool capabilities named (search, citations, full text, BibTeX, authors, co-author graph, library, collections, watches, novelty score). No invented tools or parameters.
+- [ ] No dashes used as punctuation. No hype words (unlock, seamless, revolutionary).
+- [ ] Repo link correct: github.com/YGao2005/scholar-feed-mcp
+- [ ] Hosted-API caveat stated on HN and Reddit (the local-first crowds will ask).

--- a/docs/handoff/socials/reddit-comments-to-post.md
+++ b/docs/handoff/socials/reddit-comments-to-post.md
@@ -1,0 +1,94 @@
+# Reddit comments — ready to post
+
+The copy-paste worksheet. Each entry: the thread link, then the exact comment
+(plain text, no blockquote, so you can select and paste cleanly). Ordered for
+posting — fresh/active threads first, evergreen ones after.
+
+Rules (full version in `reddit-organic.md`): post from your aged personal
+account, disclose every time (already baked in), don't post more than ~2 in a
+day, reply fast to any follow-up without re-pitching. Bank a couple of no-link
+helpful comments first.
+
+---
+
+## 1 · r/MLQuestions — post first
+**Thread:** [How do you automatically track new AI research / compute articles into a Notion or spreadsheet?](https://www.reddit.com/r/MLQuestions/comments/1rpf0i6/)
+**Why:** Recent, few answers, easy to be the top reply. Honest "partly the wrong tool" angle builds credibility.
+
+- [ ] Posted
+
+For the papers side of this there are pretty clean inputs. arxiv has a per-category RSS/Atom feed you can pipe straight into a sheet, and Semantic Scholar's API will give you summaries. The compute and infra news side is messier since that's mostly blogs and press releases, so for that you'd want RSS plus an LLM summarize step. A little cron calling the OpenAI or Anthropic API into Notion does the job, you don't really need Zapier.
+
+One warning from doing this myself: most track-everything setups die because the sheet just fills with noise and you stop opening it. Filtering hard up front, even just a keyword list or a similarity cutoff, matters more than the plumbing does.
+
+I should say I build a research-paper tool (Scholar Feed, an MCP server), so I'm biased toward the papers half. For general AI news it's honestly the wrong tool, RSS plus a summarize cron is what you want there.
+
+---
+
+## 2 · r/learnmachinelearning
+**Thread:** [What do you do when staying informed competes with actual work?](https://www.reddit.com/r/learnmachinelearning/comments/1qmnew3/)
+**Why:** Pain thread. Sell "calm," not FOMO. OP already mentions a tool (nbot), so tool mentions are welcome.
+
+- [ ] Posted
+
+What helped me was making it pull instead of push. I stopped browsing entirely. I keep a couple of narrow watches set up (specific labs, plus the two techniques my actual work depends on) and only look when one of them fires, which ends up being maybe twice a week instead of a daily anxiety scroll.
+
+Most of the FOMO turned out to be a precision thing. The large majority of the daily flood just isn't relevant to whatever you're building, you've only trained yourself to feel like you should read it.
+
+Since it's relevant: I build a tool that does the watch part inside Claude (Scholar Feed, CS/ML only). But the mindset change did more for me than the tool did. Haven't tried nbot, I'll take a look at it.
+
+---
+
+## 3 · r/MachineLearning
+**Thread:** [[D] What apps or workflows do you use to keep up with reading AI/ML papers regularly?](https://www.reddit.com/r/MachineLearning/comments/1n6ir0a/)
+**Why:** Recent, on-the-nose discovery + habit question.
+
+- [ ] Posted
+
+For finding papers, the thing that finally stuck was narrowing it to a few specific labs and a couple techniques instead of trying to follow a whole subfield. Scholar alerts are fine but noisy. Semantic Scholar's feed is a bit better since it's similarity based instead of keyword.
+
+The reading habit was harder and no tool really fixed it for me. What helped a little was killing the context switch. I stopped opening a pile of PDF tabs and started reading them in my editor, since the tab juggling was what kept breaking the habit.
+
+I'll admit some bias here, I built a small MCP server for that last part (Scholar Feed) that puts the search in Claude/Cursor next to whatever I'm writing. CS/ML only, free to try without an account. The narrowing-down part is the bit that actually mattered though, and that costs nothing.
+
+---
+
+## 4 · r/MachineLearning — evergreen (slow SEO, low live traffic)
+**Thread:** [[D] How do you keep up with the flood of new ML papers and avoid getting scooped?](https://www.reddit.com/r/MachineLearning/comments/1lhv42l/)
+**Why:** 11 months old. Ranks on Google for "keep up with ML papers." Comment compounds via search, not replies.
+
+- [ ] Posted
+
+There are kind of two separate problems tangled together here.
+
+Keeping up: scholar alerts and arxiv-sanity get noisy fast because they're keyword based, so you spend most of your time skimming near-misses. What actually helped me was tracking specific labs plus the two or three techniques my work depends on, instead of a whole area. Way fewer hits and they're mostly relevant. Semantic Scholar's feed does a decent free version of this.
+
+Getting scooped is more of a citation-graph thing than a feed thing imo. When something close to your idea shows up you want to see who's citing what, fast. Connected Papers and Research Rabbit are good for mapping a neighborhood once, but not for watching it over time.
+
+Full disclosure, that watch-it-over-time gap annoyed me enough that I ended up building a tool for it (Scholar Feed, it's an MCP server so it runs in Claude/Cursor). CS/ML only, and the search works without an account if you want to poke at it. But honestly the biggest fix was just narrowing what I track. The flood is mostly a precision problem.
+
+---
+
+## 5 · r/MachineLearning — evergreen
+**Thread:** [[D] What are your favorite tools for research?](https://www.reddit.com/r/MachineLearning/comments/1aml3w4/)
+**Why:** Tool-recommendation thread; ranks for "ML research tools." Short add to an existing list.
+
+- [ ] Posted
+
+Solid list. I'd throw in a couple specifically for the keeping-up side, since connectedpapers and consensus are more for when you already have a paper in hand.
+
+arxiv-sanity (Karpathy's) still works if you want a similarity feed of new stuff. And if you mostly live in Claude or Cursor, I built an MCP server (Scholar Feed) that puts arxiv search and citation tracing right in the editor so you're not tab hopping. CS/ML corpus only, free tier without an account.
+
+paperparrot looks interesting, hadn't come across that one. Stealing it for my own setup.
+
+---
+
+## 6 · r/MachineLearning — evergreen
+**Thread:** [[D] Favorite tips for staying up to date with AI/Deep Learning research and news?](https://www.reddit.com/r/MachineLearning/comments/122r3sr/)
+**Why:** Evergreen "how to keep up" thread (links Raschka's blog). Ranks on Google.
+
+- [ ] Posted
+
+That Raschka writeup is still the best thing on this topic honestly. The one thing I'd add a couple years later is that the tooling finally caught up to his point 4. Scholar alerts and PapersWithCode still hold up, but similarity feeds (Semantic Scholar, arxiv-sanity) beat keyword alerts now, mostly because you stop drowning in near misses.
+
+I went and built an MCP version of this so the search lives inside Claude/Cursor (Scholar Feed, CS/ML only, free without an account), so take that with the appropriate grain of salt. The habit part of his post is the genuinely hard part though, and I don't think any tool gets you out of that one.

--- a/docs/handoff/socials/reddit-organic.md
+++ b/docs/handoff/socials/reddit-organic.md
@@ -1,0 +1,138 @@
+# Reddit — organic comments + demo post
+
+Complements `launch-posts.md` (which holds the *announcement* posts: r/LocalLLaMA
+show-and-tell, Show HN, X, Discord). This file is the slower, lower-key organic
+layer: disclosed value-first **comments** on existing threads, and one
+**demo-driven post** in a different format than the announcement.
+
+## Operating rules (read once)
+
+- **Account:** use the aged 8-year personal account. Age clears the auto-spam
+  filters; 131 karma is fine for comments. Bank a little karma with no-link
+  helpful comments before the posts.
+- **Disclose every time.** "Full disclosure, I built this." On Reddit, disclosed
+  outperforms stealth, and stealth that gets caught is brand-poison.
+- **Corpus-fit filter:** Scholar Feed is CS/AI/ML only. Only recommend it where
+  the audience is CS/ML. In a field-agnostic thread, either hedge hard ("if
+  you're in CS/ML…") or skip. Recommending it to a historian is how you get
+  flagged.
+- **Comment > link-drop.** Lead by answering the actual question and naming real
+  alternatives (Connected Papers, Research Rabbit, Semantic Scholar, arxiv-sanity,
+  paperparrot) honestly. Mention Scholar Feed as one option, with its limits.
+- **Pace:** a few per week across subs, not a blitz. Don't link in every comment.
+- **You post manually** from your account. Run each draft through `/humanizer`
+  first (Reddit punishes AI tells harder than anywhere). I draft; you send.
+
+## Comment backlog (CS/ML-fit threads)
+
+| Thread | Sub | Status |
+|---|---|---|
+| [How do you keep up with the flood of new ML papers and avoid getting scooped?](https://old.reddit.com/r/MachineLearning/comments/1lhv42l/) | r/ML | drafted ↓ |
+| [What apps/workflows do you use to keep up with reading AI/ML papers?](https://old.reddit.com/r/MachineLearning/comments/1n6ir0a/) | r/ML | drafted ↓ |
+| [What are your favorite tools for research?](https://old.reddit.com/r/MachineLearning/comments/1aml3w4/) | r/ML | drafted ↓ |
+| [Favorite tips for staying up to date with AI/DL research?](https://old.reddit.com/r/MachineLearning/comments/122r3sr/) | r/ML | drafted ↓ |
+| [What do you do when staying informed competes with actual work?](https://old.reddit.com/r/learnmachinelearning/comments/1qmnew3/) | r/learnML | drafted ↓ |
+| [How do you automatically track new AI research into Notion/a spreadsheet?](https://old.reddit.com/r/MLQuestions/comments/1rpf0i6/) | r/MLQuestions | drafted ↓ (honest "wrong tool for news" angle) |
+
+Skipped (field-agnostic, corpus mismatch): r/AskAcademia "proper research tools
+HELP" (history major, wants images), "Do you track papers like books?".
+
+---
+
+## Comment drafts — humanized, send-ready
+
+Ran through /humanizer. The cross-comment tell mattered most: six comments from
+one account that all run advice → "Disclosure: I built X" → "but the real fix
+needs no tool" read as a template on a profile skim. So the disclosure wording
+and the closers are varied below. Post from your own account; don't paste all six
+the same day (that itself looks like a campaign).
+
+**Posting order — fresh/active threads first** (they're still getting traffic;
+old ones are slow SEO drip): 1) r/MLQuestions 1rpf0i6 · 2) r/learnML 1qmnew3 ·
+3) r/ML 1n6ir0a · then the three evergreen r/ML threads over the following week.
+Bank a couple of no-link helpful comments somewhere first.
+
+### r/ML — keep up / avoid getting scooped (1lhv42l)
+> There are kind of two separate problems tangled together here.
+>
+> Keeping up: scholar alerts and arxiv-sanity get noisy fast because they're keyword based, so you spend most of your time skimming near-misses. What actually helped me was tracking specific labs plus the two or three techniques my work depends on, instead of a whole area. Way fewer hits and they're mostly relevant. Semantic Scholar's feed does a decent free version of this.
+>
+> Getting scooped is more of a citation-graph thing than a feed thing imo. When something close to your idea shows up you want to see who's citing what, fast. Connected Papers and Research Rabbit are good for mapping a neighborhood once, but not for watching it over time.
+>
+> Full disclosure, that watch-it-over-time gap annoyed me enough that I ended up building a tool for it (Scholar Feed, it's an MCP server so it runs in Claude/Cursor). CS/ML only, and the search works without an account if you want to poke at it. But honestly the biggest fix was just narrowing what I track. The flood is mostly a precision problem.
+
+### r/ML — apps/workflows to track + actually read papers (1n6ir0a)
+> For finding papers, the thing that finally stuck was narrowing it to a few specific labs and a couple techniques instead of trying to follow a whole subfield. Scholar alerts are fine but noisy. Semantic Scholar's feed is a bit better since it's similarity based instead of keyword.
+>
+> The reading habit was harder and no tool really fixed it for me. What helped a little was killing the context switch. I stopped opening a pile of PDF tabs and started reading them in my editor, since the tab juggling was what kept breaking the habit.
+>
+> I'll admit some bias here, I built a small MCP server for that last part (Scholar Feed) that puts the search in Claude/Cursor next to whatever I'm writing. CS/ML only, free to try without an account. The narrowing-down part is the bit that actually mattered though, and that costs nothing.
+
+### r/ML — favorite tools for research (1aml3w4)
+> Solid list. I'd throw in a couple specifically for the keeping-up side, since connectedpapers and consensus are more for when you already have a paper in hand.
+>
+> arxiv-sanity (Karpathy's) still works if you want a similarity feed of new stuff. And if you mostly live in Claude or Cursor, I built an MCP server (Scholar Feed) that puts arxiv search and citation tracing right in the editor so you're not tab hopping. CS/ML corpus only, free tier without an account.
+>
+> paperparrot looks interesting, hadn't come across that one. Stealing it for my own setup.
+
+### r/ML — tips for staying up to date (122r3sr)
+> That Raschka writeup is still the best thing on this topic honestly. The one thing I'd add a couple years later is that the tooling finally caught up to his point 4. Scholar alerts and PapersWithCode still hold up, but similarity feeds (Semantic Scholar, arxiv-sanity) beat keyword alerts now, mostly because you stop drowning in near misses.
+>
+> I went and built an MCP version of this so the search lives inside Claude/Cursor (Scholar Feed, CS/ML only, free without an account), so take that with the appropriate grain of salt. The habit part of his post is the genuinely hard part though, and I don't think any tool gets you out of that one.
+
+### r/learnML — staying informed vs doing work (1qmnew3)
+> What helped me was making it pull instead of push. I stopped browsing entirely. I keep a couple of narrow watches set up (specific labs, plus the two techniques my actual work depends on) and only look when one of them fires, which ends up being maybe twice a week instead of a daily anxiety scroll.
+>
+> Most of the FOMO turned out to be a precision thing. The large majority of the daily flood just isn't relevant to whatever you're building, you've only trained yourself to feel like you should read it.
+>
+> Since it's relevant: I build a tool that does the watch part inside Claude (Scholar Feed, CS/ML only). But the mindset change did more for me than the tool did. Haven't tried nbot, I'll take a look at it.
+
+### r/MLQuestions — auto-track AI research into Notion/Sheet (1rpf0i6)
+*(Honest "partly the wrong tool" answer — builds credibility, post this one first.)*
+> For the papers side of this there are pretty clean inputs. arxiv has a per-category RSS/Atom feed you can pipe straight into a sheet, and Semantic Scholar's API will give you summaries. The compute and infra news side is messier since that's mostly blogs and press releases, so for that you'd want RSS plus an LLM summarize step. A little cron calling the OpenAI or Anthropic API into Notion does the job, you don't really need Zapier.
+>
+> One warning from doing this myself: most track-everything setups die because the sheet just fills with noise and you stop opening it. Filtering hard up front, even just a keyword list or a similarity cutoff, matters more than the plumbing does.
+>
+> I should say I build a research-paper tool (Scholar Feed, an MCP server), so I'm biased toward the papers half. For general AI news it's honestly the wrong tool, RSS plus a summarize cron is what you want there.
+
+---
+
+## Demo-driven post (NOT the announcement — a different format)
+
+The viral template proven by [r/artificial "I gave an AI coding agent access to 2M
+research papers"](https://old.reddit.com/r/artificial/comments/1s6afwm/) and
+[r/learnML "I was tired of drowning in arXiv so I built…"](https://old.reddit.com/r/learnmachinelearning/comments/1sdqztg/).
+Curiosity-gap title, a real demo with a concrete payoff, tool disclosed at the
+end. The payoff below is a **real** result from the live corpus (anonymous tools,
+reproducible by the reader), not a fabrication.
+
+**Best subs:** r/MachineLearning (flair `[P]`), r/artificial, r/LocalLLaMA.
+Check each sub's self-promo rules first; reply fast in comments (that's what
+carries it).
+
+**Title:**
+> I gave Claude a 600k-paper search index and asked for ways to shrink the LLM KV cache. It surfaced a paper arguing the cache shouldn't exist.
+
+**Body:**
+> I do a lot of literature review and got curious whether semantic search over a big paper corpus would beat my usual keyword-on-arXiv habit for finding non-obvious ideas. So I wired a 600k CS/AI/ML index into Claude (as an MCP server) and gave it a concrete, narrow problem: reduce the memory the KV cache eats during long-context inference.
+>
+> Keyword search for "KV cache compression" gives you the fifty papers literally titled that — quantization, eviction, low-rank, all incremental variations on "store the cache, but smaller."
+>
+> Semantic search surfaced three things I wouldn't have typed my way to:
+>
+> 1. **"The Residual Stream Is All You Need: On the Redundancy of the KV Cache"** (arXiv 2603.19664). It argues the cache is *redundant* rather than compressible — keys and values can be recomputed from the residual stream, and their scheme cuts peak memory ~59% while keeping 100% token match where baselines degrade. The interesting part is the framing: it never sells itself as "compression," so a keyword search for compression buries it.
+> 2. **HashEvict** (arXiv 2412.16187), which borrows locality-sensitive hashing straight from the classic hashing/`cs.DS` literature to decide what to evict pre-attention.
+> 3. A Shannon-limit **probabilistic-tries** approach (arXiv 2604.15356) pulling from information theory and delta coding.
+>
+> The pattern that stuck with me: the best idea for your problem is often filed under a word you didn't search. The "redundancy" paper is a different *concept* than "compression," so keyword matching can't reach it, but semantic search lands right on it. That's the case for letting an assistant search by meaning over a real corpus instead of you guessing keywords.
+>
+> Honest caveats: these are recent preprints with low citation counts, so treat the claims as unvetted (I haven't reproduced the 59% myself). The novelty scores I filtered on are LLM-generated, useful as a filter, not ground truth. Coverage is CS/AI/ML only.
+>
+> Disclosure: the index is a thing I built (Scholar Feed, an open-source MCP server). The search and orientation tools I used here run anonymously with no account, so if you want to reproduce the exact query: `npx scholar-feed-mcp init`, then ask it to orient on "memory-efficient KV cache" and search semantically for cross-domain approaches. Repo: github.com/YGao2005/scholar-feed-mcp. Genuinely curious whether other people's keyword habits are hiding better papers from them too.
+
+**Accuracy check before posting** (same discipline as launch-posts.md):
+- [ ] arXiv IDs correct: 2603.19664, 2412.16187, 2604.15356.
+- [ ] "~59% peak memory, 100% token match" matches the paper's abstract claim (it's *their* claim, stated as such).
+- [ ] Caveats paragraph kept (unvetted preprints, LLM novelty score, CS/ML-only).
+- [ ] Corpus = 600,000+, install = `npx scholar-feed-mcp init`, anonymous = no account.
+- [ ] Run through /humanizer. Flair correctly. Reply to comments fast.

--- a/docs/handoff/socials/social-preview-spec.md
+++ b/docs/handoff/socials/social-preview-spec.md
@@ -1,0 +1,86 @@
+# GitHub Social Preview Image Spec
+
+A spec for the 1280x640 image GitHub shows when the repo link is shared on X, Slack, Discord, LinkedIn, and in search/social cards. This is the single highest-leverage brand asset for the launch: it is the thumbnail every link unfurls into.
+
+## Why these dimensions
+
+GitHub renders the social preview at a 1.91:1 aspect ratio. 1280x640 is the recommended size (the minimum is 640x320 at the same ratio). Export as PNG (text and the logo stay sharp; JPG would soften the edges of the bar-logo). Keep the file under 1 MB; the hard ceiling GitHub accepts is 5 MB.
+
+Note: social cards get cropped differently across platforms. Keep all text and the logo inside a safe area with at least 80px of padding on every edge, and do not put anything load-bearing in the outer 60px.
+
+## Source assets to use
+
+From `assets/`:
+
+- `logo-light.svg` (or `logo-light.png`, 400x400) for the mark on a dark background. The logo is a stacked-bar "S" in white on the dark variant.
+- `logo-dark.svg` / `logo-dark.png` is the black-on-light variant. Only use this if you choose the light-background layout below.
+- `icon.png` (400x400) is the same mark sized for an app icon; use `logo-light`/`logo-dark` for the preview, not `icon.png`.
+
+The SVGs are vector, so prefer them when building in Figma or any vector tool: they scale to any size with no blur. The PNGs are 400x400, fine if placed at or below 200px on the canvas.
+
+## Layout (recommended: dark background)
+
+Canvas: 1280x640, solid dark background (near-black, e.g. `#0D1117`, GitHub's own dark canvas color, so the image feels native on the repo page).
+
+```
++---------------------------------------------------------------+
+|  [80px padding]                                               |
+|                                                               |
+|   [logo-light, ~140x140, top-left]                            |
+|                                                               |
+|   Scholar Feed MCP                       <- product name,     |
+|                                             ~72px bold        |
+|                                                               |
+|   Search 600,000+ CS/AI/ML papers        <- tagline,         |
+|   without leaving Claude Code or Cursor.    ~32px regular,    |
+|                                             muted gray        |
+|                                                               |
+|   25 tools  .  600,000+ papers  .  anonymous or free key      |
+|                                          <- fact strip,       |
+|                                             ~24px, mono       |
+|                                                               |
+|   github.com/YGao2005/scholar-feed-mcp   <- bottom-left,      |
+|                              [80px padding]  ~22px mono, muted |
++---------------------------------------------------------------+
+```
+
+Left-aligned everything. The logo sits top-left; name, tagline, fact strip, and repo URL stack down the left two-thirds. The right third stays empty (or holds a faint, large, low-opacity copy of the bar-logo as a watermark if you want texture). Empty space reads as confident; do not fill it with stock art.
+
+## Exact copy (use verbatim)
+
+- Product name: `Scholar Feed MCP`
+- Tagline (one line, or wrap to two as drawn above): `Search 600,000+ CS/AI/ML papers without leaving Claude Code or Cursor.`
+- Fact strip (use middots or vertical bars as separators, never dashes): `25 tools  .  600,000+ papers  .  anonymous or free key`
+- Footer: `github.com/YGao2005/scholar-feed-mcp`
+
+Do not add superlatives, "the best," exclamation points, or hype words. The facts carry it.
+
+## Type and color
+
+- Headline/name: a clean grotesque (Inter, Helvetica Neue, or system sans), bold weight.
+- Body/tagline: same family, regular weight, muted gray (e.g. `#8B949E`) so the name stays dominant.
+- Fact strip and footer: a monospace (JetBrains Mono, SF Mono, or any mono) to read as "this is a dev tool."
+- Keep to two type sizes of contrast minimum so the name clearly wins the hierarchy.
+
+If you prefer a light background, swap to `logo-dark`, use a near-white canvas (`#FFFFFF` or `#F6F8FA`), dark text (`#1F2328`), and a muted gray for the tagline. The dark layout is recommended because it matches how the mark was designed (the light logo is the white-on-dark variant) and looks better unfurled in dark-mode clients.
+
+## How to produce it
+
+Build the canvas in Figma, Canva (it has a 1280x640 GitHub-preview template), or any tool, then export PNG at exactly 1280x640. Drop the vector `logo-light.svg` in directly. Confirm the export is under 1 MB.
+
+Suggested filename: `assets/social-preview.png` (committing it to the repo keeps it versioned alongside the other brand files).
+
+## Where to upload it on GitHub
+
+Repository home -> `Settings` (top tab) -> `General` (default page) -> scroll to the `Social preview` section -> `Edit` / `Upload an image` -> select the 1280x640 PNG.
+
+The change is immediate on GitHub. External caches (X, Slack, Discord, LinkedIn) hold the old card for a while; to force a refresh, run the link through the platform's card debugger/validator after uploading, or just wait a few hours before the first launch post.
+
+## Pre-launch checklist
+
+- [ ] Exported at exactly 1280x640, PNG, under 1 MB.
+- [ ] Name, tagline, fact strip, and URL are all inside the 80px safe area.
+- [ ] Numbers match ground truth: 25 tools, 600,000+ papers.
+- [ ] No dashes used as punctuation anywhere in the copy.
+- [ ] Uploaded via Settings -> General -> Social preview.
+- [ ] Pasted the repo link into a throwaway DM/channel to confirm the card unfurls correctly.

--- a/docs/legal/privacy-policy.draft.md
+++ b/docs/legal/privacy-policy.draft.md
@@ -1,0 +1,112 @@
+<!--
+DRAFT for scholarfeed.org. Not committed to the MCP repo and not legal advice.
+Before publishing: have counsel review it, confirm the vendor list, and fill in
+every [BRACKETED] placeholder (jurisdiction, processors, effective date).
+Written to be accurate to how the service actually handles data as of 2026-06.
+-->
+
+# Privacy Policy
+
+**Effective date:** [DATE]
+
+Scholar Feed ("we", "us") operates the website at scholarfeed.org, the API at
+api.scholarfeed.org, and the `scholar-feed-mcp` client. This policy explains what
+we collect, why, and your choices.
+
+## The short version
+
+- You can use the research API anonymously (no account, no key). Anonymous use is
+  rate-limited and we record minimal request metadata to enforce that limit.
+- With a free or Pro account, we store your account details, your API usage, and
+  the library, collections, and watches you create.
+- We process the content of your requests (including search queries and the papers
+  you fetch or act on) to operate, secure, and improve the service.
+- We do not sell your personal information.
+
+## What we collect
+
+**Account data (accounts only).** Your email address and authentication details,
+your subscription tier and billing status, and the API keys you generate.
+
+**Content you create (accounts only).** Saved papers, collections, likes, and
+watches, which power your personalized feed and the email digest.
+
+**Usage and request data.** For each API call we log request metadata: the tool
+called, whether the call was anonymous or keyed, your account identifier (if any),
+the response status, a derived client identifier used for anonymous rate limiting,
+and a per-session identifier (see below). For some tools we also log the request
+content, such as the text of a search query or the arXiv identifier of a paper you
+fetch, so we can operate the service, debug it, measure which features are used,
+and improve relevance. Raw request logs are retained for up to 90 days; aggregated,
+de-identified usage counts are retained longer.
+
+**Session identifier.** The `scholar-feed-mcp` client generates a random identifier
+once per running process and sends it with each request (the `X-SF-Session` header)
+so we can group one assistant session's calls together. It is random, contains no
+personal or device information, and is not linked to your identity unless you are
+using an API key.
+
+**Payment data.** Subscription payments are handled by our payment processor
+[PAYMENT PROCESSOR]. We do not store full card numbers; we receive only the
+subscription status needed to grant access.
+
+## What the MCP client sends
+
+`scholar-feed-mcp` runs locally on your machine. It transmits your requests to
+api.scholarfeed.org, attaching your `SF_API_KEY` (if you set one) and the random
+session identifier above. Your API key is stored in your own MCP client's local
+configuration file, not by us beyond what is needed to authenticate the key. The
+client sends no other telemetry.
+
+## How we use data
+
+- Provide and secure the service, and enforce rate limits and quotas.
+- Operate accounts, subscriptions, and the email digest.
+- Personalize your feed and recommendations from the papers you save and like.
+- Understand which features are used and where results come up empty, to prioritize
+  improvements.
+
+## Sharing and processors
+
+We share data only with service providers that help us run the product, under
+agreements that limit their use of it:
+
+- Hosting and infrastructure: [HOSTING PROVIDER].
+- Database and authentication: [DATABASE PROVIDER].
+- Machine learning services for embeddings and summaries: [ML PROVIDERS].
+- Payments: [PAYMENT PROCESSOR].
+- Email delivery: [EMAIL PROVIDER].
+
+Paper metadata originates from public sources including arXiv. We do not sell your
+personal information. We may disclose data if required by law or to protect the
+service and its users.
+
+## Retention
+
+Raw API request logs are retained for up to 90 days, then deleted. Aggregated usage
+statistics, your account, and the content you create are retained for as long as
+your account is active or as needed to provide the service. You can delete your
+saved content at any time through the API or the website.
+
+## Your choices and rights
+
+- Use the API anonymously, without an account or key.
+- Access, export, or delete your account data by contacting us, subject to
+  applicable law. Depending on where you live, you may have rights under [GDPR /
+  CCPA / OTHER]; we honor verified requests.
+- Stop email digests using the unsubscribe link in any digest.
+- Remove your API key from your MCP configuration to return to anonymous use.
+
+## Children
+
+The service is not directed to children under [AGE], and we do not knowingly
+collect their personal information.
+
+## Changes
+
+We may update this policy. Material changes will be noted on this page with a new
+effective date.
+
+## Contact
+
+Questions or requests: hello@scholarfeed.org.

--- a/docs/legal/privacy-policy.md
+++ b/docs/legal/privacy-policy.md
@@ -1,0 +1,117 @@
+<!--
+Filled from privacy-policy.draft.md on 2026-06-03 with the operator's details.
+Not legal advice. Heroku as the hosting provider is inferred from project
+context; confirm or correct it.
+-->
+
+# Privacy Policy
+
+**Effective date:** June 3, 2026
+
+Scholar Feed ("we", "us"), operated by Yang Gao, an individual based in California,
+USA, provides the website at scholarfeed.org, the API at api.scholarfeed.org, and
+the `scholar-feed-mcp` client. This policy explains what we collect, why, and your
+choices.
+
+## The short version
+
+- You can use the research API anonymously (no account, no key). Anonymous use is
+  rate-limited and we record minimal request metadata to enforce that limit.
+- With a free or Pro account, we store your account details, your API usage, and
+  the library, collections, and watches you create.
+- We process the content of your requests (including search queries and the papers
+  you fetch or act on) to operate, secure, and improve the service.
+- We do not sell your personal information.
+
+## What we collect
+
+**Account data (accounts only).** Your email address and authentication details,
+your subscription tier and billing status, and the API keys you generate.
+
+**Content you create (accounts only).** Saved papers, collections, likes, and
+watches, which power your personalized feed and the email digest.
+
+**Usage and request data.** For each API call we log request metadata: the tool
+called, whether the call was anonymous or keyed, your account identifier (if any),
+the response status, a derived client identifier used for anonymous rate limiting,
+and a per-session identifier (see below). For some tools we also log the request
+content, such as the text of a search query or the arXiv identifier of a paper you
+fetch, so we can operate the service, debug it, measure which features are used,
+and improve relevance. Raw request logs are retained for up to 90 days; aggregated,
+de-identified usage counts are retained longer.
+
+**Session identifier.** The `scholar-feed-mcp` client generates a random identifier
+once per running process and sends it with each request (the `X-SF-Session` header)
+so we can group one assistant session's calls together. It is random, contains no
+personal or device information, and is not linked to your identity unless you are
+using an API key.
+
+**Payment data.** Subscription payments are handled by our payment processor,
+Stripe. We do not store full card numbers; we receive only the subscription status
+needed to grant access. Stripe's handling of your payment information is governed by
+Stripe's own privacy policy.
+
+## What the MCP client sends
+
+`scholar-feed-mcp` runs locally on your machine. It transmits your requests to
+api.scholarfeed.org, attaching your `SF_API_KEY` (if you set one) and the random
+session identifier above. Your API key is stored in your own MCP client's local
+configuration file, not by us beyond what is needed to authenticate the key. The
+client sends no other telemetry.
+
+## How we use data
+
+- Provide and secure the service, and enforce rate limits and quotas.
+- Operate accounts, subscriptions, and the email digest.
+- Personalize your feed and recommendations from the papers you save and like.
+- Understand which features are used and where results come up empty, to prioritize
+  improvements.
+
+## Sharing and processors
+
+We share data only with service providers that help us run the product, under
+agreements that limit their use of it:
+
+- Hosting and infrastructure: Heroku.
+- Database and authentication: Supabase.
+- Machine learning services: Google (the Gemini API) for text embeddings, and
+  DeepSeek for paper summaries. When you use a feature that calls these, the
+  relevant request content (for example the text you embed, or paper text we
+  summarize) is processed by that provider under its own terms.
+- Payments: Stripe.
+- Email delivery: Resend (which sends our digest mail from mail.scholarfeed.org).
+
+Paper metadata originates from public sources including arXiv. We do not sell your
+personal information. We may disclose data if required by law or to protect the
+service and its users.
+
+## Retention
+
+Raw API request logs are retained for up to 90 days, then deleted. Aggregated usage
+statistics, your account, and the content you create are retained for as long as
+your account is active or as needed to provide the service. You can delete your
+saved content at any time through the API or the website.
+
+## Your choices and rights
+
+- Use the API anonymously, without an account or key.
+- Access, export, or delete your account data by contacting us, subject to
+  applicable law. Depending on where you live, you may have rights under the EU or
+  UK GDPR (if you are in those regions) or the California Consumer Privacy Act
+  (CCPA, if you are a California resident); we honor verified requests.
+- Stop email digests using the unsubscribe link in any digest.
+- Remove your API key from your MCP configuration to return to anonymous use.
+
+## Children
+
+The service is not directed to children under 13, and we do not knowingly collect
+their personal information.
+
+## Changes
+
+We may update this policy. Material changes will be noted on this page with a new
+effective date.
+
+## Contact
+
+Questions or requests: yang@mail.scholarfeed.org.

--- a/docs/legal/terms-of-service.draft.md
+++ b/docs/legal/terms-of-service.draft.md
@@ -1,0 +1,102 @@
+<!--
+DRAFT for scholarfeed.org. Not committed to the MCP repo and not legal advice.
+Before publishing: have counsel review it and fill in every [BRACKETED]
+placeholder (legal entity, jurisdiction, effective date). Keep these terms
+consistent with the Privacy Policy; in particular do not promise that query
+content is never logged, since the Privacy Policy discloses that it may be.
+-->
+
+# Terms of Service
+
+**Effective date:** [DATE]
+
+These Terms govern your use of the Scholar Feed website (scholarfeed.org), API
+(api.scholarfeed.org), and the `scholar-feed-mcp` client (together, the "Service"),
+operated by [LEGAL ENTITY]. By using the Service you agree to these Terms.
+
+## The Service
+
+Scholar Feed provides search and analysis over a corpus of academic papers,
+including semantic search, citation and co-author graphs, full-text extraction,
+embeddings, and saved libraries, collections, and watches. Paper metadata is
+derived from public sources such as arXiv.
+
+## Accounts and API keys
+
+You may use the read API anonymously at a reduced rate limit. Higher limits and
+account features require a free or Pro account and an API key. You are responsible
+for keeping your API key confidential and for all activity under your account. Tell
+us promptly if you believe your key has been compromised.
+
+## Acceptable use
+
+You agree not to:
+
+- exceed, evade, or interfere with rate limits and quotas, or share a key to pool
+  quota across unrelated users;
+- scrape, bulk-export, or redistribute the corpus or the Service's outputs in order
+  to build or train a competing product;
+- attempt to disrupt, reverse engineer, or gain unauthorized access to the Service
+  or its infrastructure;
+- use the Service unlawfully or to infringe others' rights.
+
+We may suspend or terminate access that violates these Terms or threatens the
+Service.
+
+## Plans, billing, and changes
+
+Free and Pro tiers and their limits are described at scholarfeed.org. Paid
+subscriptions are billed through our payment processor on a recurring basis until
+cancelled, and access is granted for the period you have paid for. We may change
+features, limits, or pricing prospectively, with notice for material changes.
+
+## Content and intellectual property
+
+Paper titles, abstracts, and metadata belong to their respective authors and
+sources; the Service surfaces and analyzes them but claims no ownership of them.
+Machine-generated summaries, scores, and analyses are provided for convenience and
+may be inaccurate or incomplete. The Scholar Feed software, design, and branding
+remain ours. The `scholar-feed-mcp` client is provided under the MIT license in its
+repository; these Terms govern your use of the hosted Service it connects to.
+
+## Disclaimers
+
+THE SERVICE IS PROVIDED "AS IS" WITHOUT WARRANTIES OF ANY KIND. We do not warrant
+that results, summaries, novelty scores, or citation data are accurate, complete,
+or current, and they are not a substitute for your own review of the underlying
+papers. Availability and rate limits may change.
+
+## Limitation of liability
+
+To the maximum extent permitted by law, [LEGAL ENTITY] will not be liable for
+indirect, incidental, or consequential damages, or for lost profits or data,
+arising from your use of the Service. Our total liability for any claim is limited
+to the greater of the amount you paid us in the [12] months before the claim or
+[USD 100].
+
+## Privacy
+
+Your use of the Service is also governed by our [Privacy Policy](./privacy-policy).
+It describes the request metadata and content we process, including that we may log
+query content and the identifiers of papers you act on.
+
+## Termination
+
+You may stop using the Service at any time. We may suspend or end access for breach
+of these Terms or to protect the Service. Sections that by their nature should
+survive termination (intellectual property, disclaimers, limitation of liability)
+will survive.
+
+## Changes to these Terms
+
+We may update these Terms. Material changes will be posted here with a new effective
+date; continued use after that constitutes acceptance.
+
+## Governing law
+
+These Terms are governed by the laws of [JURISDICTION], without regard to conflict
+of law rules. Disputes will be resolved in the courts of [VENUE].
+
+## Contact
+
+Questions: hello@scholarfeed.org.

--- a/docs/legal/terms-of-service.md
+++ b/docs/legal/terms-of-service.md
@@ -1,0 +1,100 @@
+<!--
+Filled from terms-of-service.draft.md on 2026-06-03 with the operator's details.
+Not legal advice. Kept consistent with privacy-policy.md.
+-->
+
+# Terms of Service
+
+**Effective date:** June 3, 2026
+
+These Terms govern your use of the Scholar Feed website (scholarfeed.org), API
+(api.scholarfeed.org), and the `scholar-feed-mcp` client (together, the "Service"),
+operated by Yang Gao, an individual based in California, USA. By using the Service
+you agree to these Terms.
+
+## The Service
+
+Scholar Feed provides search and analysis over a corpus of academic papers,
+including semantic search, citation and co-author graphs, full-text extraction,
+embeddings, and saved libraries, collections, and watches. Paper metadata is
+derived from public sources such as arXiv.
+
+## Accounts and API keys
+
+You may use the read API anonymously at a reduced rate limit. Higher limits and
+account features require a free or Pro account and an API key. You are responsible
+for keeping your API key confidential and for all activity under your account. Tell
+us promptly if you believe your key has been compromised.
+
+## Acceptable use
+
+You agree not to:
+
+- exceed, evade, or interfere with rate limits and quotas, or share a key to pool
+  quota across unrelated users;
+- scrape, bulk-export, or redistribute the corpus or the Service's outputs in order
+  to build or train a competing product;
+- attempt to disrupt, reverse engineer, or gain unauthorized access to the Service
+  or its infrastructure;
+- use the Service unlawfully or to infringe others' rights.
+
+We may suspend or terminate access that violates these Terms or threatens the
+Service.
+
+## Plans, billing, and changes
+
+Free and Pro tiers and their limits are described at scholarfeed.org. Paid
+subscriptions are billed through our payment processor, Stripe, on a recurring basis
+until cancelled, and access is granted for the period you have paid for. We may
+change features, limits, or pricing prospectively, with notice for material changes.
+
+## Content and intellectual property
+
+Paper titles, abstracts, and metadata belong to their respective authors and
+sources; the Service surfaces and analyzes them but claims no ownership of them.
+Machine-generated summaries, scores, and analyses are provided for convenience and
+may be inaccurate or incomplete. The Scholar Feed software, design, and branding
+remain ours. The `scholar-feed-mcp` client is provided under the MIT license in its
+repository; these Terms govern your use of the hosted Service it connects to.
+
+## Disclaimers
+
+THE SERVICE IS PROVIDED "AS IS" WITHOUT WARRANTIES OF ANY KIND. We do not warrant
+that results, summaries, novelty scores, or citation data are accurate, complete,
+or current, and they are not a substitute for your own review of the underlying
+papers. Availability and rate limits may change.
+
+## Limitation of liability
+
+To the maximum extent permitted by law, Yang Gao will not be liable for indirect,
+incidental, or consequential damages, or for lost profits or data, arising from
+your use of the Service. Our total liability for any claim is limited to the greater
+of the amount you paid us in the 12 months before the claim or USD 100.
+
+## Privacy
+
+Your use of the Service is also governed by our [Privacy Policy](./privacy-policy).
+It describes the request metadata and content we process, including that we may log
+query content and the identifiers of papers you act on.
+
+## Termination
+
+You may stop using the Service at any time. We may suspend or end access for breach
+of these Terms or to protect the Service. Sections that by their nature should
+survive termination (intellectual property, disclaimers, limitation of liability)
+will survive.
+
+## Changes to these Terms
+
+We may update these Terms. Material changes will be posted here with a new effective
+date; continued use after that constitutes acceptance.
+
+## Governing law
+
+These Terms are governed by the laws of the State of California, USA, without regard
+to conflict of law rules. Disputes will be resolved in the state or federal courts
+located in Los Angeles County, California.
+
+## Contact
+
+Questions: yang@mail.scholarfeed.org.

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -161,24 +161,77 @@ describe("client error mapping", () => {
     await withStub({ status: 403, body }, {}, async () => {
       await assert.rejects(client.get("/watches"), (err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err);
-        // The backend's message wins over the generic 403 "Access denied" copy.
+        // The backend's message wins over the generic 403 conversion copy.
         assert.match(msg, /Pro lets you track more/);
-        assert.doesNotMatch(msg, /Access denied/);
+        assert.doesNotMatch(msg, /needs an account/);
         return true;
       });
     });
   });
 
-  it("ignores a half-formed envelope (message without error code → generic copy)", async () => {
-    // message-only is NOT a deliberate envelope; must not surface, to avoid
-    // leaking incidental error strings the backend didn't intend for users.
+  it("surfaces an RFC 7807 pro_required wall (detail + resolved upgrade_url)", async () => {
+    // The shape the backend actually returns today for an anon caller of a Pro
+    // tool. The human string lives in `detail` (not `message`); the relative
+    // upgrade_url must be resolved to an absolute scholarfeed.org link.
+    const body = JSON.stringify({
+      type: "about:blank",
+      title: "Forbidden",
+      status: 403,
+      detail:
+        "Text embeddings are a Pro feature. Start a free 14-day Pro trial or upgrade to keep using them.",
+      code: "pro_required",
+      error: "pro_required",
+      feature: "embeddings",
+      upgrade_url: "/pricing",
+    });
+    await withStub({ status: 403, body }, {}, async () => {
+      await assert.rejects(client.post("/public/embeddings", {}), (err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        assert.match(msg, /Pro feature/);
+        assert.match(msg, /14-day Pro trial/);
+        // Relative "/pricing" resolved to an absolute link.
+        assert.match(msg, /https:\/\/www\.scholarfeed\.org\/pricing/);
+        assert.doesNotMatch(msg, /needs an account/);
+        return true;
+      });
+    });
+  });
+
+  it("gives a bare 403 (Not authenticated / forbidden) a real conversion CTA", async () => {
+    // gaps/ask anon return code:"forbidden", detail:"Not authenticated" — NOT a
+    // value-carrying wall, so we suppress the weak detail and emit the curated
+    // account CTA instead (signup URL + how to wire the key).
+    const body = JSON.stringify({
+      status: 403,
+      detail: "Not authenticated",
+      code: "forbidden",
+    });
+    await withStub({ status: 403, body }, {}, async () => {
+      await assert.rejects(client.get("/gaps"), (err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        assert.match(msg, /needs an account/);
+        assert.match(msg, /scholarfeed\.org\/settings/);
+        assert.match(msg, /SF_API_KEY/);
+        // Don't relay the weak/internal "Not authenticated" detail verbatim.
+        assert.doesNotMatch(msg, /Not authenticated/);
+        return true;
+      });
+    });
+  });
+
+  it("does NOT surface a bare detail on an internal error (no business code)", async () => {
+    // A JSON 500 with a detail but no business code / upgrade_url must fall
+    // through to the generic copy — never leak the internal string.
     await withStub(
-      { status: 403, body: JSON.stringify({ message: "raw internal detail" }) },
+      {
+        status: 500,
+        body: JSON.stringify({ detail: "raw internal detail", code: "internal_error" }),
+      },
       {},
       async () => {
         await assert.rejects(client.get("/x"), (err: unknown) => {
           const msg = err instanceof Error ? err.message : String(err);
-          assert.match(msg, /Access denied/);
+          assert.match(msg, /HTTP 500/);
           assert.doesNotMatch(msg, /raw internal detail/);
           return true;
         });

--- a/src/client.ts
+++ b/src/client.ts
@@ -92,35 +92,105 @@ function requestHeaders(extra: Record<string, string>): Record<string, string> {
   };
 }
 
+const SITE_URL = "https://www.scholarfeed.org";
+
+/**
+ * Resolve a backend CTA/upgrade URL to an absolute scholarfeed.org link. The API
+ * returns relative paths (e.g. `upgrade_url: "/pricing"`); absolute URLs pass
+ * through unchanged.
+ */
+function resolveUpgradeUrl(raw: unknown): string | null {
+  if (typeof raw !== "string" || raw.length === 0) return null;
+  if (/^https?:\/\//i.test(raw)) return raw;
+  return `${SITE_URL}${raw.startsWith("/") ? "" : "/"}${raw}`;
+}
+
+/**
+ * Business-rule codes whose human-facing string is authored FOR the end user (a
+ * conversion / quota / upgrade wall) and is therefore safe and intended to relay
+ * to the model. Explicit set plus the `_required` / `_exceeded` / `_limit`
+ * suffixes, so a new quota code is covered without a client release. Generic
+ * internal codes (e.g. `forbidden`, `internal_error`) are deliberately excluded
+ * so their `detail` falls through to the curated status-based copy below.
+ */
+const BUSINESS_CODES = new Set([
+  "pro_required",
+  "payment_required",
+  "watch_limit",
+  "quota_exceeded",
+  "rate_limited",
+  "free_tier_limit",
+  "monthly_limit",
+]);
+
+function isBusinessCode(code: string): boolean {
+  return (
+    BUSINESS_CODES.has(code) ||
+    code.endsWith("_required") ||
+    code.endsWith("_exceeded") ||
+    code.endsWith("_limit")
+  );
+}
+
 /**
  * Surface a deliberate, user-facing error envelope from the backend.
  *
- * The API returns `{ error, message }` for intentional business-rule walls —
- * e.g. a quota/cap hit that carries an upgrade prompt ("Free tier includes 1
- * watch. Pro lets you track more — scholarfeed.org/upgrade"). We surface
- * `message` verbatim so the agent relays it to the user.
+ * The API marks intentional business-rule walls two ways: the legacy
+ * `{ error, message }` pairing, and the RFC 7807 problem+json shape it actually
+ * emits today — `{ detail, code, upgrade_url, ... }` (e.g. an anonymous caller of
+ * a Pro tool gets `code: "pro_required", detail: "Text embeddings are a Pro
+ * feature. Start a free 14-day Pro trial…", upgrade_url: "/pricing"`). We surface
+ * that human string verbatim — plus the resolved CTA URL — so the agent relays a
+ * real next step to the user instead of a dead end. (Before this, the client only
+ * recognized `{ error, message }`, so every RFC 7807 conversion prompt was
+ * discarded and replaced by the generic "Access denied" copy — the funnel's
+ * worst leak: engaged anonymous users hit a Pro tool and saw no way forward.)
  *
- * Only when BOTH `error` (a machine code) and `message` (the human string) are
- * present: that pairing marks an intentional, safe-to-show envelope. Plain or
- * unstructured error bodies still fall through to the generic status-based
- * messages, so we never leak internal error detail to the model.
+ * A body is treated as a wall ONLY when it carries a recognized business code, an
+ * explicit `upgrade_url`, or the legacy error+message pair. A bare `detail` /
+ * `message` on an internal error is NOT surfaced, so we never leak incidental
+ * internal error strings to the model.
  */
 function structuredBackendMessage(body: string): string | null {
   if (!body) return null;
+  let parsed: unknown;
   try {
-    const parsed: unknown = JSON.parse(body);
-    if (
-      parsed !== null &&
-      typeof parsed === "object" &&
-      typeof (parsed as Record<string, unknown>).error === "string" &&
-      typeof (parsed as Record<string, unknown>).message === "string"
-    ) {
-      return (parsed as { message: string }).message;
-    }
+    parsed = JSON.parse(body);
   } catch {
     // Body isn't JSON — fall through to the status-based messages.
+    return null;
   }
-  return null;
+  if (parsed === null || typeof parsed !== "object") return null;
+  const obj = parsed as Record<string, unknown>;
+
+  // The machine code may live in RFC 7807 `code` or the legacy `error` field.
+  const code =
+    (typeof obj.code === "string" && obj.code) ||
+    (typeof obj.error === "string" && obj.error) ||
+    null;
+  const upgradeUrl = resolveUpgradeUrl(obj.upgrade_url);
+  const legacyPair =
+    typeof obj.error === "string" && typeof obj.message === "string";
+
+  const isWall =
+    legacyPair || upgradeUrl !== null || (code !== null && isBusinessCode(code));
+  if (!isWall) return null;
+
+  // Prefer the legacy `message`, else the RFC 7807 `detail`.
+  const human =
+    typeof obj.message === "string"
+      ? obj.message
+      : typeof obj.detail === "string"
+        ? obj.detail
+        : null;
+  if (!human) return null;
+
+  // Append the CTA URL when the backend gave one and the message doesn't already
+  // point somewhere — so the agent always has a concrete next step.
+  if (upgradeUrl && !human.includes(upgradeUrl) && !/scholarfeed\.org/i.test(human)) {
+    return `${human} (${upgradeUrl})`;
+  }
+  return human;
 }
 
 class ScholarFeedClient {
@@ -298,8 +368,14 @@ class ScholarFeedClient {
             "Check your key at https://www.scholarfeed.org/settings",
         );
       case 403:
+        // The most common 403 is an anonymous caller hitting an account- or
+        // Pro-gated tool — the highest-intent conversion moment. Give a concrete
+        // path forward (account → key → config) rather than a dead end.
         throw new Error(
-          "Access denied. You may need a valid API key for this endpoint.",
+          "This Scholar Feed tool needs an account. Create a free one at " +
+            "https://www.scholarfeed.org/settings — it includes a 14-day Pro " +
+            "trial (no card) plus free daily paper watches — then set the key as " +
+            "SF_API_KEY in your MCP config (or run `npx scholar-feed-mcp@latest init`).",
         );
       case 429:
         throw new Error(


### PR DESCRIPTION
## The leak
Fresh `usage_events` (last 7d): ~10 anonymous hosted-MCP clients ran the deep loop (5–9 tools), ≥2 hit the `find_gaps` 403 (the Pro paywall), one returned across 4 days — and **0 converted**. The conversion moment fires; nobody converts.

## Root cause
The backend speaks RFC 7807 (`{detail, code, upgrade_url}`) — e.g. anon `/public/embeddings` returns `detail: "Text embeddings are a Pro feature. Start a free 14-day Pro trial… ", upgrade_url: "/pricing"`. But `structuredBackendMessage()` only recognized the legacy `{error, message}` pair, so **every conversion prompt was discarded** and replaced by the dead-end generic `"Access denied. You may need a valid API key."`

## Fix
- `structuredBackendMessage()` now recognizes RFC 7807 business-rule walls (`pro_required` / `*_required` / `*_exceeded` / `*_limit` / explicit `upgrade_url`), surfaces the human `detail`, and appends the resolved absolute CTA URL — while still refusing to relay bare `detail` on internal errors (no leak).
- generic 403 → a real account CTA (free signup + 14-day no-card Pro trial + free includes 1 watch + `npx scholar-feed-mcp@latest init`).
- tests: +RFC7807 `pro_required` path, +bare-403 CTA, +internal-error no-leak. **301 pass; typecheck + lint clean.**

Publishing is tag-triggered OIDC CI — bump the version to release once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)