### PR TITLE
Add OpenAI Codex support and a human page for GET /mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ A few clients need a different wrapper key or file format:
 <details>
 <summary><strong>OpenAI Codex, VS Code (GitHub Copilot), Zed, Continue, and project-scoped configs</strong></summary>
 
-**OpenAI Codex** (`~/.codex/config.toml`) uses TOML, not JSON — the block above will not work. One file serves both the Codex CLI and the IDE extension.
+**OpenAI Codex** (`~/.codex/config.toml`, or `$CODEX_HOME/config.toml` if you set that) uses TOML, not JSON — the block above will not work. One file serves both the Codex CLI and the IDE extension.
 
 ```toml
 [mcp_servers.scholar-feed]

--- a/README.md
+++ b/README.md
@@ -92,7 +92,18 @@ Drop that block into the right config file:
 A few clients need a different wrapper key or file format:
 
 <details>
-<summary><strong>VS Code (GitHub Copilot), Zed, Continue, and project-scoped configs</strong></summary>
+<summary><strong>OpenAI Codex, VS Code (GitHub Copilot), Zed, Continue, and project-scoped configs</strong></summary>
+
+**OpenAI Codex** (`~/.codex/config.toml`) uses TOML, not JSON — the block above will not work. One file serves both the Codex CLI and the IDE extension.
+
+```toml
+[mcp_servers.scholar-feed]
+command = "npx"
+args = ["-y", "scholar-feed-mcp@latest"]
+env = { SF_API_KEY = "sf_your_key_here" }
+```
+
+Drop the `env` line to run keyless at 100 calls/day. On Windows, if Codex cannot launch the server, use `command = "cmd"` with `args = ["/c", "npx", "-y", "scholar-feed-mcp@latest"]`.
 
 **VS Code: GitHub Copilot** (`.vscode/mcp.json`) uses a `servers` key and an explicit `type`, and needs Copilot agent mode. You can also run `MCP: Add Server` from the Command Palette.
 

--- a/src/__tests__/http_transport.test.ts
+++ b/src/__tests__/http_transport.test.ts
@@ -168,6 +168,58 @@ describe("remote HTTP transport (Streamable HTTP, stateless)", () => {
     const res = await fetch(`${baseUrl}/mcp`, { method: "DELETE" });
     assert.strictEqual(res.status, 405);
   });
+
+  // A browser navigation to GET /mcp gets the setup page instead of a bare JSON
+  // error. This is the regression that cost a paying customer: they pasted the
+  // endpoint into Chrome, read the JSON-RPC 405 as an outage, and never returned.
+  it("serves the HTML setup page for a browser GET /mcp", async () => {
+    const res = await fetch(`${baseUrl}/mcp`, {
+      method: "GET",
+      headers: {
+        Accept:
+          "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      },
+    });
+    // Still 405 — the method really was wrong, and a 200 would let a broken
+    // client read failure as success.
+    assert.strictEqual(res.status, 405);
+    assert.match(res.headers.get("content-type") ?? "", /text\/html/);
+    const body = await res.text();
+    assert.match(body, /This endpoint is working/);
+    // The page must carry the Codex TOML: Codex was the missing client, and
+    // pasting the JSON block into config.toml is exactly the failure being fixed.
+    assert.match(body, /\[mcp_servers\.scholar-feed\]/);
+    assert.match(body, /~\/\.codex\/config\.toml/);
+  });
+
+  // The negotiation must not leak HTML into the protocol: an MCP client sends
+  // application/json and/or text/event-stream and must keep the JSON-RPC body.
+  it("keeps the JSON-RPC 405 body for non-browser Accept headers", async () => {
+    for (const accept of [MCP_ACCEPT, "application/json", "*/*"]) {
+      const res = await fetch(`${baseUrl}/mcp`, {
+        method: "GET",
+        headers: { Accept: accept },
+      });
+      assert.strictEqual(res.status, 405, `status for Accept: ${accept}`);
+      assert.match(
+        res.headers.get("content-type") ?? "",
+        /application\/json/,
+        `content-type for Accept: ${accept}`,
+      );
+      const body = (await res.json()) as JsonRpcEnvelope;
+      assert.strictEqual(body.error?.code, -32000);
+    }
+  });
+
+  // No Accept header at all (curl, a bare socket) must also stay JSON-RPC.
+  it("keeps the JSON-RPC 405 body when Accept is absent", async () => {
+    const res = await fetch(`${baseUrl}/mcp`, {
+      method: "GET",
+      headers: { Accept: "" },
+    });
+    assert.strictEqual(res.status, 405);
+    assert.match(res.headers.get("content-type") ?? "", /application\/json/);
+  });
 });
 
 describe("DNS-rebinding guards (Origin + Host)", () => {

--- a/src/__tests__/http_transport.test.ts
+++ b/src/__tests__/http_transport.test.ts
@@ -23,6 +23,7 @@ import assert from "node:assert/strict";
 import type { AddressInfo } from "node:net";
 import type { Server } from "node:http";
 import { createApp, isOriginAllowed, isHostAllowed } from "../server-http.js";
+import { prefersHtml } from "../server-info.js";
 
 const PROTOCOL_VERSION = "2025-11-25";
 const MCP_ACCEPT = "application/json, text/event-stream";
@@ -219,6 +220,84 @@ describe("remote HTTP transport (Streamable HTTP, stateless)", () => {
     });
     assert.strictEqual(res.status, 405);
     assert.match(res.headers.get("content-type") ?? "", /application\/json/);
+  });
+
+  // The protocol must always win the negotiation. A substring test on Accept got
+  // both of these wrong: q=0 explicitly REFUSES html, and a client naming both
+  // types is a client, not a person.
+  it("serves JSON when a client names a protocol type alongside text/html", async () => {
+    for (const accept of [
+      "application/json, text/html;q=0",
+      "text/html, application/json",
+      "text/html;q=0.9, text/event-stream;q=0.8",
+      "text/html;q=0",
+    ]) {
+      const res = await fetch(`${baseUrl}/mcp`, {
+        method: "GET",
+        headers: { Accept: accept },
+      });
+      assert.match(
+        res.headers.get("content-type") ?? "",
+        /application\/json/,
+        `Accept: ${accept} must stay JSON-RPC`,
+      );
+    }
+  });
+
+  // Two representations on one URL. Without Vary a shared cache can store the
+  // browser's HTML and replay it to a protocol GET; Allow is required on a 405.
+  it("sets Vary: Accept and Allow: POST on both 405 representations", async () => {
+    for (const accept of [MCP_ACCEPT, "text/html"]) {
+      const res = await fetch(`${baseUrl}/mcp`, {
+        method: "GET",
+        headers: { Accept: accept },
+      });
+      assert.strictEqual(res.status, 405);
+      assert.match(
+        res.headers.get("vary") ?? "",
+        /accept/i,
+        `Vary missing for Accept: ${accept}`,
+      );
+      assert.strictEqual(
+        res.headers.get("allow"),
+        "POST",
+        `Allow missing for Accept: ${accept}`,
+      );
+    }
+  });
+});
+
+describe("prefersHtml content negotiation", () => {
+  it("is true only for a browser navigation", () => {
+    for (const accept of [
+      "text/html",
+      "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      "TEXT/HTML",
+    ]) {
+      assert.strictEqual(prefersHtml(accept), true, `expected true: ${accept}`);
+    }
+  });
+
+  it("is false for anything that speaks the protocol, or for no preference", () => {
+    for (const accept of [
+      undefined,
+      null,
+      "",
+      "*/*",
+      "application/json",
+      MCP_ACCEPT,
+      "application/json, text/html;q=0",
+      "text/html, application/json",
+      "text/html;q=0",
+      "text/html;q=0.0",
+      "text/event-stream, text/html",
+    ]) {
+      assert.strictEqual(
+        prefersHtml(accept),
+        false,
+        `expected false: ${String(accept)}`,
+      );
+    }
   });
 });
 

--- a/src/__tests__/init_codex.test.ts
+++ b/src/__tests__/init_codex.test.ts
@@ -240,6 +240,28 @@ describe("init: printed Codex snippet never contains a real key", () => {
     const snippet = codexTomlSnippet(true);
     assert.ok(!snippet.includes("true"));
   });
+
+  // codexTomlSnippet deliberately duplicates the template instead of delegating to
+  // the key-embedding codexTomlBlock, so the printed and written paths share no
+  // code. This pins the duplication: if the written block gains a line (a new
+  // Codex key, a changed package spec) and the printed one does not, the snippet we
+  // hand users stops matching what we write, and this fails.
+  it("stays in sync with the block that gets written to disk", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "sf-codex-sync-"));
+    const target = join(tmp, "config.toml");
+    appendCodexConfig(target, "sf_synccheck");
+    const written = readFileSync(target, "utf-8").trim();
+    rmSync(tmp, { recursive: true, force: true });
+    const printed = codexTomlSnippet(true);
+
+    const normalize = (s: string) =>
+      s.replace(/SF_API_KEY = "[^"]*"/, 'SF_API_KEY = "REDACTED"');
+    assert.strictEqual(
+      normalize(printed),
+      normalize(written),
+      "printed snippet and written block have drifted apart",
+    );
+  });
 });
 
 describe("init: codexConfigPath", () => {

--- a/src/__tests__/init_codex.test.ts
+++ b/src/__tests__/init_codex.test.ts
@@ -25,7 +25,11 @@ import {
 } from "node:fs";
 import { join, dirname } from "node:path";
 import { tmpdir, homedir } from "node:os";
-import { appendCodexConfig, codexConfigPath } from "../init.js";
+import {
+  appendCodexConfig,
+  codexConfigPath,
+  codexTomlSnippet,
+} from "../init.js";
 
 /** Count `[mcp_servers.scholar-feed]` table headers in a TOML string. */
 function countTables(toml: string): number {
@@ -206,6 +210,35 @@ args = ["some-other-mcp"]
       f.includes(".tmp"),
     );
     assert.deepStrictEqual(leftovers, []);
+  });
+});
+
+// stderr lands in scrollback, screen-shares and bug reports, so the PRINTED
+// snippet must never carry a real key — the same rule the other snippet helpers in
+// init.ts already follow. CodeQL flagged the earlier form (js/clear-text-logging)
+// because it threaded the key in and relied on a ternary to discard it.
+describe("init: printed Codex snippet never contains a real key", () => {
+  it("emits the placeholder, not the key, when a key is present", () => {
+    const snippet = codexTomlSnippet(true);
+    assert.match(snippet, /SF_API_KEY = "<your-key>"/);
+    assert.ok(
+      !snippet.includes("sf_"),
+      `printed snippet must contain no sf_ key: ${snippet}`,
+    );
+  });
+
+  it("omits env entirely when there is no key", () => {
+    const snippet = codexTomlSnippet(false);
+    assert.ok(!snippet.includes("env"), snippet);
+    assert.match(snippet, /^\[mcp_servers\.scholar-feed\]$/m);
+  });
+
+  // The function must not be able to receive a key at all — it takes a boolean.
+  it("takes a boolean, so a key cannot be passed in", () => {
+    assert.strictEqual(codexTomlSnippet.length, 1);
+    // A truthy non-boolean still yields the placeholder, never its own value.
+    const snippet = codexTomlSnippet(true);
+    assert.ok(!snippet.includes("true"));
   });
 });
 

--- a/src/__tests__/init_codex.test.ts
+++ b/src/__tests__/init_codex.test.ts
@@ -1,0 +1,141 @@
+/**
+ * `init` wizard — OpenAI Codex config writing.
+ *
+ * Codex is the one auto-configured client that uses TOML, and it REJECTS a
+ * duplicate `[mcp_servers.<name>]` table with a parse error that takes down every
+ * other server in the file. So the two properties that matter are:
+ *   1. appending produces valid TOML for any well-formed input (including a file
+ *      with no trailing newline), and
+ *   2. it is idempotent — a second run must not add a second table.
+ *
+ * These run against a real temp file rather than a mocked fs: the bug class here
+ * is corrupting a user's editor config on disk, which a mock cannot catch.
+ */
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  rmSync,
+} from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { appendCodexConfig } from "../init.js";
+
+/** Count `[mcp_servers.scholar-feed]` table headers in a TOML string. */
+function countTables(toml: string): number {
+  return (
+    toml.match(/^\s*\[\s*mcp_servers\s*\.\s*"?scholar-feed"?\s*\]/gm) ?? []
+  ).length;
+}
+
+describe("init: Codex config.toml", () => {
+  let dir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sf-codex-"));
+    configPath = join(dir, ".codex", "config.toml");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("creates the file (and parent dir) when absent, with the key", () => {
+    const outcome = appendCodexConfig(configPath, "sf_testkey123");
+    assert.strictEqual(outcome, "written");
+
+    const toml = readFileSync(configPath, "utf-8");
+    assert.match(toml, /^\[mcp_servers\.scholar-feed\]$/m);
+    assert.match(toml, /^command = "npx"$/m);
+    assert.match(toml, /^args = \["-y", "scholar-feed-mcp@latest"\]$/m);
+    assert.match(toml, /^env = \{ SF_API_KEY = "sf_testkey123" \}$/m);
+    assert.ok(toml.endsWith("\n"), "must end with a newline");
+  });
+
+  it("omits the env line entirely when no key is given", () => {
+    appendCodexConfig(configPath, "");
+    const toml = readFileSync(configPath, "utf-8");
+    assert.match(toml, /^\[mcp_servers\.scholar-feed\]$/m);
+    assert.ok(!toml.includes("env"), "keyless config must have no env line");
+  });
+
+  it("preserves an existing config and its other servers", () => {
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(
+      configPath,
+      `model = "gpt-5-codex"
+
+[mcp_servers.other-server]
+command = "uvx"
+args = ["some-other-mcp"]
+`,
+    );
+
+    const outcome = appendCodexConfig(configPath, "sf_abc");
+    assert.strictEqual(outcome, "written");
+
+    const toml = readFileSync(configPath, "utf-8");
+    assert.match(toml, /^model = "gpt-5-codex"$/m, "top-level key preserved");
+    assert.match(
+      toml,
+      /^\[mcp_servers\.other-server\]$/m,
+      "other server preserved",
+    );
+    assert.match(toml, /^\[mcp_servers\.scholar-feed\]$/m);
+    // The new table header must start its own line, or it would be parsed as
+    // part of the previous table's value.
+    assert.ok(
+      /\n\[mcp_servers\.scholar-feed\]/.test(toml),
+      "new table must begin on its own line",
+    );
+  });
+
+  it("inserts a newline when the existing file does not end with one", () => {
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, 'model = "gpt-5-codex"'); // deliberately no \n
+
+    appendCodexConfig(configPath, "");
+
+    const toml = readFileSync(configPath, "utf-8");
+    // The failure this guards: `...gpt-5-codex"[mcp_servers.scholar-feed]` on one
+    // line, which is a TOML parse error.
+    assert.ok(
+      !/gpt-5-codex"\[/.test(toml),
+      `table header spliced onto the value line: ${JSON.stringify(toml)}`,
+    );
+    assert.match(toml, /^model = "gpt-5-codex"$/m);
+    assert.match(toml, /^\[mcp_servers\.scholar-feed\]$/m);
+  });
+
+  it("is idempotent — a second run does not add a duplicate table", () => {
+    assert.strictEqual(appendCodexConfig(configPath, "sf_one"), "written");
+    assert.strictEqual(
+      appendCodexConfig(configPath, "sf_two"),
+      "already-present",
+    );
+
+    const toml = readFileSync(configPath, "utf-8");
+    assert.strictEqual(countTables(toml), 1, "exactly one table");
+    // The first key must survive untouched — we must not silently rewrite it.
+    assert.match(toml, /sf_one/);
+    assert.ok(!toml.includes("sf_two"), "second run must not write a new key");
+  });
+
+  it("detects the quoted table form so it stays idempotent", () => {
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(
+      configPath,
+      '[mcp_servers."scholar-feed"]\ncommand = "npx"\n',
+    );
+    assert.strictEqual(
+      appendCodexConfig(configPath, "sf_x"),
+      "already-present",
+    );
+    assert.strictEqual(countTables(readFileSync(configPath, "utf-8")), 1);
+  });
+});

