### PR TITLE
Reposition the listings on ranking + citations, and stop two agent dead-ends

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,13 @@
+# Node for THIS package only (mise applies it on cd into this directory).
+#
+# Why 24 when the published package supports >=18: `wrangler` — the Cloudflare
+# Workers CLI used by `npm run worker:dev|dryrun|deploy` — refuses to start on
+# anything below Node 22. The machine default is node 20, so a worker deploy
+# failed with "Wrangler requires at least Node.js v22.0.0" until this pin.
+#
+# This does NOT change what the npm package supports. package.json `engines` stays
+# ">=18.0.0" and CI still tests the 18/20/22 matrix (.github/workflows/ci.yml) —
+# the stdio build is what npm ships, and it targets node18 via tsup. This pin only
+# governs the local toolchain in this directory.
+[tools]
+node = "24"

--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@
 [![License: MIT](https://img.shields.io/npm/l/scholar-feed-mcp.svg)](./LICENSE)
 [![smithery badge](https://smithery.ai/badge/yangg40/scholar-feed)](https://smithery.ai/servers/yangg40/scholar-feed)
 
-Search 600,000+ CS/AI/ML research papers with LLM-generated novelty analysis, without leaving Claude Code, Cursor, or any MCP client. Built for researchers running a literature review where they already work: search, trace citations, pull full text, and export BibTeX in the same session.
+Research paper search with ranking and citation tracking, for LLM engineering and academic research, without leaving Claude Code, Cursor, or any MCP client.
 
-[Scholar Feed](https://www.scholarfeed.org) indexes arXiv papers daily and ranks them using a multi-signal scoring system (recency, citation velocity, institutional reputation, code availability). Each paper has an LLM-generated summary and novelty score.
+Most paper tools hand back a flat list. Scholar Feed ranks it: sort by relevance, by proven citation count, or by rising impact, then trace any paper's citation lineage forward and backward across 22M+ edges. 600k+ CS/AI/ML papers, updated daily, each with an LLM-generated summary and novelty score.
+
+[Scholar Feed](https://www.scholarfeed.org) indexes arXiv papers daily and ranks them on recency, citation velocity, institutional reputation, and code availability.
 
 ## Quick Start
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "scholar-feed-mcp",
   "mcpName": "io.github.YGao2005/scholar-feed-mcp",
   "version": "3.13.0",
-  "description": "MCP server for Scholar Feed: search 600,000+ CS/AI/ML papers with LLM-powered analysis",
+  "description": "Search 600k+ CS/AI/ML papers with ranking and citation tracking: sort by relevance, citations, or rising impact, trace citation lineage, pull full text and BibTeX",
   "type": "module",
   "license": "MIT",
   "author": "Scholar Feed <hello@scholarfeed.org>",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.YGao2005/scholar-feed-mcp",
   "title": "Scholar Feed",
-  "description": "600,000+ CS/AI/ML papers in your AI assistant: search, novelty scores, citations, daily watches.",
+  "description": "Search 600k+ CS/AI/ML papers with ranking and citation tracking over 22M+ citation edges.",
   "version": "3.9.1",
   "websiteUrl": "https://www.scholarfeed.org",
   "repository": {

--- a/src/__tests__/handlers.test.ts
+++ b/src/__tests__/handlers.test.ts
@@ -133,6 +133,83 @@ describe("search_papers handler", () => {
   it("no longer exposes has_results in its schema", () => {
     assert.ok(!("has_results" in schemaFor("search_papers")));
   });
+
+  // The backend 422s these shapes (public.py _BROWSE_SORTS / _BROWSE_MAX_OFFSET).
+  // Guard them client-side so the model gets an actionable message, not a round-trip.
+  it("q-less browse sorts are allowed through (trending/recent/impactful)", async () => {
+    for (const sort of ["trending", "recent", "impactful"]) {
+      const { url, result } = await invoke("search_papers", {
+        sort,
+        page: 1,
+        limit: 20,
+      });
+      assert.ok(url, `${sort} should reach the backend`);
+      assert.notStrictEqual(result.isError, true);
+      assert.strictEqual(url.searchParams.get("sort"), sort);
+    }
+  });
+
+  it("q-less with no sort errors locally without calling the backend", async () => {
+    const { calls, result } = await invoke("search_papers", {
+      page: 1,
+      limit: 20,
+    });
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(calls.length, 0, "must not round-trip a known-422");
+    assert.match(String(result.content[0].text), /q is required/);
+  });
+
+  it("q-less sort=community errors locally (not a browse sort)", async () => {
+    const { calls, result } = await invoke("search_papers", {
+      sort: "community",
+      page: 1,
+      limit: 20,
+    });
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(calls.length, 0);
+  });
+
+  it("q-less with filters only errors locally (filters don't substitute for q)", async () => {
+    const { calls, result } = await invoke("search_papers", {
+      category: "cs.AI",
+      days: 7,
+      page: 1,
+      limit: 20,
+    });
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(calls.length, 0);
+  });
+
+  it("q-less browse past offset 200 errors locally", async () => {
+    const { calls, result } = await invoke("search_papers", {
+      sort: "trending",
+      page: 12,
+      limit: 20,
+    });
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(calls.length, 0);
+    assert.match(String(result.content[0].text), /200 results/);
+  });
+
+  it("q-less browse AT the offset-200 boundary is allowed", async () => {
+    const { url, result } = await invoke("search_papers", {
+      sort: "trending",
+      page: 11,
+      limit: 20,
+    });
+    assert.ok(url, "offset exactly 200 must still reach the backend");
+    assert.notStrictEqual(result.isError, true);
+  });
+
+  it("anchor mode still works without q", async () => {
+    const { url, result } = await invoke("search_papers", {
+      anchor_paper_id: "2407.15831",
+      page: 1,
+      limit: 20,
+    });
+    assert.ok(url);
+    assert.notStrictEqual(result.isError, true);
+  });
 });
 
 describe("get_paper handler", () => {

--- a/src/tools/check_drift.ts
+++ b/src/tools/check_drift.ts
@@ -68,8 +68,9 @@ export function register(server: McpServer): void {
           .string()
           .min(1)
           .max(60)
+          .optional()
           .describe(
-            "Builder-problem family to query, e.g. 'rag' (retrieval-augmented generation), 'peft' (parameter-efficient fine-tuning), 'kvcache' (KV-cache compression). Query with an unknown family (e.g. 'list') to get the live list of available families.",
+            "Builder-problem family to query, e.g. 'rag' (retrieval-augmented generation), 'peft' (parameter-efficient fine-tuning), 'kvcache' (KV-cache compression). Omit it (or pass an unknown family like 'list') to get the live list of available families to pick from — start here if you don't know the family for a method.",
           ),
         method: z
           .string()
@@ -91,8 +92,12 @@ export function register(server: McpServer): void {
     },
     async ({ family, method, limit }) => {
       try {
+        // family is optional: when omitted, send the "list" sentinel the backend
+        // already answers with the available-families list (a graceful 200, same as
+        // an unknown family) instead of a 422. An agent that knows a method but not
+        // its family can call with method alone and get the picker, not an error.
         const params: Record<string, string> = {
-          family,
+          family: family && family.trim() ? family.trim() : "list",
           limit: String(limit),
         };
         if (method && method.trim()) {

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -29,7 +29,7 @@ export function register(server: McpServer): void {
           .min(1)
           .optional()
           .describe(
-            "Search query keywords. REQUIRED unless anchor_paper_id or scope_to_citations_of is set (anchor mode ignores q and returns papers similar to the anchor). sort= alone is NOT a substitute: it reranks the matches for q, so a sort without q is an error, not a topic-free feed. For 'what's hot in AI right now', pass a broad q (e.g. 'machine learning') plus sort='trending'.",
+            "Search query keywords. REQUIRED unless (a) anchor_paper_id or scope_to_citations_of is set (anchor mode ignores q and returns papers similar to the anchor), or (b) sort is one of 'trending' / 'recent' / 'impactful' — the query-less 'browse the frontier' feed, which is capped to the FIRST 200 RESULTS (paging past offset 200 is a 422; narrow with q= or filters instead). Any other q-less call is a 422, INCLUDING a q-less call with only filters (category/days/...) and a q-less sort='community'. Filters alone do NOT substitute for q — pair them with a browse sort (e.g. category='cs.AI' + sort='recent') or pass q. For 'what's hot in AI right now', either sort='trending' alone or a broad q plus sort='trending' works.",
           ),
         sort: z
           .enum([
@@ -244,6 +244,42 @@ export function register(server: McpServer): void {
       exclude_ids,
     }) => {
       try {
+        // Fail fast on the q-less shapes the backend 422s, with a message that says
+        // what to do instead. 275 such 422s in 14d of prod MCP traffic (40 distinct
+        // clients) — the model spends a round-trip to learn a rule we already know.
+        // Mirrors public.py's _BROWSE_SORTS / _BROWSE_MAX_OFFSET; keep in sync.
+        const BROWSE_SORTS = ["trending", "recent", "impactful"];
+        const browseMode =
+          !q && sort !== undefined && BROWSE_SORTS.includes(sort);
+        if (!q && anchor_paper_id === undefined && !browseMode) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text:
+                  `Error: q is required here. Pass q=<keywords>, or for a topic-free feed use ` +
+                  `sort=one of ${BROWSE_SORTS.join("/")} (capped to the first 200 results). ` +
+                  `Note: filters alone (category/days/...) and sort='community' do NOT allow a ` +
+                  `q-less call — combine them with q or a browse sort.`,
+              },
+            ],
+            isError: true,
+          };
+        }
+        if (browseMode && (page - 1) * limit > 200) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text:
+                  `Error: query-less browse is capped at the first 200 results ` +
+                  `(page ${page} x limit ${limit} exceeds it). Pass q= or narrow with filters to page deeper.`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
         const params: Record<string, string> = {};
         if (q !== undefined) params.q = q;
         if (sort !== undefined) params.sort = sort;


### PR DESCRIPTION
## Why

Every listing led with "600,000+ papers". That is the commodity claim, and it loses head-to-head against a 200M-paper competitor sitting next to us in the MCP registry. Lead instead with what search alone does not give you: ranking and citation tracking.

Verified on prod 2026-07-30 that the claim is real (`relevance` / `impactful` / `balanced` / `trending` return four distinct, coherent result sets for one query) and that the numbers hold:

| claim | measured |
|---|---|
| papers | 664,806 |
| citation edges | 22,919,324 |
| semantically indexed | 664,694 (99.98%) |
| corpus freshness | newest paper 2026-07-29 |

Kept "600k+" rather than the exact count so the untouched files that also cite it do not drift. `server.json`'s new description is 89 chars against the registry schema's 100-char `maxLength`.

## Two agent dead-ends

**`search_papers`** declared `q` optional with no guard, while the description still claimed "a sort without q is an error" — false since the backend added query-less browse for `trending`/`recent`/`impactful`. That cost **275 x 422 in 14 days of prod MCP traffic across 40 clients**, each a wasted round-trip to learn a rule we already know locally. Now the description is correct and the client fails fast on all three rejected shapes (no-sort, filters-only, `sort=community`) plus the offset-200 browse cap, with a message saying what to do instead. Mirrors `public.py`'s `_BROWSE_SORTS` / `_BROWSE_MAX_OFFSET` — keep them in sync.

**`check_drift`** required `family`, so the most natural call an agent makes (`method` with no `family`) 422'd. It is now optional and sends the `"list"` sentinel the backend already answers with the available-families list. Verified end-to-end against prod: that call returns the picker instead of an error.

## Verification

- `npm run typecheck` clean
- **355/355** tests pass
- `format:check` clean
- New guard assertions were mutation-tested: neutering the guard fails 4 tests, flipping the offset boundary `>` to `>=` fails 1

## Note

This branch also carries the pre-existing local commit `7fc3833` (pin node 24 for the Workers CLI), which was unpushed on `main` when I branched.