### PR TITLE
Wait for npm to actually serve the version before registering it

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -120,10 +120,42 @@ jobs:
           ./mcp-publisher --version
       - name: Authenticate to MCP Registry (GitHub OIDC)
         run: ./mcp-publisher login github-oidc
+      - name: Wait for the npm version to be readable
+        # The registry validates package ownership by FETCHING the version from npm, and
+        # npm's publish is asynchronous — `npm publish` prints "Your package is being
+        # processed and may take a few minutes to become available" and returns success
+        # long before a GET succeeds.
+        #
+        # MEASURED on the 3.14.0 release (2026-08-26): npm publish succeeded at 09:01,
+        # and GET /scholar-feed-mcp/3.14.0 returned 404 until ~09:22 — 21 MINUTES. The
+        # old retry budget here was 4 x 20s = 82s, so the registry job failed while the
+        # npm release itself was perfectly fine. That is a confusing failure: a red
+        # workflow on a release that shipped.
+        #
+        # Poll the version endpoint directly (not the packument, which is CDN-cached)
+        # before attempting to publish, so a slow npm shows up as waiting rather than as
+        # four identical validation errors.
+        run: |
+          VERSION="$(jq -r .version package.json)"
+          for i in $(seq 1 60); do    # 60 x 30s = 30 min
+            CODE="$(curl -s -o /dev/null -w '%{http_code}' \
+              -H 'Cache-Control: no-cache' \
+              "https://registry.npmjs.org/scholar-feed-mcp/${VERSION}")"
+            if [ "$CODE" = "200" ]; then
+              echo "npm has ${VERSION} (after $(( (i - 1) * 30 ))s)."
+              exit 0
+            fi
+            echo "npm does not serve ${VERSION} yet (HTTP ${CODE}); waiting 30s (${i}/60)..."
+            sleep 30
+          done
+          echo "::error::npm never served ${VERSION} within 30 minutes."
+          echo "The npm publish itself may still have SUCCEEDED — check the publish job."
+          echo "If so, do NOT re-tag ${VERSION} (npm refuses to republish a version);"
+          echo "re-run this workflow via workflow_dispatch once npm serves it."
+          exit 1
       - name: Publish server.json to MCP Registry
-        # On a tag release the freshly published npm version can take a few
-        # seconds to propagate before the registry's package-ownership check
-        # sees it; retry briefly so a propagation lag is not a hard failure.
+        # Retries kept as a thin backstop for a transient registry-side error. The npm
+        # propagation race — which is what actually bit us — is handled by the wait above.
         run: |
           for attempt in 1 2 3 4; do
             if ./mcp-publisher publish; then


### PR DESCRIPTION
The 3.14.0 release published to npm successfully **and the workflow still went red.** `verify` and `publish` passed; `registry` failed four times with:

```
registry validation failed for package 0 (scholar-feed-mcp): NPM package
'scholar-feed-mcp' exists, but version '3.14.0' was not found (status: 404)
```

A red workflow on a release that actually shipped is a confusing signal, and it will recur on every release until this is fixed.

## Cause

npm's publish is **asynchronous**. `npm publish` prints *"Your package is being processed and may take a few minutes to become available"* and exits 0 well before a `GET` succeeds. The MCP Registry validates package ownership by fetching the version from npm, so it cannot succeed until npm serves it.

Measured on this release rather than estimated:

| | |
|---|---|
| `npm publish` reported `+ scholar-feed-mcp@3.14.0` | 09:01 |
| `GET /scholar-feed-mcp/3.14.0` still 404 | until ~09:22 |
| **npm propagation** | **~21 minutes** |
| Retry budget in this job | 4 × 20s = **82 seconds** |

Short by a factor of ~15. The comment above the loop said "a few seconds", which is where the number came from.

## Change

A dedicated wait step polls the **version endpoint** for up to 30 minutes before attempting to publish. Polling the version endpoint specifically matters — the packument (`/scholar-feed-mcp`) is CDN-cached and served a stale `dist-tags.latest` of 3.13.2 throughout, even cache-busted.

A slow npm now reads as "waiting, 90s elapsed" instead of four identical validation errors that look like a broken OIDC token.

The existing retry loop stays as a thin backstop for a genuinely transient registry-side error.

## The failure message names the recovery, deliberately

The wrong instinct here is expensive. If npm published but never served the version, **do not re-tag** — npm refuses to republish a version, so it is burned and you need a fresh bump. Re-run via `workflow_dispatch` instead, which skips `publish` and runs `registry` alone.

That is exactly how 3.14.0 was recovered. Both surfaces are now live:

- npm `dist-tags.latest` = **3.14.0**
- MCP Registry `isLatest` record = **3.14.0**, carrying the new ranking-led description

Verified by locating the record with `isLatest: true`, **not** by reading down `/v0/servers` — that list is unsorted (its first page shows 3.10.0–3.13.0), and reading it that way is how the registry version got misreported once before in this project.

## Scope

CI-only. No version bump, no source change, published package untouched. YAML parses; `format:check` clean.