--- a/src/__tests__/init_codex.test.ts
+++ b/src/__tests__/init_codex.test.ts
@@ -20,10 +20,12 @@ import {
   readFileSync,
   writeFileSync,
   rmSync,
+  statSync,
+  readdirSync,
 } from "node:fs";
 import { join, dirname } from "node:path";
-import { tmpdir } from "node:os";
-import { appendCodexConfig } from "../init.js";
+import { tmpdir, homedir } from "node:os";
+import { appendCodexConfig, codexConfigPath } from "../init.js";
 
 /** Count `[mcp_servers.scholar-feed]` table headers in a TOML string. */
 function countTables(toml: string): number {
@@ -137,5 +139,96 @@ args = ["some-other-mcp"]
       "already-present",
     );
     assert.strictEqual(countTables(readFileSync(configPath, "utf-8")), 1);
+  });
+
+  // Every one of these already defines mcp_servers.scholar-feed. Appending a
+  // header for it is a TOML duplicate-key error, which makes Codex refuse to parse
+  // the file at all — taking down the user's OTHER servers with it. Detecting only
+  // the plain table header was not enough.
+  for (const [label, body] of [
+    ["dotted key", 'mcp_servers.scholar-feed.command = "old"\n'],
+    [
+      "fully quoted header",
+      '["mcp_servers"."scholar-feed"]\ncommand = "old"\n',
+    ],
+    [
+      "inline table at the root",
+      'mcp_servers = { scholar-feed = { command = "old" } }\n',
+    ],
+  ] as const) {
+    it(`refuses to append when the config uses the ${label} form`, () => {
+      mkdirSync(dirname(configPath), { recursive: true });
+      writeFileSync(configPath, body);
+      const outcome = appendCodexConfig(configPath, "sf_new");
+
+      assert.ok(
+        outcome === "already-present" || outcome === "manual",
+        `must not write; got ${outcome}`,
+      );
+      // The decisive assertion: the file is untouched, so it cannot have become
+      // a duplicate definition.
+      assert.strictEqual(readFileSync(configPath, "utf-8"), body);
+    });
+  }
+
+  // A key that is not TOML-safe must never reach the file. Prefix-only validation
+  // let `sf_bad"key` through and broke the whole config.
+  for (const badKey of ['sf_bad"key', "sf_back\\slash", "sf_new\nline"]) {
+    it(`declines to write an unsafe key (${JSON.stringify(badKey)})`, () => {
+      assert.strictEqual(appendCodexConfig(configPath, badKey), "manual");
+      assert.throws(
+        () => readFileSync(configPath, "utf-8"),
+        "must not have created the file at all",
+      );
+    });
+  }
+
+  it("creates the file 0600 — it can hold an API key", () => {
+    appendCodexConfig(configPath, "sf_secret");
+    const mode = statSync(configPath).mode & 0o777;
+    assert.strictEqual(
+      mode,
+      0o600,
+      `expected 0600, got 0${mode.toString(8)} (0644 would be world-readable)`,
+    );
+  });
+
+  it("preserves the mode of a file the user already had", () => {
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, 'model = "gpt-5-codex"\n', { mode: 0o640 });
+    appendCodexConfig(configPath, "sf_secret");
+    assert.strictEqual(statSync(configPath).mode & 0o777, 0o640);
+  });
+
+  it("leaves no temp file behind", () => {
+    appendCodexConfig(configPath, "sf_abc");
+    const leftovers = readdirSync(dirname(configPath)).filter((f) =>
+      f.includes(".tmp"),
+    );
+    assert.deepStrictEqual(leftovers, []);
+  });
+});
+
+describe("init: codexConfigPath", () => {
+  const saved = process.env.CODEX_HOME;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = saved;
+  });
+
+  it("honours CODEX_HOME, which Codex itself reads", () => {
+    process.env.CODEX_HOME = join("/tmp", "custom-codex");
+    assert.strictEqual(
+      codexConfigPath(),
+      join("/tmp", "custom-codex", "config.toml"),
+    );
+  });
+
+  it("falls back to ~/.codex/config.toml", () => {
+    delete process.env.CODEX_HOME;
+    assert.strictEqual(
+      codexConfigPath(),
+      join(homedir(), ".codex", "config.toml"),
+    );
   });
 });

