### PR TITLE
docs: replace broken Smithery badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![npm version](https://img.shields.io/npm/v/scholar-feed-mcp.svg)](https://www.npmjs.com/package/scholar-feed-mcp)
 [![Node](https://img.shields.io/node/v/scholar-feed-mcp.svg)](https://nodejs.org)
 [![License: MIT](https://img.shields.io/npm/l/scholar-feed-mcp.svg)](./LICENSE)
-[![smithery badge](https://smithery.ai/badge/yangg40/scholar-feed)](https://smithery.ai/servers/yangg40/scholar-feed)
+[![LightNow MCP capabilities](https://lightnow.ai/badge/io.github.YGao2005/scholar-feed-mcp)](https://lightnow.ai/servers/io.github.YGao2005/scholar-feed-mcp)
 
 Research paper search with ranking and citation tracking, for LLM engineering and academic research, without leaving Claude Code, Cursor, or any MCP client.
 


### PR DESCRIPTION
## What & why

Replaces the broken Smithery badge with LightNow. LightNow currently reports **27 T · 0 R · 0 P** for this server.

- [Server listing](https://lightnow.ai/servers/io.github.YGao2005/scholar-feed-mcp)
- [Badge documentation and variants](https://docs.lightnow.ai/how-to/add-capability-badge)

Verification: exact README-only diff; badge and destination return HTTP 200. No project code or dependencies were executed for this documentation-only change.

## Checklist

- [ ] `npm run lint` and `npm run format:check` pass — not run (README-only)
- [ ] `npm run typecheck` passes — not run (README-only)
- [ ] `npm test` passes — not run (README-only)
- [x] Tool surface unchanged
- [x] Tests not applicable
- [x] No secrets in the change