### PR TITLE
Fix search_papers sort output schema

### DIFF
--- a/src/__tests__/output_schema.test.ts
+++ b/src/__tests__/output_schema.test.ts
@@ -1,23 +1,31 @@
 /**
  * Output-schema contract tests.
  *
- * Two guarantees, both aimed at the MCP SDK's `validateToolOutput`
- * (server/mcp.js), which THROWS on a successful call when a tool declares an
- * `outputSchema` but returns no `structuredContent`, or returns one that fails
- * the schema:
+ * A declared `outputSchema` is enforced on every SUCCESSFUL call in TWO places
+ * that disagree about unknown keys, so this file checks BOTH:
  *
- *   1. every registered tool declares a non-empty `outputSchema`, and
- *   2. each tool's SUCCESS path returns a `structuredContent` that validates
- *      against that schema.
+ *   1. every registered tool declares a non-empty `outputSchema`;
+ *   2. SERVER-side (`server/mcp.js validateToolOutput` → `safeParseAsync`): each
+ *      tool's success path returns `structuredContent` that parses. Zod STRIPS
+ *      unknown keys here, so this check is lenient by construction;
+ *   3. CLIENT-side (`client/index.js callTool`, and the Python SDK's
+ *      `_validate_tool_result`): the PUBLISHED JSON Schema must accept the same
+ *      payload. `z.object()` emits `additionalProperties: false`, which REJECTS
+ *      undeclared keys the server just stripped;
+ *   4. end-to-end through the real SDK client over an in-memory transport — the
+ *      ground truth for 2+3 together.
  *
- * We replicate the SDK's check exactly — `z.object(outputSchema).safeParse(...)`
- * on the raw shape — so a green run here means the live server will not raise
- * "Output validation error" for these shapes.
+ * Checks 3 and 4 exist because relying on 2 alone let issue #42 ship: the
+ * backend began echoing `sort` on every search response, the server-side strip
+ * hid it, and every validating client failed the call.
  */
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { registerAllTools } from "../tools/index.js";
 import {
   makeFakeServer,
@@ -64,18 +72,69 @@ async function invoke(
   }
 }
 