--- a/src/init.ts
+++ b/src/init.ts
@@ -23,7 +23,14 @@
 
 import { createInterface } from "readline";
 import { execFileSync } from "child_process";
-import { readFileSync, writeFileSync, mkdirSync } from "fs";
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  statSync,
+  renameSync,
+  rmSync,
+} from "fs";
 import { join, dirname } from "path";
 import { homedir, platform } from "os";
 
@@ -169,8 +176,39 @@ function standardJsonSnippet(hasKey: boolean): string {
 }
 
 /**
- * Codex's `[mcp_servers.<name>]` TOML table. `env` is an inline table, which is
- * what Codex's own docs use.
+ * Codex's config directory. `CODEX_HOME` overrides `~/.codex`, and Codex itself
+ * honours it — verified against codex-cli 0.146.1, which read a config from
+ * `$CODEX_HOME/config.toml` and listed the server. Writing to `~/.codex`
+ * unconditionally meant the wizard reported success while Codex never saw the
+ * server at all.
+ */
+export function codexConfigPath(): string {
+  const home = process.env.CODEX_HOME;
+  return home
+    ? join(home, "config.toml")
+    : join(homedir(), ".codex", "config.toml");
+}
+
+/**
+ * Is this safe to embed in a TOML basic string?
+ *
+ * Only the prefix was validated before, so a mistyped paste like `sf_bad"key`
+ * was written straight into `SF_API_KEY = "..."` and made the user's whole Codex
+ * config unparseable. Real keys are `sf_` + hex, so restricting the charset costs
+ * nothing and removes the escaping question entirely.
+ */
+function isSafeApiKey(apiKey: string): boolean {
+  return /^sf_[A-Za-z0-9_-]+$/.test(apiKey);
+}
+
+/**
+ * Codex's `[mcp_servers.<name>]` TOML table.
+ *
+ * `env` is written as an inline table. Codex's published example uses a
+ * `[mcp_servers.<name>.env]` sub-table instead, but both are the same construct in
+ * TOML and codex-cli 0.146.1 accepts the inline form (verified: `codex mcp list`
+ * showed SF_API_KEY set from an inline-table config). Inline keeps the whole server
+ * definition in one appendable block, which the append strategy below depends on.
  */
 function codexTomlBlock(apiKey: string): string {
   const envLine = apiKey ? `\nenv = { SF_API_KEY = "${apiKey}" }` : "";
@@ -180,47 +218,92 @@ args = ["-y", "scholar-feed-mcp@latest"]${envLine}`;
 }
 
 /**
- * Add the Codex server table to `~/.codex/config.toml`, appending rather than
+ * Every way a Codex config can already define `mcp_servers.scholar-feed`.
+ *
+ * The table-header form is not the only one, and appending a second definition in
+ * ANY of these cases is a TOML duplicate-key error that takes down the user's other
+ * servers along with ours:
+ *   - `[mcp_servers.scholar-feed]`      / `[mcp_servers."scholar-feed"]`
+ *   - `["mcp_servers"."scholar-feed"]`  (fully quoted)
+ *   - `mcp_servers.scholar-feed.command = "..."`  (dotted key, no header)
+ *   - `mcp_servers = { scholar-feed = ... }`      (inline table at the root)
+ */
+const CODEX_TABLE_HEADER =
+  /^[ \t]*\[[ \t]*"?mcp_servers"?[ \t]*\.[ \t]*"?scholar-feed"?[ \t]*\]/m;
+const CODEX_DOTTED_KEY =
+  /^[ \t]*"?mcp_servers"?[ \t]*\.[ \t]*"?scholar-feed"?[ \t]*\./m;
+const CODEX_INLINE_ROOT = /^[ \t]*"?mcp_servers"?[ \t]*=/m;
+
+/**
+ * Add the Codex server table to Codex's config.toml, appending rather than
  * rewriting.
  *
  * We APPEND instead of parse-merge on purpose: bundling a TOML parser would break
  * the `dependencies: {}` rule (CLAUDE.md), and hand-rolling one to rewrite a
- * user's whole editor config is a far worse failure mode than a duplicate table.
+ * user's whole editor config is a far worse failure mode than declining to write.
  * Opening a new `[table]` header always closes the previous one, so appending is
- * valid TOML for any well-formed input.
+ * valid TOML for any input we accept.
  *
- * Idempotency matters here because Codex REJECTS a duplicate key outright: a
- * second `[mcp_servers.scholar-feed]` is a parse error that would take down the
- * user's other servers too. So if the table is already present we touch nothing
- * and say so.
+ * Because a duplicate definition breaks the ENTIRE file (Codex refuses to parse it,
+ * so every other server the user configured stops working), this fails SAFE: if any
+ * form of an existing definition is detected — or anything we cannot reason about,
+ * like a `mcp_servers = {...}` root — we write nothing and return 'manual' so the
+ * caller prints the snippet for the user to place by hand. Refusing to write is a
+ * mild inconvenience; corrupting a config is not.
  *
- * @returns 'written' | 'already-present'
+ * The write is atomic (temp file + rename) because the target holds the user's whole
+ * Codex configuration: a crash midway through a plain truncating write would destroy
+ * it. A newly created file gets mode 0600 — it can contain an API key, and Node's
+ * default under a 022 umask would be world-readable 0644. An existing file keeps its
+ * own mode, since rename preserves the temp file's; we set it explicitly to match.
+ *
+ * @returns 'written'         — the table was appended
+ *          'already-present' — a definition already exists; nothing changed
+ *          'manual'          — cannot append safely; caller must print the snippet
  */
 export function appendCodexConfig(
   filePath: string,
   apiKey: string,
-): "written" | "already-present" {
+): "written" | "already-present" | "manual" {
+  if (apiKey && !isSafeApiKey(apiKey)) return "manual";
+
   let existing = "";
+  let existingMode: number | undefined;
   try {
     existing = readFileSync(filePath, "utf-8");
+    existingMode = statSync(filePath).mode & 0o777;
   } catch {
     // Missing — we create it below.
   }
 
-  // Match the table header allowing TOML's permitted whitespace and the quoted
-  // key form (`["scholar-feed"]`), so we do not double-write a config the user
-  // (or a previous run) already has.
-  if (/^\s*\[\s*mcp_servers\s*\.\s*"?scholar-feed"?\s*\]/m.test(existing)) {
+  if (CODEX_TABLE_HEADER.test(existing) || CODEX_DOTTED_KEY.test(existing)) {
     return "already-present";
   }
+  // A root-level `mcp_servers = {...}` inline table may or may not contain our
+  // key, and appending a header for a table already defined inline is a duplicate
+  // either way. Hand it to the user rather than guess.
+  if (CODEX_INLINE_ROOT.test(existing)) return "manual";
 
   const dir = dirname(filePath);
   if (dir) mkdirSync(dir, { recursive: true });
   const separator = existing === "" || existing.endsWith("\n") ? "" : "\n";
-  writeFileSync(
-    filePath,
-    `${existing}${separator}\n${codexTomlBlock(apiKey)}\n`,
-  );
+  const next = `${existing}${separator}\n${codexTomlBlock(apiKey)}\n`;
+
+  // 0600 on create: this file can hold an API key. Preserve the mode of a file the
+  // user already had — they may have loosened or tightened it deliberately.
+  const mode = existingMode ?? 0o600;
+  const tmp = `${filePath}.scholar-feed-${process.pid}.tmp`;
+  try {
+    writeFileSync(tmp, next, { mode });
+    renameSync(tmp, filePath);
+  } catch (e) {
+    try {
+      rmSync(tmp, { force: true });
+    } catch {
+      // best effort — the rename already failed, nothing more to do
+    }
+    throw e;
+  }
   return "written";
 }
 
@@ -404,18 +487,33 @@ export async function runInit(): Promise<void> {
       break;
     }
     case "9": {
-      // OpenAI Codex — ~/.codex/config.toml, shared by the Codex CLI and the IDE
-      // extension. TOML, not JSON: pasting any of the other snippets here fails.
-      const filePath = join(homedir(), ".codex", "config.toml");
+      // OpenAI Codex — config.toml, shared by the Codex CLI and the IDE extension.
+      // TOML, not JSON: pasting any of the other snippets here fails. Honours
+      // CODEX_HOME, which Codex itself reads.
+      const filePath = codexConfigPath();
       const outcome = appendCodexConfig(filePath, apiKey);
       if (outcome === "already-present") {
         console.error(
-          `  ${filePath} already has a [mcp_servers.scholar-feed] table — left unchanged.`,
+          `  ${filePath} already defines mcp_servers.scholar-feed — left unchanged.`,
         );
         console.error(
-          "  Edit it by hand if you need to update the key (a duplicate table would",
+          "  Edit it by hand if you need to update the key (a duplicate definition",
         );
-        console.error("  make Codex reject the whole file).");
+        console.error("  would make Codex reject the whole file).");
+      } else if (outcome === "manual") {
+        // Declined to write: we could not guarantee a safe append. Print instead —
+        // a config we cannot reason about is the user's to edit, not ours.
+        console.error(
+          `  Could not safely edit ${filePath}, so nothing was changed.`,
+        );
+        console.error("  Add this to it yourself:\n");
+        console.error(codexTomlBlock(apiKey ? "<your-key>" : ""));
+        console.error(
+          "\n  (Either it already sets mcp_servers inline, or the key you entered has",
+        );
+        console.error(
+          "  characters that are not valid unquoted in TOML — check it and retry.)",
+        );
       } else {
         console.error(`  Appended to ${filePath}`);
         console.error("  Restart Codex, then ask it to search for papers.");

--- a/src/init.ts
+++ b/src/init.ts
@@ -13,6 +13,7 @@
  *     CLI, LM Studio) — handled by mergeMcpServersConfig.
  *   - VS Code uses a `servers` key with an explicit `type: "stdio"`.
  *   - Zed uses a `context_servers` key with a required `source: "custom"`.
+ *   - Codex is TOML, not JSON — appended as a `[mcp_servers.scholar-feed]` table.
  *   - Continue (YAML), JetBrains (UI), and Cline/Roo (UI) can't be safely
  *     written for the user, so we print the snippet to paste instead.
  *
@@ -26,11 +27,23 @@ import { readFileSync, writeFileSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
 import { homedir, platform } from "os";
 
-const rl = createInterface({ input: process.stdin, output: process.stderr });
+/**
+ * The readline interface, created on first use rather than at module scope.
+ *
+ * Attaching to process.stdin eagerly resumes the stream and keeps the event loop
+ * alive, which hangs any test that merely imports this module to exercise a
+ * config writer. Lazy creation keeps `init.ts` importable.
+ */
+let rl: ReturnType<typeof createInterface> | undefined;
+
+function prompt(): ReturnType<typeof createInterface> {
+  rl ??= createInterface({ input: process.stdin, output: process.stderr });
+  return rl;
+}
 
 function ask(question: string): Promise<string> {
   return new Promise((resolve) => {
-    rl.question(question, (answer) => resolve(answer.trim()));
+    prompt().question(question, (answer) => resolve(answer.trim()));
   });
 }
 
@@ -155,6 +168,62 @@ function standardJsonSnippet(hasKey: boolean): string {
 }`;
 }
 
