### PR TITLE
Reconcile the tool count to 26, pin @latest, forward the caller IP from the Worker

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "scholar-feed",
       "source": "./",
-      "description": "Search 600,000+ CS/AI/ML papers with LLM novelty analysis, citation graph, full-text extraction, and BibTeX. Ships the scholar-feed MCP server (25 tools).",
+      "description": "Search 600,000+ CS/AI/ML papers with LLM novelty analysis, citation graph, full-text extraction, and BibTeX. Ships the scholar-feed MCP server (26 tools).",
       "author": {
         "name": "Scholar Feed",
         "email": "hello@scholarfeed.org"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -28,7 +28,7 @@
   "mcpServers": {
     "scholar-feed": {
       "command": "npx",
-      "args": ["-y", "scholar-feed-mcp"]
+      "args": ["-y", "scholar-feed-mcp@latest"]
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "scholar-feed": {
       "command": "npx",
-      "args": ["-y", "scholar-feed-mcp"]
+      "args": ["-y", "scholar-feed-mcp@latest"]
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [3.11.0] - 2026-06-11
+
+### Added
+
+- `check_drift`: "is the method I use superseded, and by what?" Returns critique receipts and
+  benchmark-dominance edges over ~10 LLM builder-problem families. Read-only, anonymous-capable,
+  and outside the Pro quota.
+
+Surface is now **26 tools** (was 25 at 3.7.0): adds `check_drift`. This is the only tool-surface
+change between 3.8.0 and 3.13.2.
+
 ## [3.8.0] - 2026-06-04
 
 ### Changed (install reliability — fixes silent cold-start failures)

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Scholar Feed is a standard stdio MCP server, so any other MCP-compatible client 
 | `search_papers` | Semantic + keyword search with filters. Also does similar-paper discovery, citation-scoped search, and trending. | `q`, `category`, `novelty_min`, `days`, `sort`, `anchor_paper_id`, `scope_to_citations_of`, `mode`, `method_category`, `task`, `dataset`, `contribution_type`, `task_category`, `cursor`, `limit` |
 | `get_paper` | Get full paper details by arXiv ID. Also handles batch lookup and BibTeX export. | `arxiv_ids`, `format`, `fields`, `verbose` |
 | `get_citations` | Citation graph (outgoing refs or incoming citations) | `arxiv_id`, `direction`, `limit`, `fields` |
-| `fetch_fulltext` | Extract results/experiments from LaTeX source | `arxiv_id` |
+| `fetch_fulltext` | Extract results/experiments from LaTeX source. `sections: 'all'` returns the whole paper instead of the lean results excerpt. | `arxiv_id`, `sections` |
 
 ### Authors
 

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.YGao2005/scholar-feed-mcp",
   "title": "Scholar Feed",
-  "description": "Search 600k+ CS/AI/ML papers with ranking and citation tracking over 22M+ citation edges.",
+  "description": "Rank CS/AI/ML papers by citations, forecast impact, or code adoption; trace 23.2M citation edges.",
   "version": "3.9.1",
   "websiteUrl": "https://www.scholarfeed.org",
   "repository": {

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -26,7 +26,7 @@ startCommand:
     |-
     (config) => ({
       command: 'npx',
-      args: ['-y', 'scholar-feed-mcp'],
+      args: ['-y', 'scholar-feed-mcp@latest'],
       env: config && config.SF_API_KEY ? { SF_API_KEY: config.SF_API_KEY } : {}
     })
   exampleConfig:

--- a/src/__tests__/proxy_ip_forward.test.ts
+++ b/src/__tests__/proxy_ip_forward.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Client-IP forwarding: the end caller's IP reaches the backend ONLY as a matched
+ * pair with the shared proxy secret.
+ *
+ * WHY THIS IS LOAD-BEARING. The hosted remote (mcp.scholarfeed.org) previously
+ * forwarded no client IP at all, so every anonymous caller arrived at the backend
+ * keyed to our Worker's egress IP. Two consequences, both measured in prod: all
+ * anonymous callers shared ONE rate-limit bucket, and `usage_events.client_hash`
+ * counted egress IPs rather than clients (394 hashes on the MCP surface, with a
+ * bias direction that is genuinely indeterminate rather than merely unknown).
+ *
+ * The backend honors X-Real-Client-IP only when X-Proxy-Secret matches its own
+ * PROXY_SECRET, falling through to X-Forwarded-For otherwise. So the IP alone is
+ * inert, and emitting it alone would read as meaningful while being silently
+ * ignored. These tests pin BOTH directions of that pairing, plus the stdio path
+ * where forwarding must not happen at all (a stdio client reaches the backend
+ * directly, so Heroku's X-Forwarded-For already carries its real IP).
+ *
+ * CRITICAL: All logging uses console.error() — never console.log().
+ */
+
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import http, { type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { client } from "../client.js";
+import { runWithCreds } from "../http/credentials.js";
+
+interface Captured {
+  realClientIp: string | null;
+  proxySecret: string | null;
+  session: string | null;
+}
+
+const CALLER_IP = "203.0.113.47";
+const SECRET = "test_proxy_secret_value";
+
+describe("client IP forwarding (X-Real-Client-IP paired with X-Proxy-Secret)", () => {
+  let backend: Server;
+  const captured: Captured[] = [];
+  const savedEnv: Record<string, string | undefined> = {};
+  const ENV_KEYS = ["SF_API_BASE_URL", "SF_PROXY_SECRET", "SF_API_KEY"];
+
+  before(async () => {
+    for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+
+    backend = http.createServer((req, res) => {
+      captured.push({
+        realClientIp:
+          (req.headers["x-real-client-ip"] as string | undefined) ?? null,
+        proxySecret:
+          (req.headers["x-proxy-secret"] as string | undefined) ?? null,
+        session: (req.headers["x-sf-session"] as string | undefined) ?? null,
+      });
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ items: [], total: 0 }));
+    });
+    await new Promise<void>((r) => backend.listen(0, () => r()));
+    const { port } = backend.address() as AddressInfo;
+    process.env.SF_API_BASE_URL = `http://127.0.0.1:${port}`;
+    delete process.env.SF_API_KEY;
+  });
+
+  after(async () => {
+    await new Promise<void>((r) => backend.close(() => r()));
+    for (const k of ENV_KEYS) {
+      const v = savedEnv[k];
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  beforeEach(() => {
+    captured.length = 0;
+  });
+
+  it("forwards the caller IP verbatim when BOTH the IP and the secret are present", async () => {
+    process.env.SF_PROXY_SECRET = SECRET;
+    await runWithCreds(
+      { apiKey: null, sessionId: "s-1", clientIp: CALLER_IP },
+      () => client.get("/library"),
+    );
+    assert.equal(captured.length, 1);
+    assert.equal(captured[0].realClientIp, CALLER_IP);
+    assert.equal(captured[0].proxySecret, SECRET);
+  });
+
+  it("sends NEITHER header when the secret is unconfigured (no-op until deployed)", async () => {
+    delete process.env.SF_PROXY_SECRET;
+    await runWithCreds(
+      { apiKey: null, sessionId: "s-2", clientIp: CALLER_IP },
+      () => client.get("/library"),
+    );
+    assert.equal(captured.length, 1);
+    assert.equal(captured[0].realClientIp, null);
+    assert.equal(captured[0].proxySecret, null);
+  });
+
+  it("sends NEITHER header when CF-Connecting-IP was absent, even with a secret set", async () => {
+    process.env.SF_PROXY_SECRET = SECRET;
+    await runWithCreds({ apiKey: null, sessionId: "s-3", clientIp: null }, () =>
+      client.get("/library"),
+    );
+    assert.equal(captured.length, 1);
+    assert.equal(captured[0].realClientIp, null);
+    // The secret must never ship on its own either.
+    assert.equal(captured[0].proxySecret, null);
+  });
+
+  it("never forwards on the stdio path (no ALS context), even with a secret set", async () => {
+    process.env.SF_PROXY_SECRET = SECRET;
+    await client.get("/library");
+    assert.equal(captured.length, 1);
+    assert.equal(captured[0].realClientIp, null);
+    assert.equal(captured[0].proxySecret, null);
+    // Sanity: the stdio path still stamps its per-process session id, so this
+    // asserts absence of forwarding rather than absence of a request.
+    assert.ok(captured[0].session);
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -80,14 +80,34 @@ function getSessionId(): string {
 }
 
 /**
- * Headers shared by every request: auth (when keyed), the session id, then the
- * caller's Accept/Content-Type. Centralizing them keeps the per-verb methods
- * from each re-implementing the common set.
+ * Forward the end caller's IP to the backend, but ONLY as a matched pair with the
+ * shared proxy secret. The backend trusts X-Real-Client-IP only when
+ * X-Proxy-Secret matches, so sending the IP alone is inert; we omit both rather
+ * than emit a header that reads as meaningful and is silently ignored.
+ *
+ * Empty on the stdio path: there is no ALS context there, and a stdio client
+ * reaches the backend directly so Heroku's X-Forwarded-For already carries its
+ * real IP. Empty whenever SF_PROXY_SECRET is unconfigured, which keeps this a
+ * no-op until the secret is deployed.
+ */
+function proxyHeaders(): Record<string, string> {
+  const clientIp = getCurrentCreds()?.clientIp;
+  const secret = process.env.SF_PROXY_SECRET;
+  if (!clientIp || !secret) return {};
+  return { "X-Real-Client-IP": clientIp, "X-Proxy-Secret": secret };
+}
+
+/**
+ * Headers shared by every request: auth (when keyed), the session id, the
+ * forwarded client IP when configured, then the caller's Accept/Content-Type.
+ * Centralizing them keeps the per-verb methods from each re-implementing the
+ * common set. `extra` is spread LAST so a caller can still override.
  */
 function requestHeaders(extra: Record<string, string>): Record<string, string> {
   return {
     ...authHeaders(),
     "X-SF-Session": getSessionId(),
+    ...proxyHeaders(),
     ...extra,
   };
 }

--- a/src/http/credentials.ts
+++ b/src/http/credentials.ts
@@ -30,10 +30,19 @@ import { AsyncLocalStorage } from "node:async_hooks";
  * - `sessionId`: an opaque per-request id stamped as `X-SF-Session` so the
  *   backend can stitch one request's fan-out together. Generated fresh per
  *   request by the HTTP entry point (unlike the stdio path's per-process id).
+ * - `clientIp`: the END CALLER's IP, forwarded so the backend can key rate
+ *   limits and anonymous analytics per caller instead of per Worker egress.
+ *   Without it EVERY anonymous remote caller collapses into one bucket keyed to
+ *   our egress IP, which both shares one rate limit across all tenants and makes
+ *   `usage_events.client_hash` a count of egress IPs rather than of clients.
+ *   Optional: absent on the stdio path (which reaches the backend directly, so
+ *   Heroku's X-Forwarded-For already carries the real IP) and absent whenever no
+ *   proxy secret is configured.
  */
 export interface RequestCreds {
   apiKey: string | null;
   sessionId: string;
+  clientIp?: string | null;
 }
 
 /**

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -44,7 +44,7 @@ import { register as registerCheckDrift } from "./check_drift.js";
 /**
  * Register all Scholar Feed MCP tools on the provided server instance.
  *
- * v3.7 surface (26 tools):
+ * Current surface (26 tools, since v3.11.0):
  *   9 read/search tools (anonymous-capable, except embed_text which is Pro) +
  *   check_drift (DriftKB supersession check, anonymous-capable) + find_gaps
  *   (read-only gap analysis, Pro) + ask_library (cited synthesis over

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -86,6 +86,13 @@ const version: string =
 const CONFIG_ENV_KEYS = [
   "SF_API_BASE_URL",
   "SF_API_TIMEOUT_MS",
+  // The shared secret that lets the backend TRUST our X-Real-Client-IP header
+  // (it compares against PROXY_SECRET before honoring the IP, else it falls back
+  // to X-Forwarded-For). This is a secret, yet unlike SF_API_KEY it is CORRECT at
+  // process level: it identifies THIS SERVER to the backend, and is identical for
+  // every tenant. SF_API_KEY is per-tenant, which is why bridging it would be a
+  // cross-tenant leak. Do not use this distinction to justify adding any other key.
+  "SF_PROXY_SECRET",
   "SF_MCP_ALLOWED_HOSTS",
   "SF_MCP_ALLOWED_ORIGINS",
   "SF_MCP_RESOURCE_URI",
@@ -233,8 +240,17 @@ async function handleMcpPost(
     // Bind the per-request creds for the whole handleRequest -> tool -> client
     // chain via AsyncLocalStorage, then let the transport drive the Response.
     // handleRequest reads the body off the Request itself (no parsedBody passed).
-    response = await runWithCreds(resolution.creds, () =>
-      transport.handleRequest(request),
+    // Forward the END CALLER's IP so the backend keys anonymous rate limits and
+    // analytics per caller. CF-Connecting-IP is set by Cloudflare at the edge and
+    // cannot be spoofed by the client, so it is safe to trust here; the backend
+    // additionally requires a matching X-Proxy-Secret before honoring it, and
+    // client.ts sends neither header unless BOTH are present.
+    response = await runWithCreds(
+      {
+        ...resolution.creds,
+        clientIp: request.headers.get("CF-Connecting-IP"),
+      },
+      () => transport.handleRequest(request),
     );
   } catch (err) {
     console.error("[worker] error handling POST /mcp:", err);


### PR DESCRIPTION
Three scoped commits. No tool behaviour changes, no new dependencies, `dependencies` stays `{}`.

## 1. Tool count is 26

The surface has been 26 since v3.11.0 (`check_drift` was the 26th). The shipped tests already pinned it (`tools.test.ts` asserts "registers exactly the 26 tools"; `http_transport.test.ts` lists 26 over `tools/list`), but the README header, the barrel comment and `.claude-plugin/marketplace.json` still said 22, 24 or 25. The README table itself was already correct and lists all 26 with no phantoms.

Historical CHANGELOG counts are left alone on purpose: each is accurate for its own release, and rewriting them would turn correct history into a lie. A 3.11.0 entry is added instead, since that is the count-bearing release. `fetch_fulltext` also gains its previously undocumented `sections` param in the README table.

`server.json` now leads with ranking and citation tracking instead of corpus size, at 97 of the registry's 100-char limit. Its `version` field is deliberately untouched: `publish.yml` stamps it from `package.json` with `jq` at publish time, so editing it here would be cosmetic.

## 2. `@latest` in the three install snippets that never got it

CHANGELOG 3.8.0 claims all install snippets pin `@latest` and the README repeats it, but `smithery.yaml`, `.mcp.json` and `.claude-plugin/plugin.json` all still shipped a bare `scholar-feed-mcp`. That is the stale-npx-cache failure 3.8.0 set out to kill, left live on the Smithery and Claude-plugin install surfaces, where it presents as a silent "failed to connect" rather than as a version problem. Three one-word changes.

## 3. Forward the end caller's IP from the Worker

The hosted remote forwarded no client IP, so every anonymous caller reached the backend keyed to the Worker's egress rather than their own address. That collapses per-caller rate limiting and makes per-client analytics count egress IPs instead of clients.

The backend already trusts this path: it honours `X-Real-Client-IP` when `X-Proxy-Secret` matches, falling back to `X-Forwarded-For` otherwise. Only the Worker end was missing. `CF-Connecting-IP` is set by Cloudflare at the edge and cannot be spoofed by the client, and it rides the existing per-request `AsyncLocalStorage` store next to `apiKey` and `sessionId`, so this needed no new plumbing.

The two headers are emitted **only as a matched pair**. The IP alone is inert because the backend ignores it without the secret, and a header that reads as meaningful while being silently dropped is worse than no header. So this is a deliberate no-op until `SF_PROXY_SECRET` is configured, and the deploy is safe in either order.

`SF_PROXY_SECRET` joins the config bridge. Unlike `SF_API_KEY` it is correct at process level: it identifies the server to the backend and is identical for every tenant, whereas `SF_API_KEY` is per-tenant and bridging it would be a cross-tenant leak. The code comment says so explicitly, to stop the distinction being cited as precedent for another key.

Nothing forwards on the stdio path, deliberately: a stdio client reaches the backend directly, so its real IP is already present.

## Gates

`typecheck` clean · **365 tests pass / 0 fail** (4 new, covering both directions of the header pairing plus the stdio path) · `lint` clean · `format:check` clean · `worker:dryrun` bundles.