-/** Validate structuredContent the way the SDK does: z.object(shape).safeParse. */
+/**
+ * Normalize a declared outputSchema to a Zod object the way the SDK's
+ * `getZodSchemaObject` does — the shapes are exported pre-wrapped as loose
+ * ZodObjects, but a bare raw shape is still accepted.
+ */
+function asZodObject(schema: unknown): z.ZodType {
+  return schema instanceof z.ZodType
+    ? schema
+    : z.object(schema as z.ZodRawShape);
+}
+
+/**
+ * Validate structuredContent the way the SERVER does (mcp.js
+ * `validateToolOutput` → safeParseAsync). NOTE this is the LENIENT of the two
+ * checks: zod STRIPS unknown keys, so this alone cannot catch an undeclared
+ * field. `assertClientAccepts` below covers that.
+ */
 function validate(name: string, sc: unknown): void {
   const tool = TOOLS.get(name);
   assert.ok(tool?.outputSchema, `${name} must declare an outputSchema`);
-  const schema = z.object(tool.outputSchema as z.ZodRawShape);
-  const parsed = schema.safeParse(sc);
+  const parsed = asZodObject(tool.outputSchema).safeParse(sc);
   assert.ok(
     parsed.success,
     `${name} structuredContent must satisfy its outputSchema: ${
       parsed.success ? "" : JSON.stringify(parsed.error.issues)
     }`,
   );
+}
+
+/**
+ * Validate structuredContent the way a STRICT CLIENT does — against the
+ * PUBLISHED JSON Schema, not the server-side zod object.
+ *
+ * This is the check that issue #42 needed and the server-side one cannot
+ * provide: `z.object()` emits `additionalProperties: false`, so a client
+ * (TS SDK `callTool`, or the Python SDK's `_validate_tool_result`) REJECTS a
+ * response carrying an undeclared key even though the server happily stripped
+ * it and returned success. The backend echoed `sort` on every search response
+ * and every validating client broke.
+ */
+function assertClientAccepts(name: string, sc: Record<string, unknown>): void {
+  const tool = TOOLS.get(name);
+  assert.ok(tool?.outputSchema, `${name} must declare an outputSchema`);
+  const js = z.toJSONSchema(asZodObject(tool.outputSchema), {
+    io: "output",
+    unrepresentable: "any",
+  }) as {
+    additionalProperties?: unknown;
+    properties?: Record<string, unknown>;
+  };
+
+  if (js.additionalProperties === false) {
+    const undeclared = Object.keys(sc).filter(
+      (k) => !(k in (js.properties ?? {})),
+    );
+    assert.deepStrictEqual(
+      undeclared,
+      [],
+      `${name} publishes additionalProperties:false and its own response carries ` +
+        `undeclared key(s) [${undeclared.join(", ")}] — a validating client would ` +
+        `reject this successful call (see issue #42).`,
+    );
+  }
 }
 
 describe("every tool declares a non-empty outputSchema", () => {
@@ -86,9 +145,39 @@ describe("every tool declares a non-empty outputSchema", () => {
         "object",
         `${name} must declare an outputSchema`,
       );
+      const js = z.toJSONSchema(asZodObject(def.outputSchema), {
+        io: "output",
+        unrepresentable: "any",
+      }) as { properties?: Record<string, unknown> };
       assert.ok(
-        Object.keys(def.outputSchema ?? {}).length > 0,
+        Object.keys(js.properties ?? {}).length > 0,
         `${name} outputSchema must declare at least one field`,
+      );
+    });
+  }
+});
+
+/**
+ * The structural guard for issue #42: a tool's published output schema must not
+ * forbid unknown top-level keys. The backend is a separate service that adds
+ * response fields without notice; with `additionalProperties: false` each such
+ * addition turns every successful call into a client-side validation error.
+ * `_output.ts` wraps every shape in `looseObject()` to hold this — reverting one
+ * to a bare `{...}` shape fails here.
+ */
+describe("published output schemas accept unknown backend keys", () => {
+  for (const [name, def] of TOOLS) {
+    it(`${name} does not publish additionalProperties:false`, () => {
+      const js = z.toJSONSchema(asZodObject(def.outputSchema), {
+        io: "output",
+        unrepresentable: "any",
+      }) as { additionalProperties?: unknown };
+      assert.notStrictEqual(
+        js.additionalProperties,
+        false,
+        `${name} forbids unknown top-level keys, so any new backend response ` +
+          `field breaks every validating client (issue #42). Wrap the shape in ` +
+          `looseObject() in _output.ts.`,
       );
     });
   }
@@ -432,8 +521,115 @@ describe("tool success paths return schema-valid structuredContent", () => {
         `${label} must return structuredContent`,
       );
       validate(name, result.structuredContent);
+      assertClientAccepts(
+        name,
+        result.structuredContent as Record<string, unknown>,
+      );
     });
   }
