### PR TITLE
Correct the surface baseline: -20%, not -24%

### DIFF
--- a/src/__tests__/surface_budget.test.ts
+++ b/src/__tests__/surface_budget.test.ts
@@ -47,12 +47,15 @@ const PROTOCOL_VERSION = "2025-11-25";
  * against a description-only or schema-only figure; that mistake set this ceiling wrong on
  * the first attempt.
  *
- * Baseline history (27 tools throughout):
- *   123,031  2026-09-03  pre-gate
- *    96,950  2026-09-03  one paper array per envelope (was papers+hits+results shared 5x)
- *    96,087  2026-09-03  removed descriptions of removed features
- *    96,417  2026-09-03  declared n_authors (schema-sync found it returned but undeclared)
- *    93,214  2026-09-03  stopped re-documenting params in tool descriptions
+ * Baseline history (27 tools throughout). ALL FIGURES ARE `JSON.stringify` CHARS, as this
+ * test counts them. Do not paste in a number measured with Python's `json.dumps`: its default
+ * separators (`', '` / `': '`) plus `ensure_ascii` inflate the same payload by ~5%, which is
+ * exactly how a "-24%" was reported for what is really -20%.
+ *   ~117,100  2026-09-03  pre-gate (measured as 123,031 in inflated python units)
+ *     96,950  2026-09-03  one paper array per envelope (was papers+hits+results shared 5x)
+ *     96,087  2026-09-03  removed descriptions of removed features
+ *     96,417  2026-09-03  declared n_authors (schema-sync found it returned but undeclared)
+ *     93,214  2026-09-03  stopped re-documenting params in tool descriptions  (-20% overall)
  */
 const SURFACE_CEILING_CHARS = 95_000;
 


### PR DESCRIPTION
Comment-only fix to a units error in the baseline ledger added by #70.

## The error

The pre-gate baseline recorded in `surface_budget.test.ts` (123,031) was measured with Python's `json.dumps`, while every other figure in that list came from this test's `JSON.stringify`. Python's defaults — separators `', '` / `': '` plus `ensure_ascii` — inflate the same payload by ~5%, so comparing the two produced a "-24%" that is really **-20.0%**.

## Verified on one identical payload

Measured the same deployed worker `tools/list` three ways:

```
98,384   python json.dumps (default separators, ensure_ascii)
93,619   python json.dumps (compact separators)
93,214   JSON.stringify        <- what this test counts
```

The residual 405 chars between the last two is non-ASCII escaping (`τ-bench` → `τ-bench`).

Converting the baseline into this test's units gives ~117,100, and `93,214 / 117,100 = -20.0%` — which matches the like-for-like comparison in Python units exactly (`123,031 → 98,384 = -20.0%`).

**The reduction is real and unchanged in substance; only the arithmetic mixed units.** The comment now states which unit the ledger is in and why, so nobody pastes a Python-measured number into it and "discovers" a regression or a win that is a measurement artifact.

## How it surfaced

While verifying the deployed worker after `worker:deploy`, `mcp.scholarfeed.org` appeared to serve 98,384 chars against the gate's 93,214 — which read as the Express transport and the Cloudflare Worker disagreeing about the tool surface. They do not: diffing per-tool shows the two `tools` arrays are **byte-identical**, total delta 0. That mattered to rule out, because a real divergence would mean the gate polices a smaller surface than the main remote endpoint actually serves.

No behaviour change, no version bump needed.