### PR TITLE
Tag the no-key signup URL so the MCP surface can be attributed

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -236,12 +236,19 @@ describe("client error mapping", () => {
     await withStub({ status: 403, body: "" }, {}, async () => {
       await assert.rejects(client.get("/x"), (err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err);
-        assert.match(
-          msg,
-          /https:\/\/www\.scholarfeed\.org\/settings\?ref=mcp403&s=[0-9a-f]{8}\b/,
-        );
-        // Must stay on the canonical origin — the URL is handed to an agent.
-        assert.doesNotMatch(msg, /scholarfeed\.org\.[a-z]/);
+        // PARSE the URL rather than regex-matching the message. An unanchored
+        // pattern would also pass on https://evil.com/?u=https://www.scholarfeed.org/
+        // settings?ref=mcp403&s=..., which is the exact confusion that matters when
+        // the string is handed to an agent to open. Checking origin as a parsed value
+        // is both stronger than a lookalike-domain denylist and anchor-free by
+        // construction. (CodeQL js/regex/missing-regexp-anchor.)
+        const found = msg.match(/https:\/\/\S+/);
+        assert.ok(found, "the remedy must hand the agent a URL");
+        const url = new URL(found[0]);
+        assert.strictEqual(url.origin, "https://www.scholarfeed.org");
+        assert.strictEqual(url.pathname, "/settings");
+        assert.strictEqual(url.searchParams.get("ref"), "mcp403");
+        assert.match(url.searchParams.get("s") ?? "", /^[0-9a-f]{8}$/);
         return true;
       });
     });

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -225,6 +225,28 @@ describe("client error mapping", () => {
     );
   });
 
+  it("tags the no-key signup URL with ref=mcp403 and a session hint", async () => {
+    // Reaching an account-gated tool anonymously is the highest-intent signal the
+    // product produces, and it used to convert to nothing measurable because an
+    // anonymous caller shares no identifier with any account. `s` is the first 8 hex
+    // chars of the X-SF-Session id; the backend stores the full value on the same
+    // call in usage_events.session_id, so signup_attribution.mcp_session joins the
+    // resulting account back to this exact session. If this assertion ever fails,
+    // funnel attribution for the MCP surface is silently dead.
+    await withStub({ status: 403, body: "" }, {}, async () => {
+      await assert.rejects(client.get("/x"), (err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        assert.match(
+          msg,
+          /https:\/\/www\.scholarfeed\.org\/settings\?ref=mcp403&s=[0-9a-f]{8}\b/,
+        );
+        // Must stay on the canonical origin — the URL is handed to an agent.
+        assert.doesNotMatch(msg, /scholarfeed\.org\.[a-z]/);
+        return true;
+      });
+    });
+  });
+
   it("surfaces the RFC-9457 { code, detail } envelope (HTTPException gates)", async () => {
     // The backend re-renders every HTTPException as problem+json, so a gate's
     // `message` arrives as `detail` under a deliberate `code` — e.g. embed_text's

--- a/src/client.ts
+++ b/src/client.ts
@@ -280,18 +280,39 @@ function isProGate(body: string): boolean {
  * where each request carries its own key in the Authorization header and
  * SF_API_KEY must never be set server-side (it would leak across tenants).
  */
+/**
+ * The signup URL handed to the agent when a call fails for want of a key, tagged so
+ * the resulting account can be attributed back to THIS moment.
+ *
+ * Why it is worth tagging: reaching an account-gated tool anonymously is the
+ * highest-intent signal the product produces — measured 2026-09-04, 310 such calls
+ * from 72 source IPs over 90 days, still firing — and until now it converted to
+ * nothing measurable, because an anonymous MCP caller shares no identifier with any
+ * account. `s` is the first 8 chars of the X-SF-Session id, and the backend already
+ * stores the full value on every one of those calls in usage_events.session_id, so
+ * `signup_attribution.mcp_session` joins the account back to the exact session.
+ *
+ * The session id is an opaque per-request (remote) or per-process (stdio) random
+ * value carrying no user or environment identity, so exposing 8 chars of it in a URL
+ * the user may paste anywhere leaks nothing. 8 hex chars is 4.3e9 of space against
+ * ~11k anonymous sessions per quarter, so a collision is not a practical concern.
+ */
+function signupUrl(): string {
+  return `${SITE_ORIGIN}/settings?ref=mcp403&s=${getSessionId().replace(/-/g, "").slice(0, 8)}`;
+}
+
 function missingKeyRemedy(): string {
   if (getCurrentCreds()) {
     return (
       "This request was sent without a Scholar Feed API key. Get one at " +
-      "https://www.scholarfeed.org/settings and send it as an `Authorization: Bearer sf_...` " +
+      `${signupUrl()} and send it as an \`Authorization: Bearer sf_...\` ` +
       "header to this MCP endpoint. Do NOT retry this call until the key is attached — " +
       "it will keep failing."
     );
   }
   return (
     "No API key was sent, so this endpoint refused the request. Set SF_API_KEY " +
-    "to a key from https://www.scholarfeed.org/settings in your MCP server config " +
+    `to a key from ${signupUrl()} in your MCP server config ` +
     "(the `env` block), then restart the MCP server. Do NOT retry this call until " +
     "the key is set — it will keep failing."
   );


### PR DESCRIPTION
Reaching an account-gated tool anonymously is the highest-intent signal the product produces — **310 such calls from 72 source IPs over 90 days**, measured 2026-09-04, still firing — and it converted to nothing measurable, because an anonymous MCP caller shares no identifier with any account.

The 403 remedy now points at `/settings?ref=mcp403&s=<8 hex>`, where `s` is the first 8 chars of the `X-SF-Session` id. The backend already stores the full value on the same call in `usage_events.session_id`, so `signup_attribution.mcp_session` (scholar-feed mig 170) joins a resulting account back to the exact anonymous session that showed the CTA.

**It is a prefix, not a hash** — `getSessionId().replace(/-/g,"").slice(0,8)` over a `randomUUID()`. That matters: the reader's join is `session_id LIKE mcp_session || '%'`, which works only for a prefix, and the first 8 chars of a UUID precede the first dash. Read as a hash, a correct 0 result looks like a broken join. (The corresponding scholar-feed comments said "short hash" and are corrected in YGao2005/scholar-feed#174.)

The session id is an opaque per-request (remote) or per-process (stdio) random value carrying no user or environment identity, so 8 chars of it in a URL the user may paste anywhere leaks nothing; 8 hex is 4.3e9 of space against ~11k anonymous sessions/quarter.

## Do not tag before the website ships

This URL is **inert until `scholar-feed` PR #174's frontend is deployed**. A click before then lands on a page with no `captureFirstTouch`, and that attribution is lost with no error anywhere — silent loss on the highest-intent cohort there is. Publishing is a `v*` tag push, so merging this is safe; hold the tag.

Covered by a client test that was mutation-verified: reverting `signupUrl()` on the stdio branch fails it. 421/421 tests pass, typecheck and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1z5bf9WW6z6mD42hcKreb