### PR TITLE
Bump codeql-action to v4.37.3 (init + analyze together)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,13 +25,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           # No compiled build needed for TS — analyze from source.
           build-mode: none
           queries: security-extended
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Dependabot split one bump into two PRs — #40 (`init`) and #39 (`analyze`) — that target the **same file** and the **same SHA**. Neither can pass alone, because CodeQL requires `init` and `analyze` to run the same version:

```
Loaded a configuration file for version '4.37.3', but running version '4.36.1'
```

Both PRs were failing on exactly that, which is why they sat open since 2026-07-14. Applying both pins in one commit is the whole fix.

Closes #39
Closes #40