### PR TITLE
Accept total: null so query-less browse returns results, not -32602

### DIFF
--- a/src/__tests__/output_schema.test.ts
+++ b/src/__tests__/output_schema.test.ts
@@ -219,6 +219,28 @@ const CASES: Array<{
     },
   },
   {
+    // Query-less browse: the backend returns an EXPLICIT `total: null` (the
+    // best-effort count is skipped), not an omitted key. A non-nullable
+    // `total: z.number().optional()` therefore failed output validation on every
+    // browse call and surfaced as an opaque MCP -32602 rather than results. The
+    // fixture above uses total: 1, which is why a number-only schema passed CI
+    // while the live browse path was broken. Keep BOTH shapes covered.
+    label: "search_papers query-less browse (total: null)",
+    name: "search_papers",
+    args: { page: 1, limit: 20, sort: "trending" },
+    opts: {
+      json: {
+        papers: [PAPER],
+        total: null,
+        next_cursor: null,
+        mode: "keyword",
+        sort: "trending",
+        page: 1,
+        limit: 20,
+      },
+    },
+  },
+  {
     label: "get_paper json",
     name: "get_paper",
     args: { arxiv_ids: ["A"] },

--- a/src/tools/_output.ts
+++ b/src/tools/_output.ts
@@ -127,10 +127,19 @@ const papersShape = {
     .array(paperObject)
     .optional()
     .describe("Matched / returned papers."),
+  // NULLABLE, not just optional: the backend returns an explicit `total: null`
+  // whenever the count is skipped rather than omitting the key — the query-less
+  // browse path (sort=trending/recent/impactful) and any search whose count query
+  // hits its 3s statement_timeout both do this. A non-nullable number therefore
+  // failed output validation on every browse call ("expected number, received
+  // null") and surfaced as an opaque MCP -32602 instead of results.
   total: z
     .number()
+    .nullable()
     .optional()
-    .describe("Total results available for the query."),
+    .describe(
+      "Total results available for the query. null when the count was skipped (query-less browse, or the count query timed out).",
+    ),
   page: z.number().optional(),
   limit: z.number().optional(),
   mode: z.string().optional().describe("Search mode actually applied."),


### PR DESCRIPTION
## The bug

The backend returns an **explicit** `total: null` whenever it skips the best-effort count. The query-less browse path (`sort=trending`/`recent`/`impactful`) always does, and any search whose count query hits its 3s `statement_timeout` does too.

The output schema had `total: z.number().optional()`, which accepts a **missing** key but rejects a **present null**. So the SDK failed output validation on every browse call:

```
MCP error -32602: Output validation error: Invalid structured content for tool search_papers:
  expected "number", received null, path: ["total"]
```

Verified live on `mcp.scholarfeed.org` before this fix:

| call | backend `total` | result |
|---|---|---|
| `search_papers(sort=trending)` no `q` | `null` | **-32602, no results** |
| `search_papers(q="attention")` | `60019` | 200, results |

## Why it shipped green

This was latent until query-less browse became reachable in #47. The only `search_papers` output fixture used `total: 1`, a number, so a number-only schema passed CI while the live browse path was broken.

Fix is `.nullable()` on `total`, plus a second fixture using the real browse shape (`total: null`, `mode: keyword`) so both shapes stay covered.

## Verification

- `356/356` tests, typecheck clean, prettier clean
- **Mutation-checked:** dropping `.nullable()` again fails exactly the new case (`search_papers query-less browse (total: null)`), and nothing else. The test genuinely discriminates.

## Note

`search_papers` query-less browse is broken on the currently published 3.13.1. The tool advertises the mode and #47's guard correctly lets it through to the backend, where it then dies on output validation. This needs a follow-up patch release to reach users.