### PR TITLE
Add annotate_paper: let an agent record its verdict on a paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ mcpServers:
 
 Scholar Feed is a standard stdio MCP server, so any other MCP-compatible client works with the standard block too.
 
-## Available Tools (26)
+## Available Tools (27)
 
 ### Core Search & Discovery
 
@@ -206,7 +206,8 @@ These MUTATE or read the authenticated user's account. The core read/search tool
 | `save_paper` | Bookmark a paper to your library (idempotent; feeds personalization). | `arxiv_id` |
 | `unsave_paper` | Remove a paper from your library (idempotent). | `arxiv_id` |
 | `like_paper` | "More like this" calibration signal for the For You feed (insert-only). | `arxiv_id` |
-| `list_library` | List your saved papers, newest first. | `limit`, `page` |
+| `list_library` | List your saved papers, newest first (includes your notes). | `limit`, `page` |
+| `annotate_paper` | Record your verdict on a paper — why it matters, when to use it, why you ruled it out. Upserted; returned by `list_library`, so it is what a later session reads instead of re-deriving. | `arxiv_id`, `note_text`, `action` |
 | `list_collections` | List collections with paper counts. | (none) |
 | `create_collection` | Create a named collection (get-or-create; no error on duplicate). | `name` |
 | `add_to_collection` | Add a paper to a collection by name or id (also auto-saves). | `arxiv_id`, `collection_name`, `collection_id` |

--- a/src/__tests__/annotations.test.ts
+++ b/src/__tests__/annotations.test.ts
@@ -4,7 +4,7 @@
  * Directory submission (Anthropic Connectors / OpenAI) REQUIRES every tool to
  * carry a human-readable `title` plus `readOnlyHint`/`destructiveHint`
  * annotations. These tests register the real tools on the fake server and assert
- * that all 26 are present, each has a non-empty title, the hints match the
+ * that all 27 are present, each has a non-empty title, the hints match the
  * locked M2 table (spec §6 / DECISIONS), and every tool name is within the MCP
  * 64-char name budget.
  */
