### PR TITLE
Fix the paper-array gate, which never checked anything

### DIFF
--- a/src/__tests__/surface_budget.test.ts
+++ b/src/__tests__/surface_budget.test.ts
@@ -89,7 +89,26 @@ interface ToolDef {
   name: string;
   description?: string;
   inputSchema?: unknown;
-  outputSchema?: unknown;
+  outputSchema?: {
+    properties?: Record<string, { type?: string } | undefined>;
+  };
+}
+
+/**
+ * Which of the paper-array keys a tool's outputSchema declares.
+ *
+ * Reads the PARSED schema. An earlier version regex-matched the serialized JSON for
+ * `"papers":{"type":"array"` and silently matched nothing: once a field carries a
+ * `.describe()`, `description` is serialized FIRST, so the pattern never saw the tools it
+ * was written to check and the assertion below passed vacuously. Caught only by probing the
+ * built bundle by hand. Do not reintroduce a string match here.
+ */
+function paperArrayKeys(tool: ToolDef): string[] {
+  const props = tool.outputSchema?.properties ?? {};
+  // Only these three; `not_found` is also type:array (of strings) and must not count.
+  return ["papers", "hits", "results"].filter(
+    (k) => props[k]?.type === "array",
+  );
 }
 
 function parseMcpResponse(
@@ -210,15 +229,33 @@ describe("tool surface budget", () => {
     // `results` described a key NOTHING returns. If a tool needs a new array key, give it
     // its own envelope instead of widening a shared one.
     for (const t of tools) {
-      const schema = JSON.stringify(t.outputSchema ?? {});
-      const arrays = ["papers", "hits", "results"].filter((k) =>
-        new RegExp(`"${k}":\\s*\\{"type":"array"`).test(schema),
-      );
+      const arrays = paperArrayKeys(t);
       assert.ok(
         arrays.length <= 1,
         `${t.name} declares ${arrays.length} paper arrays (${arrays.join(", ")}). ` +
           `Each duplicated paperObject costs ~1,750 chars in EVERY session.`,
       );
     }
+  });
+
+  it("actually sees the paper arrays it is checking", () => {
+    // Guards the guard. The assertion above is satisfied by BOTH "one array per tool" and
+    // "the detector is broken and sees none" — and the first implementation was the latter.
+    // Pinning the expected detections means a future refactor of the schema shape breaks
+    // loudly instead of turning the check into a no-op.
+    const found = tools
+      .map((t) => [t.name, paperArrayKeys(t)] as const)
+      .filter(([, keys]) => keys.length > 0)
+      .map(([name, keys]) => `${name}:${keys.join("+")}`)
+      .sort();
+    assert.deepStrictEqual(found, [
+      "ask_library:papers",
+      "check_watches:hits",
+      "get_citations:papers",
+      "get_field_orientation:papers",
+      "get_paper:papers",
+      "list_library:papers",
+      "search_papers:papers",
+    ]);
   });
 });


### PR DESCRIPTION
Follow-up to #70. The `declares each paper array on exactly one envelope` assertion I added there **passed vacuously** — it never checked the tools it was written to protect.

## The bug

It regex-matched the serialized schema for a pattern that cannot occur:

```js
new RegExp(`"${k}":\\s*\\{"type":"array"`)
```

Once a field carries a `.describe()`, `zod-to-json-schema` serializes `description` **first**:

```json
"papers":{"description":"Matched / returned papers.","type":"array", ...}
```

So it matched only `ask_library` (whose `papers` array happens to have no description) and missed `search_papers`, `get_citations`, `get_field_orientation`, `list_library`, `get_paper` and `check_watches` — i.e. all six tools the assertion exists for.

This is precisely the gate theatre #70 was written to prevent. I mutation-tested the other two assertions in that file and skipped this one, so it shipped green and meaningless.

Found by hand-probing the built stdio bundle while testing locally. CI could not have caught it: a broken detector and a clean codebase produce the identical result.

## The fix

Reads the **parsed** schema instead of string-matching:

```ts
function paperArrayKeys(tool: ToolDef): string[] {
  const props = tool.outputSchema?.properties ?? {};
  return ["papers", "hits", "results"].filter((k) => props[k]?.type === "array");
}
```

Restricted to those three keys on purpose — `not_found` is also `type: array` (of strings) and would false-positive a naive "count the arrays" check.

## Verified by reintroducing the original defect

Adding a second paper array back onto the shared envelope now fails 4 of 5 assertions:

```
[surface] 27 tools, 101,344 chars (~25,336 tokens), ceiling 95,000
not ok 1 - keeps the whole surface within budget
not ok 2 - keeps any single tool within budget
not ok 4 - declares each paper array on exactly one envelope
    error: 'search_papers declares 2 paper arrays (papers, results).'
not ok 5 - actually sees the paper arrays it is checking
```

93,214 → 101,344 chars also independently confirms the ~8.1k duplication cost that #70's envelope split removed.

## Plus a guard on the guard

New assertion `actually sees the paper arrays it is checking` pins the 7 expected detections. The old check was satisfied by **both** "one array per tool" and "the detector is blind" — that ambiguity is what let this ship, so the ambiguity is now removed rather than just the bug.

Test-only. The published `3.17.0` bundle is unaffected — the schemas were always correct, only the check was not. 420 tests pass.