+});
+
+/**
+ * The end-to-end guard: drive a real McpServer with the real Client over an
+ * in-memory transport, so BOTH the server-side zod parse and the client-side
+ * JSON Schema validation run exactly as they do in production.
+ *
+ * This is the test that reproduces issue #42 directly. With `search_papers`
+ * registered under a schema that forbids unknown keys, `callTool` throws
+ * "Structured content does not match the tool's output schema" even though the
+ * search succeeded and the server returned valid data.
+ */
+describe("a real SDK client accepts the search_papers response", () => {
+  /** Register one tool with the given schema + payload; return callTool's outcome. */
+  async function roundTrip(
+    outputSchema: unknown,
+    structuredContent: Record<string, unknown>,
+  ): Promise<{ ok: boolean; error?: string; additionalProperties?: unknown }> {
+    const server = new McpServer({ name: "test", version: "0.0.0" });
+    server.registerTool(
+      "probe",
+      {
+        description: "probe",
+        inputSchema: {},
+        outputSchema: outputSchema as never,
+      },
+      async () => ({
+        content: [{ type: "text" as const, text: "ok" }],
+        structuredContent,
+      }),
+    );
+    const client = new Client({ name: "test-client", version: "0.0.0" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await Promise.all([
+      server.connect(serverTransport),
+      client.connect(clientTransport),
+    ]);
+    const listed = (await client.listTools()) as {
+      tools: Array<{ outputSchema?: { additionalProperties?: unknown } }>;
+    };
+    const additionalProperties =
+      listed.tools[0]?.outputSchema?.additionalProperties;
+    try {
+      await client.callTool({ name: "probe", arguments: {} });
+      return { ok: true, additionalProperties };
+    } catch (error) {
+      return {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+        additionalProperties,
+      };
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  }
+
+  // The exact shape the live backend returns — `sort` is echoed on EVERY search
+  // response, including when no sort argument was passed.
+  const SEARCH_RESPONSE = {
+    papers: [PAPER],
+    total: 1,
+    page: 1,
+    limit: 20,
+    mode: "semantic",
+    sort: "trending",
+    next_cursor: null,
+  };
+
+  it("passes with the shipped papersOutput schema", async () => {
+    const { ok, error, additionalProperties } = await roundTrip(
+      TOOLS.get("search_papers")?.outputSchema,
+      SEARCH_RESPONSE,
+    );
+    assert.notStrictEqual(
+      additionalProperties,
+      false,
+      "papersOutput must not publish additionalProperties:false",
+    );
+    assert.ok(ok, `real SDK client rejected a valid search response: ${error}`);
+  });
+
+  it("reproduces #42 when the envelope forbids unknown keys", async () => {
+    // Same payload, but a strict envelope that omits `sort` — i.e. the pre-fix
+    // schema. This asserts the failure mode is real, so the guard above cannot
+    // pass for the wrong reason.
+    const strict = {
+      papers: z.array(z.unknown()).optional(),
+      total: z.number().optional(),
+      page: z.number().optional(),
+      limit: z.number().optional(),
+      mode: z.string().optional(),
+      next_cursor: z.string().nullable().optional(),
+    };
+    const { ok, error, additionalProperties } = await roundTrip(
+      strict,
+      SEARCH_RESPONSE,
+    );
+    assert.strictEqual(additionalProperties, false);
+    assert.strictEqual(ok, false);
+    assert.match(String(error), /does not match the tool's output schema/);
+  });
 });
 
 describe("the bundled affordance text is preserved alongside structuredContent", () => {

--- a/src/__tests__/output_schema.test.ts
+++ b/src/__tests__/output_schema.test.ts
@@ -118,9 +118,15 @@ const CASES: Array<{
   {
     label: "search_papers",
     name: "search_papers",
-    args: { q: "x", page: 1, limit: 20 },
+    args: { q: "x", page: 1, limit: 20, sort: "trending" },
     opts: {
-      json: { papers: [PAPER], total: 1, next_cursor: null, mode: "semantic" },
+      json: {
+        papers: [PAPER],
+        total: 1,
+        next_cursor: null,
+        mode: "semantic",
+        sort: "trending",
+      },
     },
   },
   {
@@ -193,7 +199,8 @@ const CASES: Array<{
     // surface unresolved/unscored namesakes whose bibliometrics + scores are
     // explicit JSON null. zod .optional() rejects null, so this exact shape threw
     // "Output validation error" until the author fields became .nullable().
-    label: "find_author q-mode with NULL bibliometrics/scores (unscored namesake)",
+    label:
+      "find_author q-mode with NULL bibliometrics/scores (unscored namesake)",
     name: "find_author",
     args: { q: "Friston", limit: 20 },
     opts: {

--- a/src/tools/_output.ts
+++ b/src/tools/_output.ts
@@ -105,6 +105,7 @@ export const papersOutput = {
   page: z.number().optional(),
   limit: z.number().optional(),
   mode: z.string().optional().describe("Search mode actually applied."),
+  sort: z.string().optional().describe("Search sort order actually applied."),
   direction: z
     .string()
     .optional()

--- a/src/tools/_output.ts
+++ b/src/tools/_output.ts
@@ -7,24 +7,51 @@
  * because the backend response shape is owned by a separate service and evolves
  * (lean vs verbose paper shapes, new extraction fields, paginated envelopes).
  *
- * Why permissive matters: the MCP SDK validates `structuredContent` against the
- * declared schema on every SUCCESSFUL call (server/mcp.js `validateToolOutput`)
- * and THROWS on a mismatch. Zod objects strip unknown keys instead of rejecting
- * them, so the only way to fail is a DECLARED field present with the wrong type.
- * Keeping every field optional + loosely typed means a benign backend addition
- * can never turn into a hard tool error. The original `structuredContent` is sent
- * on the wire unchanged (validation does not mutate it), so the stripping is a
- * gate, not a filter — extra fields still reach the client.
+ * Why permissive matters: the declared schema is validated on every SUCCESSFUL
+ * call, in TWO places that behave DIFFERENTLY on an unknown key:
+ *
+ *   - SERVER (mcp.js `validateToolOutput`) runs `safeParseAsync`, and a zod
+ *     object STRIPS unknown keys — so an extra key passes here.
+ *   - CLIENT (client/index.js `callTool`, and the Python SDK's
+ *     `_validate_tool_result`) validates against the PUBLISHED JSON SCHEMA with
+ *     a jsonschema validator. `z.object()` emits `additionalProperties: false`,
+ *     so an extra key is REJECTED there and the whole call fails.
+ *
+ * That asymmetry is why issue #42 shipped: the backend started echoing `sort`
+ * on every search response, the server-side strip hid it, and every strict
+ * client broke. A schema that merely lists today's keys is therefore not enough
+ * — the ENVELOPE ITSELF must accept unknown keys, because the backend response
+ * shape is owned by a separate service and adds fields without notice.
+ *
+ * So every exported shape below is wrapped in `looseObject()`, which emits
+ * `additionalProperties: {}`. Declared fields still carry types + descriptions
+ * (that is the machine-readable contract); undeclared ones ride along instead of
+ * turning a successful search into a client-side hard error. Keep every declared
+ * field optional + loosely typed for the same reason.
  *
  * The text `content` is unchanged, so clients that ignore `structuredContent`
  * see no difference; clients that read it get typed, machine-usable output.
  *
- * Shapes are exported as raw Zod shapes (plain objects of validators) — the same
- * form `inputSchema` uses, and the form `registerTool` expects for `outputSchema`
- * (mcp.js `getZodSchemaObject` → `objectFromShape`).
+ * `registerTool` accepts either a raw shape or a full Zod schema for
+ * `outputSchema` (mcp.js `getZodSchemaObject`), so passing the wrapped objects
+ * is a drop-in. Do NOT "simplify" these back to bare `{...}` shapes — that
+ * silently restores `additionalProperties: false` and re-opens #42. The
+ * output_schema contract test asserts this and will fail if you do.
  */
 
 import { z } from "zod";
+
+/**
+ * Wrap a raw shape so the emitted JSON Schema allows unknown top-level keys
+ * (`additionalProperties: {}`) instead of forbidding them. See the file header:
+ * a bare `z.object()` is what broke #42 for every validating client.
+ *
+ * Exported so a tool that declares its own output shape locally (check_drift)
+ * gets the same guarantee — pass every `outputSchema` through this.
+ */
+export function looseObject<T extends z.ZodRawShape>(shape: T) {
+  return z.object(shape).catchall(z.unknown());
+}
 
 /**
  * Coerce an arbitrary backend payload into a JSON object for `structuredContent`
@@ -90,10 +117,13 @@ const paperObject = z
 /**
  * Shared envelope for every tool that returns a `papers` array:
  * search_papers, get_citations, get_field_orientation, list_library,
- * check_watches. Unknown top-level keys (e.g. an endpoint's own wrapper) are
- * stripped, not rejected, so this fits all of them.
+ * check_watches. Unknown top-level keys (e.g. an endpoint's own wrapper) ride
+ * along rather than failing the call, so this fits all of them.
+ *
+ * Kept as a raw shape so `getPaperOutput` can spread it; the wrapped export is
+ * `papersOutput` below.
  */
-export const papersOutput = {
+const papersShape = {
   papers: z
     .array(paperObject)
     .optional()
@@ -128,18 +158,20 @@ export const papersOutput = {
   results: z.array(paperObject).optional(),
 };
 
+export const papersOutput = looseObject(papersShape);
+
 /** get_paper: the papers envelope, plus the bibtex / status keys for format='bibtex'. */
-export const getPaperOutput = {
-  ...papersOutput,
+export const getPaperOutput = looseObject({
+  ...papersShape,
   bibtex: z.string().optional().describe("BibTeX entry (format='bibtex')."),
   count: z.number().optional(),
   format: z.string().optional(),
   ok: z.boolean().optional(),
   message: z.string().optional(),
-};
+});
 
 /** fetch_fulltext: lean `results_text` mode and the full `sections` object mode. */
-export const fulltextOutput = {
+export const fulltextOutput = looseObject({
   source: z
     .string()
     .optional()
@@ -163,7 +195,7 @@ export const fulltextOutput = {
     .optional()
     .describe("Per-section text (sections='all')."),
   table_captions: z.array(z.string()).optional(),
-};
+});
 
 const lineagePaper = z
   .object({
@@ -180,7 +212,7 @@ const lineagePaper = z
   .catchall(z.unknown());
 
 /** get_foundational_lineage: the three citation-graph tiers (nested under `tiers`). */
-export const lineageOutput = {
+export const lineageOutput = looseObject({
   anchor: z.string().optional(),
   scope: z.string().optional(),
   niche_size: z.number().optional(),
@@ -198,7 +230,7 @@ export const lineageOutput = {
   field_level: z.array(lineagePaper).optional(),
   discipline: z.array(lineagePaper).optional(),
   note: z.string().nullable().optional(),
-};
+});
 
 const authorObject = z
   .object({
@@ -219,7 +251,7 @@ const authorObject = z
   .catchall(z.unknown());
 
 /** find_author: polymorphic — q-mode list envelope OR id-mode flat profile. */
-export const authorOutput = {
+export const authorOutput = looseObject({
   // q-mode envelope
   query: z.string().optional(),
   search_type: z.string().optional(),
@@ -241,10 +273,10 @@ export const authorOutput = {
     .array(paperObject)
     .optional()
     .describe("Top papers by rank (id-mode profile)."),
-};
+});
 
 /** co_author_graph: co-authorship edges. */
-export const coAuthorGraphOutput = {
+export const coAuthorGraphOutput = looseObject({
   queried_author_ids: z.array(z.number()).optional(),
   window_years: z.number().optional(),
   edge_count: z.number().optional(),
@@ -263,10 +295,10 @@ export const coAuthorGraphOutput = {
     .describe(
       "Co-authorship edges {from, to, papers_count, last_collab_year}.",
     ),
-};
+});
 
 /** embed_text: the embedding vector + model metadata. */
-export const embedOutput = {
+export const embedOutput = looseObject({
   embedding: z
     .array(z.number())
     .optional()
@@ -275,10 +307,10 @@ export const embedOutput = {
   task_type: z.string().optional(),
   dimensions: z.number().optional(),
   dims: z.number().optional(),
-};
+});
 
 /** preview_watch: dry-run summary of a structured filter. */
-export const previewWatchOutput = {
+export const previewWatchOutput = looseObject({
   window_days: z.number().optional(),
   needs_similarity: z.boolean().optional(),
   match_count: z.number().optional(),
@@ -288,10 +320,10 @@ export const previewWatchOutput = {
     .describe("A sample of matching papers."),
   ok: z.boolean().optional(),
   message: z.string().optional(),
-};
+});
 
 /** list_collections: the user's named collections. */
-export const collectionsListOutput = {
+export const collectionsListOutput = looseObject({
   collections: z
     .array(
       z
@@ -305,10 +337,10 @@ export const collectionsListOutput = {
     .optional(),
   ok: z.boolean().optional(),
   message: z.string().optional(),
-};
+});
 
 /** list_watches: the user's standing watches. */
-export const watchesListOutput = {
+export const watchesListOutput = looseObject({
   watches: z
     .array(
       z
@@ -325,10 +357,10 @@ export const watchesListOutput = {
     .optional(),
   ok: z.boolean().optional(),
   message: z.string().optional(),
-};
+});
 
 /** find_gaps: the two gap buckets. */
-export const gapsOutput = {
+export const gapsOutput = looseObject({
   foundational_gaps: z
     .array(paperObject)
     .optional()
@@ -339,10 +371,10 @@ export const gapsOutput = {
     .describe("Recent high-novelty work you haven't saved."),
   ok: z.boolean().optional(),
   message: z.string().optional(),
-};
+});
 
 /** ask_library: the synthesized answer + grounding. */
-export const askLibraryOutput = {
+export const askLibraryOutput = looseObject({
   answer: z
     .string()
     .optional()
@@ -351,10 +383,10 @@ export const askLibraryOutput = {
   papers: z.array(paperObject).optional(),
   ok: z.boolean().optional(),
   message: z.string().optional(),
-};
+});
 
 /** Shared shape for the status / mutation tools (save, like, watch/collection writes). */
-export const statusOutput = {
+export const statusOutput = looseObject({
   ok: z.boolean().optional().describe("True when the operation succeeded."),
   message: z
     .string()
@@ -375,4 +407,4 @@ export const statusOutput = {
     .unknown()
     .optional()
     .describe("The created/affected watch, when applicable."),
-};
+});

--- a/src/tools/check_drift.ts
+++ b/src/tools/check_drift.ts
@@ -20,11 +20,12 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { client } from "../client.js";
 import { fencePaperContent } from "./_untrusted.js";
-import { asStructuredObject } from "./_output.js";
+import { asStructuredObject, looseObject } from "./_output.js";
 
-// Permissive output shape (all-optional, loose) covering both modes — unknown
-// keys are stripped, never rejected, so a backend addition can't hard-fail.
-const driftOutput = {
+// Permissive output shape (all-optional, loose) covering both modes. looseObject
+// keeps unknown keys out of the PUBLISHED schema's additionalProperties, so a
+// backend addition can't hard-fail a validating client (see _output.ts / #42).
+const driftOutput = looseObject({
   family: z.string().optional(),
   label: z.string().optional(),
   description: z.string().optional(),
@@ -51,7 +52,7 @@ const driftOutput = {
   stats: z.record(z.string(), z.unknown()).optional(),
   message: z.string().optional(),
   note: z.string().optional(),
-};
+});
 
 export function register(server: McpServer): void {
   server.registerTool(


### PR DESCRIPTION
## Summary
- declare the `sort` field in the shared papers output schema used by `search_papers`
- cover the reported `sort: "trending"` structuredContent shape in the output schema contract test

Fixes #42

## Validation
- npm ci
- node --import tsx --test src/__tests__/output_schema.test.ts
- npm test
- npm run typecheck
- npm run format:check
- git diff --check