+/**
+ * Codex's `[mcp_servers.<name>]` TOML table. `env` is an inline table, which is
+ * what Codex's own docs use.
+ */
+function codexTomlBlock(apiKey: string): string {
+  const envLine = apiKey ? `\nenv = { SF_API_KEY = "${apiKey}" }` : "";
+  return `[mcp_servers.scholar-feed]
+command = "npx"
+args = ["-y", "scholar-feed-mcp@latest"]${envLine}`;
+}
+
+/**
+ * Add the Codex server table to `~/.codex/config.toml`, appending rather than
+ * rewriting.
+ *
+ * We APPEND instead of parse-merge on purpose: bundling a TOML parser would break
+ * the `dependencies: {}` rule (CLAUDE.md), and hand-rolling one to rewrite a
+ * user's whole editor config is a far worse failure mode than a duplicate table.
+ * Opening a new `[table]` header always closes the previous one, so appending is
+ * valid TOML for any well-formed input.
+ *
+ * Idempotency matters here because Codex REJECTS a duplicate key outright: a
+ * second `[mcp_servers.scholar-feed]` is a parse error that would take down the
+ * user's other servers too. So if the table is already present we touch nothing
+ * and say so.
+ *
+ * @returns 'written' | 'already-present'
+ */
+export function appendCodexConfig(
+  filePath: string,
+  apiKey: string,
+): "written" | "already-present" {
+  let existing = "";
+  try {
+    existing = readFileSync(filePath, "utf-8");
+  } catch {
+    // Missing — we create it below.
+  }
+
+  // Match the table header allowing TOML's permitted whitespace and the quoted
+  // key form (`["scholar-feed"]`), so we do not double-write a config the user
+  // (or a previous run) already has.
+  if (/^\s*\[\s*mcp_servers\s*\.\s*"?scholar-feed"?\s*\]/m.test(existing)) {
+    return "already-present";
+  }
+
+  const dir = dirname(filePath);
+  if (dir) mkdirSync(dir, { recursive: true });
+  const separator = existing === "" || existing.endsWith("\n") ? "" : "\n";
+  writeFileSync(
+    filePath,
+    `${existing}${separator}\n${codexTomlBlock(apiKey)}\n`,
+  );
+  return "written";
+}
+
 function continueYamlSnippet(hasKey: boolean): string {
   const envBlock = hasKey ? `\n    env:\n      SF_API_KEY: <your-key>` : "";
   return `mcpServers:
@@ -181,7 +250,7 @@ export async function runInit(): Promise<void> {
     console.error(
       "  Error: API key must start with 'sf_'. Get one at https://www.scholarfeed.org/settings",
     );
-    rl.close();
+    prompt().close();
     process.exit(1);
   }
 
@@ -196,11 +265,12 @@ export async function runInit(): Promise<void> {
   console.error("   6) Zed");
   console.error("   7) Gemini CLI");
   console.error("   8) LM Studio");
+  console.error("   9) OpenAI Codex");
   console.error("  Print snippet to paste:");
-  console.error("   9) Continue");
-  console.error("  10) JetBrains / PyCharm");
-  console.error("  11) Cline / Roo Code");
-  const choice = await ask("  Choice (1-11): ");
+  console.error("  10) Continue");
+  console.error("  11) JetBrains / PyCharm");
+  console.error("  12) Cline / Roo Code");
+  const choice = await ask("  Choice (1-12): ");
 
   // Step 3: Configure
   printStep(3, 3, "Configuring...");
@@ -334,6 +404,33 @@ export async function runInit(): Promise<void> {
       break;
     }
     case "9": {
+      // OpenAI Codex — ~/.codex/config.toml, shared by the Codex CLI and the IDE
+      // extension. TOML, not JSON: pasting any of the other snippets here fails.
+      const filePath = join(homedir(), ".codex", "config.toml");
+      const outcome = appendCodexConfig(filePath, apiKey);
+      if (outcome === "already-present") {
+        console.error(
+          `  ${filePath} already has a [mcp_servers.scholar-feed] table — left unchanged.`,
+        );
+        console.error(
+          "  Edit it by hand if you need to update the key (a duplicate table would",
+        );
+        console.error("  make Codex reject the whole file).");
+      } else {
+        console.error(`  Appended to ${filePath}`);
+        console.error("  Restart Codex, then ask it to search for papers.");
+      }
+      if (platform() === "win32") {
+        console.error(
+          '  On Windows, if Codex cannot launch the server, change command to "cmd"',
+        );
+        console.error(
+          '  and args to ["/c", "npx", "-y", "scholar-feed-mcp@latest"].',
+        );
+      }
+      break;
+    }
+    case "10": {
       // Continue — YAML config; print rather than risk corrupting the file.
       console.error(
         "  Add this to ~/.continue/config.yaml (global) or .continue/config.yaml (workspace):\n",
@@ -344,7 +441,7 @@ export async function runInit(): Promise<void> {
       }
       break;
     }
-    case "10": {
+    case "11": {
       // JetBrains AI Assistant — configured through the IDE UI.
       console.error(
         "  In your JetBrains IDE: Settings -> Tools -> AI Assistant ->",
@@ -358,7 +455,7 @@ export async function runInit(): Promise<void> {
       }
       break;
     }
-    case "11": {
+    case "12": {
       // Cline / Roo Code — configured through the extension UI.
       console.error(
         "  In Cline or Roo Code: click the MCP Servers icon -> Configure / Edit,",
@@ -374,7 +471,7 @@ export async function runInit(): Promise<void> {
       console.error(
         "  Invalid choice. Run 'npx scholar-feed-mcp@latest init' again.",
       );
-      rl.close();
+      prompt().close();
       process.exit(1);
     }
   }
@@ -383,7 +480,7 @@ export async function runInit(): Promise<void> {
   console.error("\n  Verifying connection...");
   await verifyKey(apiKey);
 
-  rl.close();
+  prompt().close();
   console.error(
     '\nDone! Try asking: "Search for papers on test-time compute scaling"',
   );

--- a/src/init.ts
+++ b/src/init.ts
@@ -220,15 +220,25 @@ args = ["-y", "scholar-feed-mcp@latest"]${envLine}`;
 /**
  * The PRINTABLE Codex block — placeholder only, never a real key.
  *
- * Takes a boolean rather than the key itself, matching standardJsonSnippet and
- * continueYamlSnippet. The key must not reach this path at all: stderr ends up in
- * scrollback, screen-shares and bug reports. Threading `apiKey` in and relying on
- * a ternary to swap in a placeholder also tripped CodeQL's clear-text-logging rule
- * (js/clear-text-logging), which cannot see that the ternary discards it — and a
- * rule that has to be argued with about a secret is a rule worth just satisfying.
+ * Deliberately does NOT delegate to codexTomlBlock, even though the template is
+ * the same. codexTomlBlock is the function that embeds the real key (for the file
+ * we write at 0600); sharing it with a path that reaches `console.error` means the
+ * only thing standing between a secret and stderr is which argument a caller
+ * happened to pass. CodeQL says so too: its summary of codexTomlBlock is
+ * context-insensitive, so `console.error(shared(placeholder))` still reported
+ * js/clear-text-logging because a DIFFERENT caller passes apiKey.
+ *
+ * So the two paths share no code. This one has no parameter a key could enter
+ * through, which makes the invariant structural rather than a matter of reviewer
+ * attention. The duplicated template is pinned by a test that fails if the two
+ * blocks drift apart; that is the cost of the separation and it is worth paying,
+ * because stderr ends up in scrollback, screen-shares and bug reports.
  */
 export function codexTomlSnippet(hasKey: boolean): string {
-  return codexTomlBlock(hasKey ? "<your-key>" : "");
+  const envLine = hasKey ? `\nenv = { SF_API_KEY = "<your-key>" }` : "";
+  return `[mcp_servers.scholar-feed]
+command = "npx"
+args = ["-y", "scholar-feed-mcp@latest"]${envLine}`;
 }
 
 /**

--- a/src/init.ts
+++ b/src/init.ts
@@ -218,6 +218,20 @@ args = ["-y", "scholar-feed-mcp@latest"]${envLine}`;
 }
 
 /**
+ * The PRINTABLE Codex block — placeholder only, never a real key.
+ *
+ * Takes a boolean rather than the key itself, matching standardJsonSnippet and
+ * continueYamlSnippet. The key must not reach this path at all: stderr ends up in
+ * scrollback, screen-shares and bug reports. Threading `apiKey` in and relying on
+ * a ternary to swap in a placeholder also tripped CodeQL's clear-text-logging rule
+ * (js/clear-text-logging), which cannot see that the ternary discards it — and a
+ * rule that has to be argued with about a secret is a rule worth just satisfying.
+ */
+export function codexTomlSnippet(hasKey: boolean): string {
+  return codexTomlBlock(hasKey ? "<your-key>" : "");
+}
+
+/**
  * Every way a Codex config can already define `mcp_servers.scholar-feed`.
  *
  * The table-header form is not the only one, and appending a second definition in
@@ -507,7 +521,7 @@ export async function runInit(): Promise<void> {
           `  Could not safely edit ${filePath}, so nothing was changed.`,
         );
         console.error("  Add this to it yourself:\n");
-        console.error(codexTomlBlock(apiKey ? "<your-key>" : ""));
+        console.error(codexTomlSnippet(hasKey));
         console.error(
           "\n  (Either it already sets mcp_servers inline, or the key you entered has",
         );

--- a/src/server-http.ts
+++ b/src/server-http.ts
@@ -27,6 +27,8 @@ import {
   buildServerInfo,
   SERVER_INSTRUCTIONS,
   landingPageHtml,
+  mcpEndpointHtml,
+  prefersHtml,
 } from "./server-info.js";
 import { faviconBytes } from "./favicon-asset.js";
 import { runWithCreds } from "./http/credentials.js";
@@ -194,7 +196,15 @@ async function handleMcpPost(
 }
 
 /** GET/DELETE /mcp in stateless mode: there is no session to stream or delete. */
-function methodNotAllowed(_req: Request, res: Response): void {
+function methodNotAllowed(req: Request, res: Response): void {
+  // A person pasted the endpoint into a browser. Serve the setup page rather than
+  // a bare JSON error they will read as an outage (see mcpEndpointHtml). Status
+  // stays 405 so no client can mistake this for a successful call. Mirrors the
+  // same branch in worker.ts — keep the two entry points in sync.
+  if (req.method.toUpperCase() === "GET" && prefersHtml(req.headers.accept)) {
+    res.status(405).type("html").send(mcpEndpointHtml());
+    return;
+  }
   res.status(405).json({
     jsonrpc: "2.0",
     error: {

--- a/src/server-http.ts
+++ b/src/server-http.ts
@@ -197,6 +197,12 @@ async function handleMcpPost(
 
 /** GET/DELETE /mcp in stateless mode: there is no session to stream or delete. */
 function methodNotAllowed(req: Request, res: Response): void {
+  // `Vary: Accept` is load-bearing now that this route has two representations —
+  // without it a shared cache can replay the browser HTML to a protocol GET.
+  // `Allow` is required on a 405 by RFC 9110. Both apply to either branch.
+  res.setHeader("Allow", "POST");
+  res.setHeader("Vary", "Accept");
+
   // A person pasted the endpoint into a browser. Serve the setup page rather than
   // a bare JSON error they will read as an outage (see mcpEndpointHtml). Status
   // stays 405 so no client can mistake this for a successful call. Mirrors the

--- a/src/server-info.ts
+++ b/src/server-info.ts
@@ -53,6 +53,107 @@ export function landingPageHtml(): string {
 }
 
 /**
+ * The human-facing page for `GET /mcp`.
+ *
+ * `GET /mcp` is protocol-correct as a JSON-RPC 405 (stateless mode has no session
+ * to resume), but a person who pastes the endpoint into a browser — which is the
+ * first thing someone does when a client config will not connect — sees a bare
+ * JSON error and reads it as "the server is broken". That happened to a paying
+ * customer on 2026-08-27: two requests, `GET /mcp` -> 405 then `/favicon.ico`,
+ * and they never returned. The endpoint was healthy the whole time.
+ *
+ * So: content-negotiate. A browser navigation (`Accept: text/html`) gets this
+ * page; every real MCP client — which sends `Accept: application/json` and/or
+ * `text/event-stream`, never `text/html` — still gets the JSON-RPC 405 body
+ * unchanged. The status stays 405 either way: the request genuinely was the wrong
+ * method, and a 200 here would let a misconfigured client read failure as success.
+ *
+ * Kept dependency-free and inline (see the `dependencies: {}` rule in CLAUDE.md).
+ */
+export function mcpEndpointHtml(): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Scholar Feed MCP — you found the right endpoint</title>
+<link rel="icon" type="image/png" href="/favicon.ico">
+<link rel="icon" type="image/png" href="${iconUrl()}">
+<meta property="og:title" content="Scholar Feed MCP endpoint">
+<meta property="og:image" content="${iconUrl()}">
+<style>
+body{font-family:system-ui,-apple-system,sans-serif;max-width:44rem;margin:3rem auto;padding:0 1.25rem;line-height:1.6;color:#1c1917;background:#f7f6f3}
+h1{font-size:1.4rem;margin:0 0 .5rem}
+h2{font-size:.8rem;text-transform:uppercase;letter-spacing:.06em;color:#0d5c63;margin:2rem 0 .5rem}
+.ok{background:#e7f1f1;border-left:3px solid #0d5c63;padding:.75rem 1rem;margin:0 0 1.5rem;border-radius:0 .25rem .25rem 0}
+pre{background:#1c1917;color:#f7f6f3;padding:.9rem 1rem;border-radius:.4rem;overflow-x:auto;font-size:.82rem;line-height:1.5}
+code{font-size:.9em}
+p code,li code{background:#eae8e3;padding:.1rem .35rem;border-radius:.25rem}
+a{color:#0d5c63}
+ul{padding-left:1.1rem}
+footer{margin-top:2.5rem;font-size:.85rem;color:#6b6660}
+</style>
+</head>
+<body>
+<h1>Scholar Feed MCP</h1>
+<div class="ok">
+<strong>This endpoint is working.</strong> You reached it with a browser, which sends
+<code>GET</code> — the MCP protocol only speaks <code>POST</code> here, so you got a 405.
+Nothing is broken. Point an MCP client at this URL instead of opening it directly.
+</div>
+
+<h2>Claude Code</h2>
+<pre><code>claude mcp add scholar-feed -- npx -y scholar-feed-mcp</code></pre>
+
+<h2>OpenAI Codex</h2>
+<p>Codex uses TOML, not JSON. Add to <code>~/.codex/config.toml</code>:</p>
+<pre><code>[mcp_servers.scholar-feed]
+command = "npx"
+args = ["-y", "scholar-feed-mcp"]
+env = { SF_API_KEY = "sf_your_key_here" }</code></pre>
+
+<h2>Cursor, Claude Desktop, Windsurf, and most others</h2>
+<pre><code>{
+  "mcpServers": {
+    "scholar-feed": {
+      "command": "npx",
+      "args": ["-y", "scholar-feed-mcp"],
+      "env": { "SF_API_KEY": "sf_your_key_here" }
+    }
+  }
+}</code></pre>
+
+<h2>Or let the wizard do it</h2>
+<pre><code>npx scholar-feed-mcp init</code></pre>
+<p>It detects your client, writes the config file, and verifies the connection.</p>
+
+<h2>Using this URL directly</h2>
+<p>If your client supports remote streamable HTTP, use <code>POST</code> to this
+endpoint with <code>Authorization: Bearer sf_your_key_here</code>. Without a key you
+get 100 calls/day; a free key raises it to 1,000/day.</p>
+
+<footer>
+Full setup for every client, the tool reference, and free API keys:
+<a href="https://www.scholarfeed.org/developers">scholarfeed.org/developers</a>.
+</footer>
+</body>
+</html>
+`;
+}
+
+/**
+ * Does this request look like a person in a browser rather than an MCP client?
+ *
+ * Deliberately narrow: `text/html` must be explicitly present. MCP clients send
+ * `application/json` and/or `text/event-stream`; curl and other CLI tools send a
+ * wildcard Accept or none at all. Only a real browser navigation asks for HTML, so
+ * nothing that speaks the protocol can be diverted to the HTML page by accident.
+ */
+export function prefersHtml(acceptHeader: string | null | undefined): boolean {
+  return (acceptHeader ?? "").toLowerCase().includes("text/html");
+}
+
+/**
  * Server-level usage instructions, surfaced to the host model on initialize and
  * shared by all entry points (stdio, HTTP, worker). A fresh agent's reflex is
  * "research = search", so without this it calls search_papers once and never

--- a/src/server-info.ts
+++ b/src/server-info.ts
@@ -141,16 +141,43 @@ Full setup for every client, the tool reference, and free API keys:
 `;
 }
 
+/** One parsed Accept media range: the type and its q-value (default 1). */
+function acceptQ(acceptHeader: string, mediaType: string): number | undefined {
+  for (const part of acceptHeader.toLowerCase().split(",")) {
+    const [type, ...params] = part.split(";").map((s) => s.trim());
+    if (type !== mediaType) continue;
+    const q = params
+      .map((p) => /^q=([0-9.]+)$/.exec(p))
+      .find((m): m is RegExpExecArray => m !== null);
+    return q ? Number.parseFloat(q[1]) : 1;
+  }
+  return undefined;
+}
+
 /**
  * Does this request look like a person in a browser rather than an MCP client?
  *
- * Deliberately narrow: `text/html` must be explicitly present. MCP clients send
- * `application/json` and/or `text/event-stream`; curl and other CLI tools send a
- * wildcard Accept or none at all. Only a real browser navigation asks for HTML, so
- * nothing that speaks the protocol can be diverted to the HTML page by accident.
+ * THE PROTOCOL ALWAYS WINS. HTML is served only when the client asks for
+ * `text/html` with a non-zero q AND names neither protocol content type. A
+ * substring test was not enough:
+ *   - `Accept: application/json, text/html;q=0` explicitly REFUSES html, but
+ *     `includes("text/html")` said yes.
+ *   - `Accept: text/html, application/json` is a client that speaks both; handing
+ *     it HTML would break it.
+ * A real browser navigation sends html at q=1 alongside xhtml/xml and a trailing
+ * wildcard, naming no protocol type, so it still gets the page. curl and CLI tools
+ * send a bare wildcard or no Accept at all and keep JSON-RPC.
  */
 export function prefersHtml(acceptHeader: string | null | undefined): boolean {
-  return (acceptHeader ?? "").toLowerCase().includes("text/html");
+  const accept = acceptHeader ?? "";
+  const html = acceptQ(accept, "text/html");
+  if (html === undefined || html <= 0) return false;
+  // Any explicitly requested protocol type means this is a client, not a person.
+  for (const protocolType of ["application/json", "text/event-stream"]) {
+    const q = acceptQ(accept, protocolType);
+    if (q !== undefined && q > 0) return false;
+  }
+  return true;
 }
 
 /**

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -332,10 +332,18 @@ export default {
       // A person pasted the endpoint into a browser. Serve the setup page rather
       // than a bare JSON error they will read as an outage (see mcpEndpointHtml).
       // Status stays 405 so no client can mistake this for a successful call.
+      //
+      // `Vary: Accept` is load-bearing: this route now has two representations,
+      // so without it a shared cache can store the browser's HTML and replay it
+      // to a later protocol GET. `Allow` is required on a 405 by RFC 9110.
       if (method === "GET" && prefersHtml(request.headers.get("accept"))) {
         return new Response(mcpEndpointHtml(), {
           status: 405,
-          headers: { "Content-Type": "text/html; charset=utf-8" },
+          headers: {
+            "Content-Type": "text/html; charset=utf-8",
+            Allow: "POST",
+            Vary: "Accept",
+          },
         });
       }
       // GET/DELETE /mcp in stateless mode: no session to stream or delete.
@@ -343,6 +351,7 @@ export default {
         405,
         -32000,
         "Method Not Allowed: this stateless MCP server only accepts POST",
+        { Allow: "POST", Vary: "Accept" },
       );
     }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -39,6 +39,8 @@ import {
   buildServerInfo,
   SERVER_INSTRUCTIONS,
   landingPageHtml,
+  mcpEndpointHtml,
+  prefersHtml,
 } from "./server-info.js";
 import { faviconArrayBuffer } from "./favicon-asset.js";
 import { runWithCreds } from "./http/credentials.js";
@@ -326,6 +328,15 @@ export default {
     if (pathname === "/mcp") {
       if (method === "POST") {
         return handleMcpPost(request, getVerifier(), defaultCredentialResolver);
+      }
+      // A person pasted the endpoint into a browser. Serve the setup page rather
+      // than a bare JSON error they will read as an outage (see mcpEndpointHtml).
+      // Status stays 405 so no client can mistake this for a successful call.
+      if (method === "GET" && prefersHtml(request.headers.get("accept"))) {
+        return new Response(mcpEndpointHtml(), {
+          status: 405,
+          headers: { "Content-Type": "text/html; charset=utf-8" },
+        });
       }
       // GET/DELETE /mcp in stateless mode: no session to stream or delete.
       return jsonRpcError(


### PR DESCRIPTION
## Why

Traced the first self-serve paid customer ($180/yr Pro, Aug 26). They created four API keys — two named for Codex — and **never made a single MCP call**. Verified five independent ways: `api_keys.last_used_at` NULL, `api_key_usage` empty, no `usage_events` rows, their IP hash absent from `usage_events` (with a positive control: 21/25 known MCP IPs matched, so the salt was right), and Cloudflare logs showing exactly two requests to the MCP host, ever:

```
2026-08-27T00:55:12  GET /mcp          -> 405  {"error":{"code":-32000,...}}
2026-08-27T00:55:13  GET /favicon.ico  -> 200
```

They pasted the endpoint into Chrome, read the JSON-RPC 405 as an outage, and never came back. The server was healthy the whole time. **Codex was also absent from the `init` wizard entirely.**

## What

**`GET /mcp` speaks to humans** (`server-info.ts`, `worker.ts`, `server-http.ts`). A browser navigation gets a setup page opening with "This endpoint is working", carrying the Codex TOML, the standard JSON block, and `npx scholar-feed-mcp init`. Status stays **405** deliberately — the method really was wrong, and a 200 would let a broken client read failure as success.

The negotiation is q-value aware, so **the protocol always wins**: `application/json, text/html;q=0` and `text/html, application/json` both keep the JSON-RPC body. Both 405 branches now set `Vary: Accept` (two representations on one URL — without it a shared cache can replay browser HTML to a protocol GET) and the `Allow` header RFC 9110 requires.

**Codex in the wizard** (`init.ts`, option 9). Appends `[mcp_servers.scholar-feed]` to Codex's `config.toml`. Appended rather than parse-merged because a TOML parser would break the `dependencies: {}` rule.

A duplicate definition makes Codex reject the **entire** file, taking the user's other MCP servers down with ours — so this fails **safe**: `CODEX_HOME` is honored, the dotted-key / fully-quoted / inline-root forms are all detected, anything unreasonable returns a new `manual` outcome that prints instead of writing, the API key is charset-validated, and the write is atomic (temp + rename) at `0600` rather than truncating at `0644`.

## Verification

389 tests (24 new) · typecheck · prettier · coverage floors · `worker:dryrun`.

**Mutation-tested all six fixes** — each reverted fix fails at least one test. Build-green is a gameable proxy; these bite.

Against the **real `codex-cli` 0.146.1**, not just the docs:
- `CODEX_HOME=/tmp/...` → wrote there, **not** to `~/.codex`, mode `0600`
- `codex mcp list` listed `scholar-feed` with `SF_API_KEY` set — the actual acceptance test
- inline `env` **is** accepted (the docs show a sub-table; both are equivalent TOML). Corrected a false claim in my own comment that cited the docs for something they don't say.

Also rendered the page over `dev:http` and confirmed `POST initialize` and a client-style `GET` are byte-identical to before.

## Not fixed here

The Worker answers `OPTIONS /mcp` with a bare 405 and no CORS headers, so a cross-origin browser MCP client can't preflight it. Express handles preflight; the Worker doesn't. **Pre-existing**, out of scope for this PR.
