### PR TITLE
feat(search): expose traction/adoption filters + sort=community in search_papers

### DIFF
--- a/src/tools/_output.ts
+++ b/src/tools/_output.ts
@@ -68,6 +68,7 @@ const paperObject = z
     primary_category: z.string().optional(),
     has_code: z.boolean().optional(),
     github_url: z.string().nullable().optional(),
+    github_stars: z.number().nullable().optional(),
     citation_count: z.number().optional(),
     venue_name: z.string().nullable().optional(),
     llm_summary: z.string().nullable().optional(),

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -22,7 +22,7 @@ export function register(server: McpServer): void {
       annotations: { readOnlyHint: true, destructiveHint: false },
       outputSchema: papersOutput,
       description:
-        "Search Scholar Feed's 600k+ CS/AI/ML paper corpus. Defaults to semantic (embedding) search — finds conceptually related papers even when the user's wording doesn't match the paper's title/abstract. Pass mode='keyword' for exact-string full-text search. CAVEAT: semantic search often misses old high-citation CANONICAL papers (e.g. foundational anchors like H2O for KV eviction, GRIT for unified embedding+generation) because the ranker prefers recent stylistically-matched papers. If you're hunting the canonical anchor for an area, parse the top-5 result abstracts for baseline mentions ('we compare against X, Y, Z'), then look the most-mentioned name up directly. Returns papers with LLM-generated summaries, novelty scores, and structured extraction data. Default response is a lean 14-field shape (arxiv_id, title, authors, year, categories, has_code, github_url, citation_count, venue_name, llm_summary, llm_significance, llm_novelty_score, impact_pct, impact_tier) — pass verbose=true or fields=... for the full shape with method/task/dataset extraction. RANKING BY IMPACT — two different notions, don't confuse them: (1) PROVEN impact = citations. For 'the important/seminal papers on topic X', pass sort='impactful' (most-cited among the relevant) or sort='balanced' (relevant AND well-cited). This is the right tool for established/foundational work. (2) FORECAST impact = impact_pct (0-100), an ML per-category percentile of PREDICTED citations, only computed for the last ~90 days; impact_tier is its A+/A/B/C/D grade. For 'what's rising/new in X' pass sort='trending' or filter impact_min=N — but NOTE impact_pct is NULL on everything older than ~90 days, so impact_min DROPS all established/canonical papers (it is NOT a way to find the influential papers in a niche — use sort='impactful' for that). Both impact notions are distinct from llm_novelty_score (new-idea-ness, an orthogonal filter). Supports filtering by category, novelty, recency, method, task, dataset, and contribution type. v3 ABSORPTIONS: pass sort='trending' to rank by rising/forecast impact (impact_pct); pass anchor_paper_id to replicate find_similar (q is ignored in anchor mode, results carry similarity_score); pass scope_to_citations_of to restrict search to a paper's citation graph (replaces find_citations_about).",
+        "Search Scholar Feed's 600k+ CS/AI/ML paper corpus. Defaults to semantic (embedding) search — finds conceptually related papers even when the user's wording doesn't match the paper's title/abstract. Pass mode='keyword' for exact-string full-text search. CAVEAT: semantic search often misses old high-citation CANONICAL papers (e.g. foundational anchors like H2O for KV eviction, GRIT for unified embedding+generation) because the ranker prefers recent stylistically-matched papers. If you're hunting the canonical anchor for an area, parse the top-5 result abstracts for baseline mentions ('we compare against X, Y, Z'), then look the most-mentioned name up directly. Returns papers with LLM-generated summaries, novelty scores, and structured extraction data. Default response is a lean 14-field shape (arxiv_id, title, authors, year, categories, has_code, github_url, citation_count, venue_name, llm_summary, llm_significance, llm_novelty_score, impact_pct, impact_tier) — pass verbose=true or fields=... for the full shape with method/task/dataset extraction. RANKING BY IMPACT — two different notions, don't confuse them: (1) PROVEN impact = citations. For 'the important/seminal papers on topic X', pass sort='impactful' (most-cited among the relevant) or sort='balanced' (relevant AND well-cited). This is the right tool for established/foundational work. (2) FORECAST impact = impact_pct (0-100), an ML per-category percentile of PREDICTED citations, only computed for the last ~90 days; impact_tier is its A+/A/B/C/D grade. For 'what's rising/new in X' pass sort='trending' or filter impact_min=N — but NOTE impact_pct is NULL on everything older than ~90 days, so impact_min DROPS all established/canonical papers (it is NOT a way to find the influential papers in a niche — use sort='impactful' for that). Both impact notions are distinct from llm_novelty_score (new-idea-ness, an orthogonal filter). (3) ADOPTION impact = GitHub traction. Pass sort='community' to rank by real-world engineering adoption (stars + star-velocity) — the papers practitioners are actually running/building on, independent of citations or recency. Filter on it with min_stars=N (minimum GitHub stars) and has_code=true (only papers with a code release); has_code/min_stars surface RUNNABLE/ADOPTED work, the engineering counterpart to citations. github_url_exists=true is the stricter has_code (requires a linked repo). Supports filtering by category, novelty, recency, method, task, dataset, and contribution type — plus min_citations (minimum PROVEN citations, keeps established papers unlike the ~90-day impact_min) and an explicit date window via published_after / published_before ('YYYY-MM-DD', vs days' rolling lookback). v3 ABSORPTIONS: pass sort='trending' to rank by rising/forecast impact (impact_pct); pass anchor_paper_id to replicate find_similar (q is ignored in anchor mode, results carry similarity_score); pass scope_to_citations_of to restrict search to a paper's citation graph (replaces find_citations_about).",
       inputSchema: {
         q: z
           .string()
@@ -32,10 +32,17 @@ export function register(server: McpServer): void {
             "Search query keywords. Optional when anchor_paper_id is set (anchor mode ignores q and returns papers similar to the anchor).",
           ),
         sort: z
-          .enum(["relevance", "balanced", "impactful", "trending", "recent"])
+          .enum([
+            "relevance",
+            "balanced",
+            "impactful",
+            "trending",
+            "recent",
+            "community",
+          ])
           .optional()
           .describe(
-            "Result ranking — a relevance↔impact dial plus two time-based orders. 'relevance' (default) = best topical match. 'balanced' = relevant AND well-cited. 'impactful' = the most-cited (proven-influential) papers among those relevant to the query — use this for 'the important/seminal papers on topic X'. 'trending' = rising/FORECAST impact (impact_pct, last ~90 days) — use for 'what's hot/new in X', NOT for established work. 'recent' = newest first. Proven impact ('impactful'/'balanced') ranks by real citations; 'trending' is a model prediction. Pair with get_foundational_lineage for a topic's canonical roots.",
+            "Result ranking — a relevance↔impact dial plus time-based and adoption orders. 'relevance' (default) = best topical match. 'balanced' = relevant AND well-cited. 'impactful' = the most-cited (proven-influential) papers among those relevant to the query — use this for 'the important/seminal papers on topic X'. 'trending' = rising/FORECAST impact (impact_pct, last ~90 days) — use for 'what's hot/new in X', NOT for established work. 'recent' = newest first. 'community' = GitHub adoption (stars + star-velocity) — surfaces the papers practitioners are actually running/building on, regardless of citations or recency. Proven impact ('impactful'/'balanced') ranks by real citations; 'trending' is a model prediction; 'community' is real-world engineering traction. Pair with get_foundational_lineage for a topic's canonical roots.",
           ),
         anchor_paper_id: z
           .string()
@@ -75,6 +82,46 @@ export function register(server: McpServer): void {
           .max(3650)
           .optional()
           .describe("Limit to papers published within N days"),
+        has_code: z
+          .boolean()
+          .optional()
+          .describe(
+            "Filter to papers with a linked code release (has_code=true). Surfaces runnable/reproducible work — pair with min_stars/sort='community' to find the papers practitioners actually adopt.",
+          ),
+        min_citations: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe(
+            "Minimum real citation count. Unlike impact_min (a ~90-day FORECAST percentile), this filters on PROVEN citations and keeps established/canonical papers.",
+          ),
+        min_stars: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe(
+            "Minimum GitHub stars on the paper's linked repo. A proxy for engineering adoption — surfaces work that practitioners are actually running/building on. Pair with sort='community' to rank by it.",
+          ),
+        github_url_exists: z
+          .boolean()
+          .optional()
+          .describe(
+            "Filter on whether the paper has a linked GitHub URL (true = only papers with a repo). Stricter than has_code (which counts any code link).",
+          ),
+        published_after: z
+          .string()
+          .optional()
+          .describe(
+            "Only papers published on or after this date, 'YYYY-MM-DD'. Use with published_before to bound an arbitrary date window (days only gives a rolling N-day lookback).",
+          ),
+        published_before: z
+          .string()
+          .optional()
+          .describe(
+            "Only papers published on or before this date, 'YYYY-MM-DD'. Pair with published_after for an explicit window.",
+          ),
         method_category: z
           .string()
           .optional()
@@ -176,6 +223,12 @@ export function register(server: McpServer): void {
       novelty_min,
       impact_min,
       days,
+      has_code,
+      min_citations,
+      min_stars,
+      github_url_exists,
+      published_after,
+      published_before,
       method_category,
       method_name,
       task,
@@ -202,6 +255,16 @@ export function register(server: McpServer): void {
         if (novelty_min !== undefined) params.novelty_min = String(novelty_min);
         if (impact_min !== undefined) params.impact_min = String(impact_min);
         if (days !== undefined) params.days = String(days);
+        if (has_code !== undefined) params.has_code = String(has_code);
+        if (min_citations !== undefined)
+          params.min_citations = String(min_citations);
+        if (min_stars !== undefined) params.min_stars = String(min_stars);
+        if (github_url_exists !== undefined)
+          params.github_url_exists = String(github_url_exists);
+        if (published_after !== undefined)
+          params.published_after = published_after;
+        if (published_before !== undefined)
+          params.published_before = published_before;
         if (method_category !== undefined)
           params.method_category = method_category;
         if (method_name !== undefined) params.method_name = method_name;


### PR DESCRIPTION
Forwards the new backend factual filters so an agent can narrow to runnable/adopted work and rank by community traction. Pairs with `scholar-feed#<backend PR>`.

## Changes
- **`search.ts`** — new optional params: `has_code`, `min_citations`, `min_stars`, `github_url_exists`, `published_after/before`; new `sort='community'` (GitHub stars + star-velocity). All threaded to `GET /public/papers/search`. Tool description updated; the relevance↔impact dial untouched (`community` is additive).
- **`_output.ts`** — `github_stars` added to the paper shape.

Inert until the backend PR ships the params + the GitHub-stars backfill runs. Build verified (`npm run build` + `tsc --noEmit` green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)