@@ -37,6 +37,7 @@ const READ_ONLY_TOOLS = [
 
 const WRITE_NON_DESTRUCTIVE_TOOLS = [
   "save_paper",
+  "annotate_paper",
   "like_paper",
   "create_collection",
   "add_to_collection",
@@ -71,9 +72,9 @@ function toolFor(name: string): CapturedTool {
 }
 
 describe("tool registry surface", () => {
-  it("registers exactly the 26 expected tools", () => {
-    assert.strictEqual(TOOLS.size, 26);
-    assert.strictEqual(ALL_TOOLS.length, 26);
+  it("registers exactly the 27 expected tools", () => {
+    assert.strictEqual(TOOLS.size, 27);
+    assert.strictEqual(ALL_TOOLS.length, 27);
     for (const name of ALL_TOOLS) {
       assert.ok(TOOLS.has(name), `expected tool "${name}" to be registered`);
     }

--- a/src/__tests__/http_transport.test.ts
+++ b/src/__tests__/http_transport.test.ts
@@ -6,7 +6,7 @@
  * goal is to prove the stateless transport is mounted and serves the full MCP
  * tool surface end to end:
  *   1. POST /mcp initialize -> a successful JSON-RPC result
- *   2. POST /mcp tools/list -> all 26 tools (this does NOT call the backend, so
+ *   2. POST /mcp tools/list -> all 27 tools (this does NOT call the backend, so
  *      no network is needed)
  *   3. GET /mcp -> 405 (stateless)
  *
@@ -130,7 +130,7 @@ describe("remote HTTP transport (Streamable HTTP, stateless)", () => {
     );
   });
 
-  it("lists all 26 tools over POST /mcp tools/list", async () => {
+  it("lists all 27 tools over POST /mcp tools/list", async () => {
     const { status, envelope } = await postMcp(baseUrl, {
       jsonrpc: "2.0",
       id: 2,
@@ -146,8 +146,8 @@ describe("remote HTTP transport (Streamable HTTP, stateless)", () => {
     );
     assert.strictEqual(
       result.tools.length,
-      26,
-      `expected 26 tools, got ${result.tools.length}: ${result.tools
+      27,
+      `expected 27 tools, got ${result.tools.length}: ${result.tools
         .map((t) => t.name)
         .join(", ")}`,
     );

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -33,6 +33,7 @@ const EXPECTED_TOOLS = [
   "unsave_paper",
   "like_paper",
   "list_library",
+  "annotate_paper",
   "list_collections",
   "create_collection",
   "add_to_collection",
@@ -103,7 +104,7 @@ describe("package.json", () => {
 });
 
 describe("tool registry", () => {
-  it("registers exactly the 26 tools", () => {
+  it("registers exactly the 27 tools", () => {
     const { server, tools } = makeFakeServer();
     registerAllTools(server);
     assert.deepStrictEqual(

--- a/src/__tests__/write_tools.test.ts
+++ b/src/__tests__/write_tools.test.ts
@@ -592,3 +592,79 @@ describe("get_foundational_lineage handler", () => {
     assert.strictEqual(result.isError, true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// notes.ts — annotate_paper (upsert / get / delete)
+//
+// The tool exists because PUT /notes/{id} was unreachable: JWT-only auth 401'd
+// every API-key call, and the route addressed papers by internal UUID which the
+// public API never exposes. Both were fixed backend-side 2026-09-03, so these
+// assert the arXiv-ID path and the PUT verb the client only just learned.
+// ---------------------------------------------------------------------------
+
+describe("annotate_paper handler", () => {
+  const NOTE = {
+    id: "n1",
+    paper_id: "967a85d7-ca96-4414-85f1-1539a4cc3597",
+    note_text: "our baseline — beat this on the 7B setting",
+    created_at: "2026-09-03T12:00:00Z",
+    updated_at: "2026-09-03T12:00:00Z",
+  };
+
+  it("PUTs the note to /notes/<arxiv_id> and reports Saved on first write", async () => {
+    const { calls, url, result } = await invoke(
+      "annotate_paper",
+      { arxiv_id: "2503.08669", note_text: NOTE.note_text, action: "upsert" },
+      { json: NOTE },
+    );
+    assert.strictEqual(calls.length, 1);
+    assert.strictEqual(methodOf(calls[0]), "PUT");
+    assert.ok(url?.pathname.endsWith("/notes/2503.08669"));
+    assert.deepStrictEqual(bodyOf(calls[0]), { note_text: NOTE.note_text });
+    assert.match(result.content[0].text, /Saved your note/);
+  });
+
+  it("reports Updated when the row already existed (updated_at moved)", async () => {
+    const { result } = await invoke(
+      "annotate_paper",
+      { arxiv_id: "2503.08669", note_text: "revised", action: "upsert" },
+      { json: { ...NOTE, updated_at: "2026-09-03T13:00:00Z" } },
+    );
+    assert.match(result.content[0].text, /Updated your note/);
+  });
+
+  it("upsert without note_text is a client-side error, not a request", async () => {
+    const { calls, result } = await invoke(
+      "annotate_paper",
+      { arxiv_id: "2503.08669", action: "upsert" },
+      { json: NOTE },
+    );
+    assert.strictEqual(calls.length, 0);
+    assert.strictEqual(result.isError, true);
+    assert.match(result.content[0].text, /note_text is required/);
+  });
+
+  it("action=get reads without writing", async () => {
+    const { calls, url, result } = await invoke(
+      "annotate_paper",
+      { arxiv_id: "2503.08669", action: "get" },
+      { json: NOTE },
+    );
+    assert.strictEqual(calls.length, 1);
+    assert.notStrictEqual(methodOf(calls[0]), "PUT");
+    assert.ok(url?.pathname.endsWith("/notes/2503.08669"));
+    assert.strictEqual(
+      (result.structuredContent as { note_text?: string }).note_text,
+      NOTE.note_text,
+    );
+  });
+
+  it("surfaces a backend error instead of pretending the note was written", async () => {
+    const { result } = await invoke(
+      "annotate_paper",
+      { arxiv_id: "9999.99999", note_text: "x", action: "upsert" },
+      { status: 404, json: { detail: "No paper found for '9999.99999'" } },
+    );
+    assert.strictEqual(result.isError, true);
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -351,6 +351,21 @@ class ScholarFeedClient {
     return this.parseJson<T>(await response.text(), response.status);
   }
 
+  /** Make a PUT request (full replace / upsert). Throws on non-2xx / timeout. */
+  async put<T>(path: string, body: unknown): Promise<T> {
+    const response = await this.fetchWithTimeout(`${getBaseUrl()}${path}`, {
+      method: "PUT",
+      headers: requestHeaders({ "Content-Type": "application/json" }),
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      await this.throwApiError(response);
+    }
+
+    return this.parseJson<T>(await response.text(), response.status);
+  }
+
   /** Make a PATCH request (partial update). Throws on non-2xx / timeout. */
   async patch<T>(path: string, body: unknown): Promise<T> {
     const response = await this.fetchWithTimeout(`${getBaseUrl()}${path}`, {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -39,18 +39,20 @@ import { register as registerCollectionsWrite } from "./collections_write.js";
 import { register as registerWatches } from "./watches.js";
 import { register as registerGaps } from "./gaps.js";
 import { register as registerAskLibrary } from "./ask_library.js";
+import { register as registerNotes } from "./notes.js";
 import { register as registerCheckDrift } from "./check_drift.js";
 
 /**
  * Register all Scholar Feed MCP tools on the provided server instance.
  *
- * Current surface (26 tools, since v3.11.0):
+ * Current surface (27 tools, since v3.15.0):
  *   9 read/search tools (anonymous-capable, except embed_text which is Pro) +
  *   check_drift (DriftKB supersession check, anonymous-capable) + find_gaps
  *   (read-only gap analysis, Pro) + ask_library (cited synthesis over
- *   your saved set) + 14 library/collection/watch tools that operate on the
+ *   your saved set) + 15 library/collection/watch tools that operate on the
  *   authenticated user's account and require an SF_API_KEY:
- *     library (4):     save_paper, unsave_paper, like_paper, list_library
+ *     library (5):     save_paper, unsave_paper, like_paper, list_library,
+ *                      annotate_paper
  *     collections (4): list_collections, create_collection, add_to_collection,
  *                      remove_from_collection
  *     watches (6):     create_watch, list_watches, check_watches, update_watch,
@@ -71,5 +73,6 @@ export function registerAllTools(server: McpServer): void {
   registerWatches(server);
   registerGaps(server);
   registerAskLibrary(server);
+  registerNotes(server);
   registerCheckDrift(server);
 }

--- a/src/tools/notes.ts
+++ b/src/tools/notes.ts
@@ -1,0 +1,128 @@
+/**
+ * Note tool — annotate_paper.
+ *
+ * Records the user's own verdict on a paper: why it matters for their work, when to
+ * use it, why it was ruled out. One note per (user, paper), upserted.
+ *
+ * WHY THIS EXISTS: `PUT /notes/{paper_id}` shipped long before any tool could reach
+ * it — the route was JWT-only, so every API-key call got a 401, and it addressed
+ * papers by internal UUID which the public API never exposes. The result was a
+ * judgment layer with literally zero rows: an agent could save a paper but could not
+ * record a single thing it concluded, so every verdict died at the end of the session
+ * and got re-derived from the abstract next time. Both limitations were lifted
+ * 2026-09-03 (require_any_auth + arXiv-ID resolution).
+ *
+ * The note is the ONLY durable memory across sessions. `list_library` returns
+ * note_text on every saved paper, so a note written now is what a later session reads
+ * instead of re-reading the paper.
+ *
+ * Endpoints:
+ *   PUT /notes/{arxiv_id}   (upsert; body {note_text})
+ *   GET /notes/{arxiv_id}   (read one)
+ *
+ * The backend also exposes DELETE, but this tool deliberately does not: exposing it
+ * would require destructiveHint: true, which flags the common write path as dangerous
+ * and discourages the exact behaviour the tool exists to encourage. A wrong note is
+ * corrected by overwriting it; the web UI keeps the delete affordance.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { client } from "../client.js";
+import { fencePaperContent } from "./_untrusted.js";
+import { statusContent, statusOutput } from "./_output.js";
+
+interface NoteResponse {
+  id: string;
+  paper_id: string;
+  note_text: string;
+  created_at: string;
+  updated_at: string;
+}
+
+function text(t: string, structured?: Record<string, unknown>) {
+  return {
+    content: [{ type: "text" as const, text: t }],
+    structuredContent: structured ?? statusContent(t),
+  };
+}
+
+function errorResult(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    content: [{ type: "text" as const, text: `Error: ${message}` }],
+    isError: true,
+  };
+}
+
+export function register(server: McpServer): void {
+  server.registerTool(
+    "annotate_paper",
+    {
+      title: "Annotate Paper",
+      annotations: { readOnlyHint: false, destructiveHint: false },
+      outputSchema: statusOutput,
+      description:
+        "Record YOUR verdict on a paper — why it matters for your work, when to use it, or why you ruled it out. One note per paper, upserted (writing again replaces it), so it is safe to call repeatedly. Requires SF_API_KEY. " +
+        "WHY IT MATTERS: this note is the only thing that survives between sessions. list_library returns note_text on every saved paper, so a verdict written now is what a future session reads INSTEAD of re-reading the paper and re-deriving the same conclusion. " +
+        'WRITE A JUDGMENT, NOT A SUMMARY — the paper already carries llm_summary and an abstract, so restating what the paper says adds nothing. Write what those cannot: how it bears on YOUR problem. Prefer a claim someone could later prove wrong ("needs a labeled trace log we don\'t have", "our baseline — beat this on the 7B setting") over an unfalsifiable verdict ("interesting", "not very relevant"), because a mechanism can be re-checked when circumstances change and a sentiment cannot. ' +
+        'State the basis when it is thin: a verdict formed from the abstract alone deserves "(abstract only)", since fetch_fulltext defaults to ~800 characters of the results section rather than the whole paper. ' +
+        "Pass action='get' to read the existing note before overwriting it — worth doing when a prior session may already have judged this paper. To correct a note, just write the corrected text (it replaces).",
+      inputSchema: {
+        arxiv_id: z
+          .string()
+          .min(1)
+          .describe("arXiv ID of the paper to annotate, e.g. '2407.15831'."),
+        note_text: z
+          .string()
+          .min(1)
+          .max(5000)
+          .optional()
+          .describe(
+            "Your verdict (max 5000 chars). Required for the default upsert; ignored for action='get'.",
+          ),
+        action: z
+          .enum(["upsert", "get"])
+          .default("upsert")
+          .describe(
+            "'upsert' (default) writes/replaces the note. 'get' returns the current note without changing it. There is deliberately no delete: a wrong note is corrected by overwriting it, which keeps this tool non-destructive.",
+          ),
+      },
+    },
+    async ({ arxiv_id, note_text, action }) => {
+      const id = encodeURIComponent(arxiv_id.trim());
+      try {
+        if (action === "get") {
+          const existing = await client.get<NoteResponse>(`/notes/${id}`);
+          // A note is user-authored, but it can quote paper text — fence it.
+          return text(fencePaperContent(existing), {
+            ok: true,
+            action: "read",
+            arxiv_id,
+            note_text: existing.note_text,
+          });
+        }
+
+        if (!note_text || !note_text.trim()) {
+          return errorResult(
+            new Error("note_text is required for action='upsert'."),
+          );
+        }
+
+        const saved = await client.put<NoteResponse>(`/notes/${id}`, {
+          note_text: note_text.trim(),
+        });
+        const isUpdate = saved.updated_at !== saved.created_at;
+        const msg = `${isUpdate ? "Updated" : "Saved"} your note on ${arxiv_id}. It will come back with this paper in list_library.`;
+        return text(msg, {
+          ok: true,
+          action: isUpdate ? "updated" : "created",
+          arxiv_id,
+          message: msg,
+        });
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Why

The library had a judgment layer with **zero rows in it**, and the reason is mechanical rather than behavioural: `PUT /notes/{paper_id}` existed and worked, but no tool could reach it. The route was JWT-only, so every API-key call got a 401, and it addressed papers by internal UUID — which the public API never exposes.

An agent could save a paper but could not record a single thing it concluded. Every verdict died at the end of the session and was re-derived from the abstract next time.

## Change

`annotate_paper` writes that verdict (upsert, so repeat calls are safe) and reads it back with `action='get'`. Notes already come back on every saved paper via `list_library`, so a note written now is what a later session reads **instead of** re-reading the paper.

Adds `client.put` — the client had `get`/`post`/`patch`/`del` but no PUT.

## The description does real work here

Given a freeform text field, the reflex is to restate the abstract. That is pure redundancy: `llm_summary` and the abstract already ship with every paper. So the description asks for a **falsifiable claim about the caller's own problem** ("needs a labeled trace log we don't have") over an unfalsifiable one ("not very relevant") — a mechanism can be re-checked when circumstances change, a sentiment cannot. It also asks callers to mark a verdict formed from the abstract alone, since `fetch_fulltext` returns ~800 characters by default rather than the paper.

## No delete action, deliberately

Exposing one would require `destructiveHint: true`, which flags the common write path as dangerous and discourages the exact behaviour the tool exists to encourage. A wrong note is corrected by overwriting it; the web UI keeps the delete affordance.

## Requires the backend counterpart

`require_any_auth` + arXiv-ID resolution on `/notes` ships separately (scholar-feed#160). **Until that is live this tool returns the backend's 401 verbatim**, so this should not be released to npm before that deploy.

## Verification

- `typecheck` clean
- **403/403 tests pass** — 6 new handler cases covering the PUT verb, the arXiv-ID path, `action='get'` not writing, the missing-`note_text` client-side guard, and a backend error surfacing rather than being reported as a successful write
- c8 coverage gate passes; `notes.ts` at **100% statements**
- 27 tools; registry, annotation-hint, and HTTP-transport `tools/list` counts all updated