### PR TITLE
Relay watch_limit walls and the backend's upgrade_url to the agent

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -278,17 +278,57 @@ describe("client error mapping", () => {
     await withStub({ status: 403, body }, { SF_API_KEY: "sf_ok" }, async () => {
       await assert.rejects(client.get("/x"), (err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err);
-        // Plain substring check, not a regex: this asserts the CTA is PRESENT in an
-        // error string, and an unanchored host pattern trips CodeQL's
-        // js/regex/missing-regexp-anchor (a fair rule — it would be wrong for URL
-        // validation, and includes() says what we actually mean here).
+        // Assert the exact suffix rather than "contains a URL": CodeQL flags both an
+        // unanchored host regex and a bare includes() on a URL (js/regex/missing-
+        // regexp-anchor, js/incomplete-url-substring-sanitization) because neither
+        // proves WHICH host matched. The message ends with " (<cta>)", so an endsWith
+        // on the full parenthesised form is both stricter and alert-free.
         assert.ok(
-          msg.includes("https://www.scholarfeed.org/pricing"),
-          `expected the absolute CTA in: ${msg}`,
+          msg.endsWith("(https://www.scholarfeed.org/pricing)"),
+          `expected the absolute CTA at the end of: ${msg}`,
         );
         return true;
       });
     });
+  });
+
+  it("refuses an off-origin upgrade_url (phishing vector)", async () => {
+    // upgrade_url arrives in an HTTP response body and lands in text the model relays
+    // to a user as the thing to click, so an arbitrary absolute URL would be a
+    // phishing vector — the same threat model that makes this codebase fence paper
+    // content. Lookalike hosts must be rejected too: a substring check for
+    // "scholarfeed.org" passes evil-scholarfeed.org and scholarfeed.org.attacker.test,
+    // which is why withUpgradeUrl compares origins exactly.
+    for (const evil of [
+      "https://evil.test/pricing",
+      "https://evil-scholarfeed.org/pricing",
+      "https://www.scholarfeed.org.attacker.test/pricing",
+      "http://www.scholarfeed.org/pricing", // wrong scheme -> different origin
+      "javascript:alert(1)",
+    ]) {
+      const body = JSON.stringify({
+        status: 403,
+        detail: "Daily limit reached.",
+        code: "quota_exceeded",
+        upgrade_url: evil,
+      });
+      await withStub(
+        { status: 403, body },
+        { SF_API_KEY: "sf_ok" },
+        async () => {
+          await assert.rejects(client.get("/x"), (err: unknown) => {
+            const msg = err instanceof Error ? err.message : String(err);
+            assert.ok(
+              !msg.includes(evil),
+              `off-origin CTA must be dropped, but message carried it: ${msg}`,
+            );
+            // The wall's own copy still reaches the agent; only the link is dropped.
+            assert.ok(msg.includes("Daily limit reached."));
+            return true;
+          });
+        },
+      );
+    }
   });
 
   it("does not double-append when the copy already carries a link", async () => {

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -278,7 +278,14 @@ describe("client error mapping", () => {
     await withStub({ status: 403, body }, { SF_API_KEY: "sf_ok" }, async () => {
       await assert.rejects(client.get("/x"), (err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err);
-        assert.match(msg, /https:\/\/www\.scholarfeed\.org\/pricing/);
+        // Plain substring check, not a regex: this asserts the CTA is PRESENT in an
+        // error string, and an unanchored host pattern trips CodeQL's
+        // js/regex/missing-regexp-anchor (a fair rule — it would be wrong for URL
+        // validation, and includes() says what we actually mean here).
+        assert.ok(
+          msg.includes("https://www.scholarfeed.org/pricing"),
+          `expected the absolute CTA in: ${msg}`,
+        );
         return true;
       });
     });
@@ -294,10 +301,12 @@ describe("client error mapping", () => {
     await withStub({ status: 403, body }, { SF_API_KEY: "sf_ok" }, async () => {
       await assert.rejects(client.get("/x"), (err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err);
+        // Count occurrences by splitting on the literal rather than a global regex
+        // (same CodeQL anchor rule as above; this is substring counting, not matching).
         assert.strictEqual(
-          (msg.match(/scholarfeed\.org\/pricing/g) ?? []).length,
+          msg.split("scholarfeed.org/pricing").length - 1,
           1,
-          "CTA must appear exactly once",
+          `CTA must appear exactly once, got: ${msg}`,
         );
         return true;
       });

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -247,6 +247,82 @@ describe("client error mapping", () => {
     });
   });
 
+  it("relays watch_limit, a wall the backend emits but the client ignored", async () => {
+    // api/routers/watches.py raises 403 code="watch_limit" with user-facing copy.
+    // It was absent from ACTIONABLE_PROBLEM_CODES, so create_watch's wall fell
+    // through to the generic status message and the agent lost the next step.
+    const body = JSON.stringify({
+      status: 403,
+      detail: "Free accounts can keep 1 watch. Upgrade to track up to 50.",
+      code: "watch_limit",
+      upgrade_url: "/pricing",
+    });
+    await withStub({ status: 403, body }, { SF_API_KEY: "sf_ok" }, async () => {
+      await assert.rejects(client.get("/watches"), (err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        assert.match(msg, /Free accounts can keep 1 watch/);
+        return true;
+      });
+    });
+  });
+
+  it("appends the backend's upgrade_url as an ABSOLUTE link", async () => {
+    // The backend sends relative CTAs ("/pricing") from five sites. A bare path is
+    // useless to a model with no origin, and it was being dropped entirely.
+    const body = JSON.stringify({
+      status: 403,
+      detail: "Daily limit reached.",
+      code: "quota_exceeded",
+      upgrade_url: "/pricing",
+    });
+    await withStub({ status: 403, body }, { SF_API_KEY: "sf_ok" }, async () => {
+      await assert.rejects(client.get("/x"), (err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        assert.match(msg, /https:\/\/www\.scholarfeed\.org\/pricing/);
+        return true;
+      });
+    });
+  });
+
+  it("does not double-append when the copy already carries a link", async () => {
+    const body = JSON.stringify({
+      status: 403,
+      detail: "Upgrade at https://www.scholarfeed.org/pricing to continue.",
+      code: "quota_exceeded",
+      upgrade_url: "/pricing",
+    });
+    await withStub({ status: 403, body }, { SF_API_KEY: "sf_ok" }, async () => {
+      await assert.rejects(client.get("/x"), (err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        assert.strictEqual(
+          (msg.match(/scholarfeed\.org\/pricing/g) ?? []).length,
+          1,
+          "CTA must appear exactly once",
+        );
+        return true;
+      });
+    });
+  });
+
+  it("does NOT admit an unlisted *_limit code (the allowlist stays fail-closed)", async () => {
+    // A suffix rule (code.endsWith("_limit")) would auto-admit future codes,
+    // including one whose detail carries internals — e.g. health.py's 503 stringifies
+    // a raw connection error. New codes must be added explicitly, not matched.
+    const body = JSON.stringify({
+      status: 503,
+      detail:
+        "connection to host db.internal:5432 failed: password authentication",
+      code: "db_connection_limit",
+    });
+    await withStub({ status: 503, body }, { SF_API_KEY: "sf_ok" }, async () => {
+      await assert.rejects(client.get("/x"), (err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        assert.doesNotMatch(msg, /db\.internal|password/);
+        return true;
+      });
+    });
+  });
+
   it("does not let a generic problem+json code displace the actionable copy", async () => {
     // code='forbidden' is derived from the status alone and its detail is
     // FastAPI's bare "Not authenticated" — surfacing that would bury the

--- a/src/client.ts
+++ b/src/client.ts
@@ -105,6 +105,13 @@ function requestHeaders(extra: Record<string, string>): Record<string, string> {
  * to a named code, exactly as pro_required was promoted. Unknown codes must stay
  * opaque and fall through to the status-based messages below.
  */
+/**
+ * The ONLY origin a backend-supplied CTA link may resolve to. Compared with exact
+ * origin equality (not a substring test) in withUpgradeUrl below, so a lookalike host
+ * like evil-scholarfeed.org or scholarfeed.org.attacker.test cannot slip through.
+ */
+const SITE_ORIGIN = "https://www.scholarfeed.org";
+
 const ACTIONABLE_PROBLEM_CODES = new Set([
   "pro_required",
   "quota_exceeded",
@@ -179,12 +186,27 @@ function structuredBackendMessage(body: string): string | null {
  */
 function withUpgradeUrl(human: string, raw: unknown): string {
   if (typeof raw !== "string" || raw.length === 0) return human;
-  const url = /^https?:\/\//i.test(raw)
-    ? raw
-    : `https://www.scholarfeed.org${raw.startsWith("/") ? "" : "/"}${raw}`;
-  // Skip when the copy already points somewhere — several backend strings embed
-  // their own link, and a duplicate CTA reads as a formatting bug to the model.
-  if (human.includes(url) || /scholarfeed\.org/i.test(human)) return human;
+
+  // Resolve against our own origin and then require that origin EXACTLY. The value
+  // arrives in an HTTP response body and ends up in text the model relays to a user
+  // as the next step to click, so an arbitrary absolute URL here is a phishing
+  // vector — the same reason paper content gets fenced in this codebase. A substring
+  // test (`/scholarfeed\.org/`) is not sufficient: evil-scholarfeed.org and
+  // scholarfeed.org.attacker.test both contain it. new URL() + origin equality is
+  // exact, and resolution makes the common relative case ("/pricing") absolute,
+  // which a model with no origin cannot otherwise use.
+  let url: string;
+  try {
+    const parsed = new URL(raw, SITE_ORIGIN);
+    if (parsed.origin !== SITE_ORIGIN) return human;
+    url = parsed.toString();
+  } catch {
+    return human; // unparseable — drop the CTA rather than emit garbage
+  }
+
+  // Skip when the copy already carries this link; several backend strings embed
+  // their own, and a duplicate CTA reads as a formatting bug to the model.
+  if (human.includes(url)) return human;
   return `${human} (${url})`;
 }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -109,7 +109,17 @@ const ACTIONABLE_PROBLEM_CODES = new Set([
   "pro_required",
   "quota_exceeded",
   "anon_daily_limit",
+  // watches.py raises 403 code="watch_limit" with user-facing copy ("Free accounts
+  // can keep N watches..."). It was missing here, so create_watch's wall fell through
+  // to the generic status copy and the agent lost the one message that says how to
+  // proceed. Verified present in the backend: api/routers/watches.py.
+  "watch_limit",
 ]);
+
+// NOTE: deliberately NOT a suffix rule (`code.endsWith("_limit")` etc.). A pattern
+// match is fail-OPEN for exactly the reason the allowlist exists — it would auto-admit
+// any future *_limit/*_exceeded code, including one whose detail carries internals.
+// New codes get added here explicitly, after checking what the backend puts in detail.
 
 /** The subset of the above that means "authenticated fine, but this needs Pro". */
 const PRO_GATE_CODES = new Set(["pro_required"]);
@@ -141,19 +151,41 @@ function structuredBackendMessage(body: string): string | null {
     if (parsed === null || typeof parsed !== "object") return null;
     const rec = parsed as Record<string, unknown>;
     if (typeof rec.error === "string" && typeof rec.message === "string") {
-      return rec.message;
+      return withUpgradeUrl(rec.message, rec.upgrade_url);
     }
     if (
       typeof rec.code === "string" &&
       typeof rec.detail === "string" &&
       ACTIONABLE_PROBLEM_CODES.has(rec.code)
     ) {
-      return rec.detail;
+      return withUpgradeUrl(rec.detail, rec.upgrade_url);
     }
   } catch {
     // Body isn't JSON — fall through to the status-based messages.
   }
   return null;
+}
+
+/**
+ * Append the backend's own CTA link to a wall message, as an absolute URL.
+ *
+ * Five backend sites send `upgrade_url` alongside the wall (public.py, auth.py,
+ * alerts.py, billing.py, following.py) and it was being dropped on the floor, so the
+ * agent got the explanation without the one thing it can act on. Most are RELATIVE
+ * ("/pricing"), which is useless to a model with no origin — hence the absolute-ising.
+ *
+ * Only ever called on a body that already qualified as a deliberate wall above, so
+ * this cannot promote an internal error envelope into user-facing copy.
+ */
+function withUpgradeUrl(human: string, raw: unknown): string {
+  if (typeof raw !== "string" || raw.length === 0) return human;
+  const url = /^https?:\/\//i.test(raw)
+    ? raw
+    : `https://www.scholarfeed.org${raw.startsWith("/") ? "" : "/"}${raw}`;
+  // Skip when the copy already points somewhere — several backend strings embed
+  // their own link, and a duplicate CTA reads as a formatting bug to the model.
+  if (human.includes(url) || /scholarfeed\.org/i.test(human)) return human;
+  return `${human} (${url})`;
 }
 
 /**


### PR DESCRIPTION
Salvages the live part of #25 (open since 2026-06-07, 38 commits stale). I had earlier reported that PR as fully redundant — **that was wrong**. My grep matched `upgrade_url` inside *comments* and I read it as code. Two of its fixes never shipped.

## 1. `watch_limit` was missing from the allowlist

`api/routers/watches.py` really raises `403 code="watch_limit"` with user-facing copy ("Free accounts can keep N watches..."). It was absent from `ACTIONABLE_PROBLEM_CODES`, so `create_watch`'s wall fell through to the generic status-based message and the agent lost the one string that says how to proceed.

## 2. `upgrade_url` was read by nothing

Five backend sites send it alongside the wall — `public.py`, `auth.py`, `alerts.py`, `billing.py`, `following.py` — and the client dropped it, so the model got the explanation without the actionable link. Most are **relative** (`/pricing`), which is useless to a model with no origin, so they are now absolute-ised. Copy that already embeds a link is left alone rather than double-appended.

Demonstrated before fixing — with only the old allowlist, both `watch_limit` and `quota_exceeded` hit the generic dead-end path and the backend's `detail` + `upgrade_url` were discarded.

## Deliberately NOT taken from #25

Its `code.endsWith("_limit" / "_exceeded" / "_required")` suffix fallback. That is **fail-open**, which is exactly what the allowlist comment in `client.ts` warns against:

> health.py raises 503 with detail={"error":"db_unavailable","message":str(e)}, which stringifies a raw connection error (host, port, DSN) and would leak the moment anyone promotes it to a named code

A pattern match would auto-admit any future `*_limit` code, including that one. New codes get added explicitly instead, and a regression test asserts an unlisted `db_connection_limit` stays opaque (no host/password in the message).

## Verification

- **360/360** tests, typecheck clean, prettier clean
- **Mutation-tested:** removing `watch_limit` fails its test; making `withUpgradeUrl` a no-op fails its test; neither breaks anything else

## Follow-up

Once this merges, #25 can be closed: its 23 doc files are now in the gitignored `.local-docs/` (per #50) and its code is superseded here.