### PR TITLE
fix(distribution): tag Smithery, fix retired pricing, end four-way version drift

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "scholar-feed",
   "displayName": "Scholar Feed",
-  "version": "3.7.1",
+  "version": "3.19.1",
   "description": "Search 600,000+ CS/AI/ML papers with LLM novelty analysis, citation graph, full-text extraction, and BibTeX, without leaving Claude Code. Built for literature reviews.",
   "author": {
     "name": "Scholar Feed",
@@ -28,7 +28,10 @@
   "mcpServers": {
     "scholar-feed": {
       "command": "npx",
-      "args": ["-y", "scholar-feed-mcp@latest"]
+      "args": [
+        "-y",
+        "scholar-feed-mcp@latest"
+      ]
     }
   }
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -28,10 +28,7 @@
   "mcpServers": {
     "scholar-feed": {
       "command": "npx",
-      "args": [
-        "-y",
-        "scholar-feed-mcp@latest"
-      ]
+      "args": ["-y", "scholar-feed-mcp@latest"]
     }
   }
 }

--- a/.codex-plugin/mcp.json
+++ b/.codex-plugin/mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "scholar-feed": {
+      "command": "npx",
+      "args": ["-y", "scholar-feed-mcp@latest"],
+      "env_vars": ["SF_API_KEY", "SF_SRC"]
+    }
+  }
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,37 @@
+{
+  "name": "scholar-feed",
+  "version": "3.19.1",
+  "description": "Search 600,000+ CS/AI/ML papers with semantic search, a 23.2M-edge citation graph, full-text extraction, and BibTeX, without leaving your editor. Built for literature reviews.",
+  "author": {
+    "name": "Scholar Feed",
+    "url": "https://www.scholarfeed.org"
+  },
+  "homepage": "https://www.scholarfeed.org",
+  "repository": "https://github.com/YGao2005/scholar-feed-mcp",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "research",
+    "research-papers",
+    "arxiv",
+    "citations",
+    "citation-graph",
+    "semantic-search",
+    "literature-review",
+    "embeddings",
+    "bibtex"
+  ],
+  "interface": {
+    "displayName": "Scholar Feed",
+    "shortDescription": "Semantic search and citation-graph traversal over 600k+ CS/AI/ML papers.",
+    "longDescription": "A research copilot over 600,000+ CS/AI/ML papers: semantic search, citation-graph traversal, co-author graphs, full-text extraction, foundational-lineage lookup, text embeddings, and saved libraries, collections, and standing watches. Runs anonymously at 200 calls/month with no signup; a free key raises that to 500/month and unlocks your library.",
+    "developerName": "Scholar Feed",
+    "category": "Developer Tools",
+    "capabilities": [
+      "MCP",
+      "Read"
+    ],
+    "websiteURL": "https://www.scholarfeed.org"
+  },
+  "mcpServers": "./.codex-plugin/mcp.json"
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -27,10 +27,7 @@
     "longDescription": "A research copilot over 600,000+ CS/AI/ML papers: semantic search, citation-graph traversal, co-author graphs, full-text extraction, foundational-lineage lookup, text embeddings, and saved libraries, collections, and standing watches. Runs anonymously at 200 calls/month with no signup; a free key raises that to 500/month and unlocks your library.",
     "developerName": "Scholar Feed",
     "category": "Developer Tools",
-    "capabilities": [
-      "MCP",
-      "Read"
-    ],
+    "capabilities": ["MCP", "Read"],
     "websiteURL": "https://www.scholarfeed.org"
   },
   "mcpServers": "./.codex-plugin/mcp.json"

--- a/.codexignore
+++ b/.codexignore
@@ -1,0 +1,17 @@
+# Keep local build output, caches and any local env files out of plugin scans
+# and out of anything that packages this repo as a plugin.
+#
+# The HOL plugin-scanner walks the working tree, not git's index, so an
+# untracked .vercel/.env.production.local or a freshly built bundle shows up as
+# a "hardcoded secret" finding even though neither is committed. Measured
+# 2026-09-06: those artifacts contributed 8 of 20 high findings locally.
+node_modules/
+build/
+dist/
+dist-worker/
+coverage/
+.vercel/
+*.mcpb
+*.tsbuildinfo
+.env
+.env.*

--- a/.github/workflows/plugin-scan.yml
+++ b/.github/workflows/plugin-scan.yml
@@ -1,0 +1,41 @@
+name: Plugin Security Scan
+
+# HOL Guard's plugin-scanner, the scoring engine behind the HOL Plugin Registry
+# (hol.org/registry/plugins), which auto-ingests every entry in the 188-star
+# hashgraph-online/awesome-ai-plugins catalogue — one of the directories we
+# appear in without ever having submitted.
+#
+# WHY: their published model applies a flat 10% trust-score reduction to
+# projects without scanner CI. Measured 2026-09-06 our scores were trust 72 /
+# security 64 with the badge reading "Unprotected". Every other input to that
+# score is already satisfied in this repo (SECURITY.md, LICENSE, dependabot,
+# CODE_OF_CONDUCT, CONTRIBUTING, CodeQL, and every action SHA-pinned), so this
+# workflow is the only remaining lever: 72 / 0.9 ~= 80.
+#
+# 🔴 THIRD-PARTY ACTION, DELIBERATE. This runs code we do not own in our CI.
+# It is constrained the way the vendor documents and we verified before adding:
+#   - pinned to a commit SHA, never a moving tag;
+#   - `contents: read` is the only permission granted;
+#   - no repository secrets are exposed to it;
+#   - checkout credentials are not persisted.
+# It runs on pull_request and push only — never on the tag path that publishes
+# to npm, so a compromised scanner cannot reach a release. Drop this file if
+# that trade stops being worth ~8 points on one directory's score.
+
+on: [pull_request, push]
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: hashgraph-online/ai-plugin-scanner-action@55616c962cf86368423f7673b2ecdfdbe613d1af # v1.2.515
+        with:
+          plugin_dir: "."
+          min_score: 80
+          fail_on_severity: high

--- a/.github/workflows/plugin-scan.yml
+++ b/.github/workflows/plugin-scan.yml
@@ -38,4 +38,17 @@ jobs:
         with:
           plugin_dir: "."
           min_score: 80
-          fail_on_severity: high
+          # 🔴 GATE ON `critical`, NOT `high`, AND THAT IS DELIBERATE.
+          # Every `high` this scanner reports on us is HARDCODED_SECRET matching
+          # documentation placeholders -- the literal `sf_your_key_here` in
+          # src/server-info.ts and the README, the word "secret" in a comment in
+          # src/init.ts, and `sf_test`-style fixtures in the test suite. Verified
+          # 2026-09-06: `git grep` for a real key pattern returns nothing, and the
+          # only DANGEROUS_DYNAMIC_EXECUTION hits are in bundler output, not source.
+          # The heuristic keys on the `sf_` prefix, so any honest placeholder trips
+          # it and no amount of rewording fixes it. There is no baseline-generation
+          # command and findings carry no file/line identity, so a hand-written
+          # suppression file would be guesswork.
+          # `min_score: 80` above is the gate that actually bites (we score 87).
+          # If a `critical` ever appears, this fails -- which is the point.
+          fail_on_severity: critical

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ These MUTATE or read the authenticated user's account. The core read/search tool
 | `preview_watch` | Dry-run a structured `criteria` filter over recent papers without creating a watch; returns `match_count` and a `sample` to tune before saving. Read-only. | `criteria`, `recency_days` |
 | `delete_watch` | Delete a watch by name or id (idempotent). | `name`, `watch_id` |
 | `find_gaps` | "What am I missing?" for a collection or topic: foundational + frontier work you haven't saved (read-only, **Pro**). | `collection_name`, `collection_id`, `topic`, `scope`, `limit` |
-| `ask_library` | "Answer from my saved set": a cited synthesis over your library or one collection, grounded only in papers you've saved (read-only). The inverse of `find_gaps`. **Free 1/month, then Pro 200/day.** | `question`, `collection_name`, `collection_id`, `limit` |
+| `ask_library` | "Answer from my saved set": a cited synthesis over your library or one collection, grounded only in papers you've saved (read-only). The inverse of `find_gaps`. **Free 20/month, then Pro 200/day.** | `question`, `collection_name`, `collection_id`, `limit` |
 
 ## Novelty Score
 

--- a/docker-mcp-registry/servers/scholar-feed/server.yaml
+++ b/docker-mcp-registry/servers/scholar-feed/server.yaml
@@ -32,8 +32,8 @@ about:
     A research copilot over 600,000+ CS/AI/ML papers: semantic search,
     citation-graph traversal, co-author graphs, full-text extraction,
     foundational-lineage lookup, text embeddings, and saved libraries,
-    collections, and standing watches. Works anonymously at 100 calls/day,
-    or 1,000/day with a free API key.
+    collections, and standing watches. Works anonymously at 200 calls/month,
+    or 500/month with a free API key.
   icon: https://avatars.githubusercontent.com/u/9919?s=200&v=4
 source:
   project: https://github.com/YGao2005/scholar-feed-mcp
@@ -42,9 +42,10 @@ source:
   commit: 882809ed55e87b016222700afd1ff919a35741a4
 config:
   description: >-
-    Optional. Scholar Feed runs anonymously (100 calls/day) with no
-    configuration. To raise limits to 1,000 calls/day, supply a free API key
-    from https://www.scholarfeed.org/settings as the SF_API_KEY secret.
+    Optional. Scholar Feed runs anonymously (200 calls/month) with no
+    configuration. To raise your quota to 500 calls/month and unlock your
+    library, supply a free API key from https://www.scholarfeed.org/settings
+    as the SF_API_KEY secret.
   secrets:
     - name: scholar-feed.api_key
       env: SF_API_KEY

--- a/manifest.json
+++ b/manifest.json
@@ -17,9 +17,7 @@
     "type": "git",
     "url": "https://github.com/YGao2005/scholar-feed-mcp"
   },
-  "privacy_policies": [
-    "https://www.scholarfeed.org/privacy-policy"
-  ],
+  "privacy_policies": ["https://www.scholarfeed.org/privacy-policy"],
   "license": "MIT",
   "keywords": [
     "research",
@@ -35,9 +33,7 @@
     "entry_point": "build/index.js",
     "mcp_config": {
       "command": "node",
-      "args": [
-        "${__dirname}/build/index.js"
-      ],
+      "args": ["${__dirname}/build/index.js"],
       "env": {
         "SF_API_KEY": "${user_config.sf_api_key}"
       }

--- a/manifest.json
+++ b/manifest.json
@@ -2,10 +2,10 @@
   "manifest_version": "0.3",
   "name": "scholar-feed-mcp",
   "display_name": "Scholar Feed",
-  "version": "3.8.0",
+  "version": "3.19.1",
   "description": "Semantic search, citation graph, full text, embeddings, and BibTeX export over 600,000+ CS/AI/ML papers.",
   "icon": "assets/icon-marketplace.png",
-  "long_description": "Scholar Feed gives your AI assistant a research copilot over 600,000+ CS/AI/ML papers: semantic search, citation-graph traversal, co-author graphs, full-text extraction, foundational-lineage lookup, text embeddings, and saved libraries, collections, and standing watches. Works anonymously at 100 calls/day, or 1,000/day with a free API key.",
+  "long_description": "Scholar Feed gives your AI assistant a research copilot over 600,000+ CS/AI/ML papers: semantic search, citation-graph traversal, co-author graphs, full-text extraction, foundational-lineage lookup, text embeddings, and saved libraries, collections, and standing watches. Works anonymously at 200 calls/month, or 500/month with a free API key.",
   "author": {
     "name": "Yang Gao",
     "url": "https://www.scholarfeed.org",
@@ -17,7 +17,9 @@
     "type": "git",
     "url": "https://github.com/YGao2005/scholar-feed-mcp"
   },
-  "privacy_policies": ["https://www.scholarfeed.org/privacy-policy"],
+  "privacy_policies": [
+    "https://www.scholarfeed.org/privacy-policy"
+  ],
   "license": "MIT",
   "keywords": [
     "research",
@@ -33,7 +35,9 @@
     "entry_point": "build/index.js",
     "mcp_config": {
       "command": "node",
-      "args": ["${__dirname}/build/index.js"],
+      "args": [
+        "${__dirname}/build/index.js"
+      ],
       "env": {
         "SF_API_KEY": "${user_config.sf_api_key}"
       }
@@ -43,7 +47,7 @@
     "sf_api_key": {
       "type": "string",
       "title": "Scholar Feed API key (optional)",
-      "description": "Paste a free key from scholarfeed.org/settings to raise limits to 1,000 calls/day. Leave blank for anonymous mode (100 calls/day).",
+      "description": "Paste a free key from scholarfeed.org/settings to raise your quota to 500 calls/month and unlock your library. Leave blank for anonymous mode (200 calls/month).",
       "sensitive": true,
       "required": false
     }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,9 @@
     "test": "node --import tsx --test src/__tests__/*.test.ts",
     "coverage": "c8 node --import tsx --test src/__tests__/*.test.ts",
     "prepublishOnly": "npm run lint && npm run build && npm run coverage",
-    "schema:sync": "node scripts/schema-sync.mjs"
+    "schema:sync": "node scripts/schema-sync.mjs",
+    "sync:manifests": "node scripts/sync-manifests.mjs",
+    "version": "node scripts/sync-manifests.mjs && git add server.json manifest.json .claude-plugin/plugin.json .codex-plugin/plugin.json"
   },
   "comment:dependencies": "Runtime deps are intentionally empty: the published bin (build/index.js) is a self-contained esbuild bundle (see tsup.config.ts), so `npx`/Docker consumers install ZERO transitive deps. The five former runtime deps (sdk/zod for the stdio bundle; express/cors/jose for the HTTP+Worker deploy targets) live in devDependencies — they are bundled in at build time by every deploy target and CI, never installed by consumers.",
   "dependencies": {},

--- a/scripts/sync-manifests.mjs
+++ b/scripts/sync-manifests.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Stamp package.json's version onto every distribution manifest.
+ *
+ * WHY THIS EXISTS: on 2026-09-06 an audit of the live listings found four
+ * manifests carrying four different versions — package.json 3.19.1,
+ * server.json 3.9.1, manifest.json 3.8.0, .claude-plugin 3.7.1. Only
+ * server.json was ever synced (in publish.yml, at publish time), so the other
+ * three had silently drifted eleven releases behind and were shipping that
+ * stale version to the MCPB bundle and the plugin directories.
+ *
+ * Wired as the npm `version` lifecycle script, so `npm version <patch|minor|major>`
+ * syncs and stages them as part of the release commit the tag points at.
+ * `distribution_manifests.test.ts` is the backstop: it fails the tagged
+ * `verify` job if any manifest is out of step, so a forgotten sync cannot
+ * reach npm.
+ *
+ * server.json is included here even though publish.yml also syncs it — belt
+ * and braces, and it keeps the committed file honest between releases.
+ */
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+
+const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+const version = pkg.version;
+
+/** JSON manifests whose top-level `version` tracks package.json. */
+const JSON_TARGETS = [
+  "server.json",
+  "manifest.json",
+  ".claude-plugin/plugin.json",
+  ".codex-plugin/plugin.json",
+];
+
+let changed = 0;
+for (const file of JSON_TARGETS) {
+  if (!existsSync(file)) {
+    console.warn(`  skip   ${file} (absent)`);
+    continue;
+  }
+  const raw = readFileSync(file, "utf8");
+  const doc = JSON.parse(raw);
+  const before = doc.version;
+  doc.version = version;
+
+  // server.json additionally pins each package reference to the same version;
+  // the registry validates that against npm, so it must match exactly.
+  if (Array.isArray(doc.packages)) {
+    for (const p of doc.packages) p.version = version;
+  }
+
+  // Preserve the 2-space + trailing-newline shape the repo already uses, so a
+  // sync never shows up as unrelated formatting churn in a release diff.
+  const next = `${JSON.stringify(doc, null, 2)}\n`;
+  if (next !== raw) {
+    writeFileSync(file, next);
+    changed++;
+    console.log(`  sync   ${file}  ${before} -> ${version}`);
+  } else {
+    console.log(`  ok     ${file}  ${version}`);
+  }
+}
+
+console.log(`\nsync-manifests: ${changed} file(s) updated to ${version}`);

--- a/scripts/sync-manifests.mjs
+++ b/scripts/sync-manifests.mjs
@@ -18,7 +18,7 @@
  * server.json is included here even though publish.yml also syncs it — belt
  * and braces, and it keeps the committed file honest between releases.
  */
-import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 
 const pkg = JSON.parse(readFileSync("package.json", "utf8"));
 const version = pkg.version;
@@ -33,24 +33,34 @@ const JSON_TARGETS = [
 
 let changed = 0;
 for (const file of JSON_TARGETS) {
-  if (!existsSync(file)) {
-    console.warn(`  skip   ${file} (absent)`);
-    continue;
+  // Read first and handle ENOENT, rather than existsSync-then-read: the check
+  // and the use are separate syscalls, so the file can change in between
+  // (CodeQL js/file-system-race). Attempting the read is both race-free and
+  // one syscall cheaper.
+  let raw;
+  try {
+    raw = readFileSync(file, "utf8");
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      console.warn(`  skip   ${file} (absent)`);
+      continue;
+    }
+    throw err;
   }
-  const raw = readFileSync(file, "utf8");
-  const doc = JSON.parse(raw);
-  const before = doc.version;
-  doc.version = version;
+  const before = JSON.parse(raw).version;
 
-  // server.json additionally pins each package reference to the same version;
-  // the registry validates that against npm, so it must match exactly.
-  if (Array.isArray(doc.packages)) {
-    for (const p of doc.packages) p.version = version;
-  }
-
-  // Preserve the 2-space + trailing-newline shape the repo already uses, so a
-  // sync never shows up as unrelated formatting churn in a release diff.
-  const next = `${JSON.stringify(doc, null, 2)}\n`;
+  // Rewrite the version STRINGS in place rather than re-serialising the parsed
+  // document. `JSON.stringify(doc, null, 2)` does not reproduce Prettier's JSON
+  // output, so re-serialising made every sync fail `npm run format:check` — and
+  // because the sync runs from the `npm version` lifecycle hook, that would put
+  // a lint failure inside the release commit the tag points at.
+  //
+  // The pattern matches the literal key `"version"`, which is why it updates
+  // server.json's top-level version AND its packages[].version (the registry
+  // validates that against npm, so both must match) while never touching
+  // manifest.json's `"manifest_version"` — that key has no `"version"`
+  // substring, since the opening quote belongs to `"manifest_version"`.
+  const next = raw.replace(/("version"\s*:\s*")[^"]*(")/g, `$1${version}$2`);
   if (next !== raw) {
     writeFileSync(file, next);
     changed++;

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.YGao2005/scholar-feed-mcp",
   "title": "Scholar Feed",
   "description": "Rank CS/AI/ML papers by citations, forecast impact, or code adoption; trace 23.2M citation edges.",
-  "version": "3.9.1",
+  "version": "3.19.1",
   "websiteUrl": "https://www.scholarfeed.org",
   "repository": {
     "url": "https://github.com/YGao2005/scholar-feed-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "scholar-feed-mcp",
-      "version": "3.9.1",
+      "version": "3.19.1",
       "transport": {
         "type": "stdio"
       },

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,9 +1,14 @@
 # Smithery configuration file: https://smithery.ai/docs/build/project-config
 #
 # Scholar Feed MCP — a STDIO server published to npm as `scholar-feed-mcp`.
-# Smithery launches the published bin via npx. SF_API_KEY is OPTIONAL: the
-# server works anonymously (100 calls/day); a free key raises limits to
-# 1,000/day. Get one at https://www.scholarfeed.org/settings
+# Smithery containerizes this and launches the published bin via npx, so this
+# runs the stdio path: SF_SRC IS honoured here (the client only ignores a
+# server-level SF_SRC when a per-request credential context is present, which
+# never happens on stdio). That is what makes this listing attributable.
+#
+# SF_API_KEY is OPTIONAL: the server works anonymously at 200 calls/month; a
+# free key raises that to 500/month and unlocks your library (saved papers,
+# collections, watches). Get one at https://www.scholarfeed.org/settings
 
 startCommand:
   type: stdio
@@ -17,17 +22,24 @@ startCommand:
         title: Scholar Feed API key (optional)
         description: >-
           Optional. Paste a free key from https://www.scholarfeed.org/settings
-          to raise limits to 1,000 calls/day. Leave blank for anonymous mode
-          (100 calls/day). Keys start with "sf_".
+          to raise your quota to 500 calls/month and unlock your library. Leave
+          blank for anonymous mode (200 calls/month). Keys start with "sf_".
   commandFunction:
     # A JS function that produces the CLI command + env to start the MCP on stdio.
     # Maps the optional SF_API_KEY config value into the launched server's env;
     # when omitted, the server runs in anonymous mode.
+    #
+    # SF_SRC tags every call from this listing as coming from Smithery, so the
+    # channel shows up in usage_events.src (backend mig 174) instead of being
+    # indistinguishable from any other anonymous caller. Do not remove it.
     |-
     (config) => ({
       command: 'npx',
       args: ['-y', 'scholar-feed-mcp@latest'],
-      env: config && config.SF_API_KEY ? { SF_API_KEY: config.SF_API_KEY } : {}
+      env: Object.assign(
+        { SF_SRC: 'smithery' },
+        config && config.SF_API_KEY ? { SF_API_KEY: config.SF_API_KEY } : {}
+      )
     })
   exampleConfig:
     SF_API_KEY: sf_your_free_key_here

--- a/src/__tests__/affordances.test.ts
+++ b/src/__tests__/affordances.test.ts
@@ -43,7 +43,11 @@ describe("account affordance — when it fires", () => {
     for (let i = 1; i < THRESHOLD; i++) accountAffordance();
 
     const first = accountAffordance();
-    assert.notStrictEqual(first, "", "the Nth call must produce the affordance");
+    assert.notStrictEqual(
+      first,
+      "",
+      "the Nth call must produce the affordance",
+    );
     assert.match(first, /calling Scholar Feed anonymously/);
 
     for (let i = 0; i < 10; i++) {
@@ -65,7 +69,10 @@ describe("account affordance — who must never see it", () => {
   });
 
   it("never fires on the remote transport, which has no per-user counter", () => {
-    const creds = { apiKey: null, sessionId: "11111111-2222-3333-4444-555555555555" };
+    const creds = {
+      apiKey: null,
+      sessionId: "11111111-2222-3333-4444-555555555555",
+    };
     for (let i = 0; i < THRESHOLD * 3; i++) {
       assert.strictEqual(
         runWithCreds(creds, () => accountAffordance()),
@@ -76,12 +83,19 @@ describe("account affordance — who must never see it", () => {
   });
 
   it("remote calls do not advance the stdio counter", () => {
-    const creds = { apiKey: null, sessionId: "11111111-2222-3333-4444-555555555555" };
+    const creds = {
+      apiKey: null,
+      sessionId: "11111111-2222-3333-4444-555555555555",
+    };
     for (let i = 0; i < THRESHOLD * 3; i++) {
       runWithCreds(creds, () => accountAffordance());
     }
     // If remote traffic had ticked the counter, the very first stdio call would fire.
-    assert.strictEqual(accountAffordance(), "", "ineligible callers must not tick");
+    assert.strictEqual(
+      accountAffordance(),
+      "",
+      "ineligible callers must not tick",
+    );
   });
 });
 
@@ -115,7 +129,10 @@ describe("account affordance — placement in the payload", () => {
     const fenceEnd = out.indexOf(UNTRUSTED_END);
     const nudge = out.indexOf("calling Scholar Feed anonymously");
     assert.ok(fenceEnd >= 0, "the fence must still close");
-    assert.ok(nudge > fenceEnd, "trusted server text must never sit inside the fence");
+    assert.ok(
+      nudge > fenceEnd,
+      "trusted server text must never sit inside the fence",
+    );
   });
 
   it("still closes on the fence, with a header, when there is no next-steps footer", () => {
@@ -128,7 +145,10 @@ describe("account affordance — placement in the payload", () => {
     const header = out.indexOf("Scholar Feed next steps");
     const nudge = out.indexOf("calling Scholar Feed anonymously");
     assert.ok(fenceEnd >= 0);
-    assert.ok(header > fenceEnd, "the affordance must be introduced by the header");
+    assert.ok(
+      header > fenceEnd,
+      "the affordance must be introduced by the header",
+    );
     assert.ok(nudge > header);
   });
 

--- a/src/__tests__/attribution_headers.test.ts
+++ b/src/__tests__/attribution_headers.test.ts
@@ -25,7 +25,11 @@ import { describe, it, before, after, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import http, { type Server } from "node:http";
 import type { AddressInfo } from "node:net";
-import { client, setStdioClientName, __resetStdioClientName } from "../client.js";
+import {
+  client,
+  setStdioClientName,
+  __resetStdioClientName,
+} from "../client.js";
 import { runWithCreds } from "../http/credentials.js";
 
 interface Captured {
@@ -77,7 +81,12 @@ describe("attribution headers (X-SF-Src / X-SF-Client)", () => {
 
   it("forwards ?src= and the User-Agent supplied per request", async () => {
     await runWithCreds(
-      { apiKey: null, sessionId: "s-1", src: "smithery", client: "claude-ai/1.0" },
+      {
+        apiKey: null,
+        sessionId: "s-1",
+        src: "smithery",
+        client: "claude-ai/1.0",
+      },
       () => client.get("/library"),
     );
     assert.equal(captured.length, 1);

--- a/src/__tests__/distribution_manifests.test.ts
+++ b/src/__tests__/distribution_manifests.test.ts
@@ -96,7 +96,8 @@ test("no surface advertises the RETIRED daily caps (mig 173 replaced them)", () 
 test("the monthly quota is stated correctly wherever quota copy appears", () => {
   // Only files that actually make a quota claim are checked; a manifest may
   // legitimately not mention quotas at all.
-  const MENTIONS_QUOTA = /calls?\s*\/\s*month|calls? a month|requests?\/month|per month/i;
+  const MENTIONS_QUOTA =
+    /calls?\s*\/\s*month|calls? a month|requests?\/month|per month/i;
   const CORRECT_ANON = /\b200\b/;
   const CORRECT_FREE = /\b500\b/;
 
@@ -106,10 +107,21 @@ test("the monthly quota is stated correctly wherever quota copy appears", () => 
     const text = read(file);
     if (!MENTIONS_QUOTA.test(text)) continue;
     checked++;
-    assert.match(text, CORRECT_ANON, `${file} states a monthly quota but never mentions 200 (anon)`);
-    assert.match(text, CORRECT_FREE, `${file} states a monthly quota but never mentions 500 (free)`);
+    assert.match(
+      text,
+      CORRECT_ANON,
+      `${file} states a monthly quota but never mentions 200 (anon)`,
+    );
+    assert.match(
+      text,
+      CORRECT_FREE,
+      `${file} states a monthly quota but never mentions 500 (free)`,
+    );
   }
-  assert.ok(checked >= 4, `expected quota copy on at least 4 surfaces, found ${checked}`);
+  assert.ok(
+    checked >= 4,
+    `expected quota copy on at least 4 surfaces, found ${checked}`,
+  );
 });
 
 test("README's ask_library allowance matches the backend (20/month free)", () => {
@@ -128,7 +140,11 @@ test("the Smithery listing tags its calls with SF_SRC", () => {
   // path where a server-level SF_SRC is honoured. Without it, our single
   // largest listing (7,974 uses) is indistinguishable from anonymous traffic.
   const y = read("smithery.yaml");
-  assert.match(y, /SF_SRC:\s*'smithery'/, "smithery.yaml must set SF_SRC so the channel is attributable");
+  assert.match(
+    y,
+    /SF_SRC:\s*'smithery'/,
+    "smithery.yaml must set SF_SRC so the channel is attributable",
+  );
 });
 
 test("the codex plugin manifest resolves the install URL third parties publish", () => {
@@ -136,12 +152,24 @@ test("the codex plugin manifest resolves the install URL third parties publish",
   //   install_url: .../HEAD/.codex-plugin/plugin.json
   // which 404'd until this file existed, breaking one-click install for every
   // Codex user who found us through that list.
-  assert.ok(existsSync(".codex-plugin/plugin.json"), ".codex-plugin/plugin.json must exist");
+  assert.ok(
+    existsSync(".codex-plugin/plugin.json"),
+    ".codex-plugin/plugin.json must exist",
+  );
   const plugin = json(".codex-plugin/plugin.json") as { mcpServers?: string };
-  assert.equal(typeof plugin.mcpServers, "string", "codex plugins point mcpServers at a file path");
-  assert.ok(existsSync(plugin.mcpServers!.replace(/^\.\//, "")), "the referenced mcp.json must exist");
+  assert.equal(
+    typeof plugin.mcpServers,
+    "string",
+    "codex plugins point mcpServers at a file path",
+  );
+  assert.ok(
+    existsSync(plugin.mcpServers!.replace(/^\.\//, "")),
+    "the referenced mcp.json must exist",
+  );
 
-  const mcp = json(".codex-plugin/mcp.json") as { mcpServers: Record<string, { command: string; args: string[] }> };
+  const mcp = json(".codex-plugin/mcp.json") as {
+    mcpServers: Record<string, { command: string; args: string[] }>;
+  };
   const entry = mcp.mcpServers["scholar-feed"];
   assert.ok(entry, "mcp.json must declare the scholar-feed server");
   assert.equal(entry.command, "npx");

--- a/src/__tests__/distribution_manifests.test.ts
+++ b/src/__tests__/distribution_manifests.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Distribution-manifest consistency.
+ *
+ * These files are the product's shop windows: every directory listing, plugin
+ * catalogue and one-click installer reads its copy from one of them, and none
+ * of them is exercised by any other test. Two real regressions on 2026-09-06
+ * motivated this file:
+ *
+ *  1. VERSION DRIFT. package.json 3.19.1, server.json 3.9.1, manifest.json
+ *     3.8.0, .claude-plugin 3.7.1 — only server.json was ever synced, so the
+ *     MCPB bundle and the plugin directories shipped a version eleven releases
+ *     stale. `scripts/sync-manifests.mjs` fixes it; this test keeps it fixed.
+ *
+ *  2. RETIRED PRICING. mig 173 replaced the daily caps with a monthly meter
+ *     (200 anon / 500 free / 10,000 Pro), but smithery.yaml, manifest.json and
+ *     the Docker entry still advertised "100 calls/day" and "1,000/day" —
+ *     a free tier ~60x larger than reality. A plain web search for the product
+ *     still returns the retired numbers, because directories are what search
+ *     engines and LLMs read. Copy drift here is public misinformation about
+ *     what the product costs, not a typo.
+ *
+ * The quota numbers below are asserted against backend/api/quotas.py
+ * (ANON_MONTHLY_LIMIT=200, FREE_MONTHLY_LIMIT=500, PRO_MONTHLY_LIMIT=10_000)
+ * and backend/api/metering.py (FREE_MONTHLY_LIMITS.ask_library=20). If the
+ * backend defaults change, this test SHOULD fail — that is the point.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, existsSync } from "node:fs";
+
+const read = (f: string) => readFileSync(f, "utf8");
+const json = (f: string) => JSON.parse(read(f)) as Record<string, unknown>;
+
+const PKG_VERSION = (json("package.json") as { version: string }).version;
+
+/** Every manifest whose `version` must track package.json. */
+const VERSIONED = [
+  "server.json",
+  "manifest.json",
+  ".claude-plugin/plugin.json",
+  ".codex-plugin/plugin.json",
+];
+
+/** Everything a stranger reads before installing. */
+const COPY_SURFACES = [
+  "README.md",
+  "smithery.yaml",
+  "manifest.json",
+  "server.json",
+  ".claude-plugin/plugin.json",
+  ".codex-plugin/plugin.json",
+  "docker-mcp-registry/servers/scholar-feed/server.yaml",
+];
+
+test("every distribution manifest carries the package.json version", () => {
+  for (const file of VERSIONED) {
+    assert.ok(existsSync(file), `${file} is missing`);
+    const doc = json(file) as { version?: string };
+    assert.equal(
+      doc.version,
+      PKG_VERSION,
+      `${file} is at ${doc.version}, package.json is at ${PKG_VERSION}. ` +
+        `Run \`npm run sync:manifests\` (npm version does this automatically).`,
+    );
+  }
+});
+
+test("server.json pins every package reference to the same version", () => {
+  const doc = json("server.json") as { packages?: { version?: string }[] };
+  for (const p of doc.packages ?? []) {
+    assert.equal(
+      p.version,
+      PKG_VERSION,
+      "the MCP Registry validates package version against npm; a mismatch fails the publish",
+    );
+  }
+});
+
+test("no surface advertises the RETIRED daily caps (mig 173 replaced them)", () => {
+  // Matches "100 calls/day", "1,000/day", "1000 calls per day", etc. Deliberately
+  // broad: any daily-cap claim about the free/anon tier is now wrong, because the
+  // daily numbers survive only as an internal burst guardrail we do not advertise.
+  const RETIRED = /\b(100|1,?000)\s*(calls?\s*)?(\/|per\s+)day\b/i;
+  for (const file of COPY_SURFACES) {
+    if (!existsSync(file)) continue;
+    const text = read(file);
+    const hit = text.split("\n").findIndex((l) => RETIRED.test(l));
+    assert.equal(
+      hit,
+      -1,
+      `${file}:${hit + 1} advertises a retired daily cap: "${text.split("\n")[hit]?.trim()}"`,
+    );
+  }
+});
+
+test("the monthly quota is stated correctly wherever quota copy appears", () => {
+  // Only files that actually make a quota claim are checked; a manifest may
+  // legitimately not mention quotas at all.
+  const MENTIONS_QUOTA = /calls?\s*\/\s*month|calls? a month|requests?\/month|per month/i;
+  const CORRECT_ANON = /\b200\b/;
+  const CORRECT_FREE = /\b500\b/;
+
+  let checked = 0;
+  for (const file of COPY_SURFACES) {
+    if (!existsSync(file)) continue;
+    const text = read(file);
+    if (!MENTIONS_QUOTA.test(text)) continue;
+    checked++;
+    assert.match(text, CORRECT_ANON, `${file} states a monthly quota but never mentions 200 (anon)`);
+    assert.match(text, CORRECT_FREE, `${file} states a monthly quota but never mentions 500 (free)`);
+  }
+  assert.ok(checked >= 4, `expected quota copy on at least 4 surfaces, found ${checked}`);
+});
+
+test("README's ask_library allowance matches the backend (20/month free)", () => {
+  const readme = read("README.md");
+  // The README stated BOTH "Free 1/month" and "20/month free" in different
+  // sections; 20 is what metering.FREE_MONTHLY_LIMITS actually enforces.
+  assert.ok(
+    !/free\s*1\s*\/\s*month/i.test(readme),
+    "README still claims a 1/month ask_library allowance; the backend allows 20/month",
+  );
+  assert.match(readme, /20\s*\/\s*month|20\/month/i);
+});
+
+test("the Smithery listing tags its calls with SF_SRC", () => {
+  // Smithery containerises this config and runs the STDIO binary, which is the
+  // path where a server-level SF_SRC is honoured. Without it, our single
+  // largest listing (7,974 uses) is indistinguishable from anonymous traffic.
+  const y = read("smithery.yaml");
+  assert.match(y, /SF_SRC:\s*'smithery'/, "smithery.yaml must set SF_SRC so the channel is attributable");
+});
+
+test("the codex plugin manifest resolves the install URL third parties publish", () => {
+  // awesome-ai-plugins (188 stars) publishes
+  //   install_url: .../HEAD/.codex-plugin/plugin.json
+  // which 404'd until this file existed, breaking one-click install for every
+  // Codex user who found us through that list.
+  assert.ok(existsSync(".codex-plugin/plugin.json"), ".codex-plugin/plugin.json must exist");
+  const plugin = json(".codex-plugin/plugin.json") as { mcpServers?: string };
+  assert.equal(typeof plugin.mcpServers, "string", "codex plugins point mcpServers at a file path");
+  assert.ok(existsSync(plugin.mcpServers!.replace(/^\.\//, "")), "the referenced mcp.json must exist");
+
+  const mcp = json(".codex-plugin/mcp.json") as { mcpServers: Record<string, { command: string; args: string[] }> };
+  const entry = mcp.mcpServers["scholar-feed"];
+  assert.ok(entry, "mcp.json must declare the scholar-feed server");
+  assert.equal(entry.command, "npx");
+  assert.ok(entry.args.includes("scholar-feed-mcp@latest"));
+});

--- a/src/__tests__/worker_entry.test.ts
+++ b/src/__tests__/worker_entry.test.ts
@@ -31,7 +31,8 @@ const ENV = {
   SF_MCP_AUDIENCE: `https://${HOST}/mcp`,
   SF_MCP_RESOURCE_URI: `https://${HOST}/mcp`,
   SF_OAUTH_ISSUER: "https://example.supabase.co/auth/v1",
-  SF_OAUTH_JWKS_URL: "https://example.supabase.co/auth/v1/.well-known/jwks.json",
+  SF_OAUTH_JWKS_URL:
+    "https://example.supabase.co/auth/v1/.well-known/jwks.json",
   SF_OAUTH_ENFORCE_ISSUER: "false",
 } as const;
 
@@ -53,7 +54,10 @@ describe("worker entry — credential resolver selection", () => {
     await assert.rejects(
       () => Promise.resolve(resolver.resolve({ subject: "u-1" } as never)),
       (err: Error) => {
-        assert.match(err.message, new RegExp(UNCONFIGURED_RESOLVER_MESSAGE.slice(0, 20)));
+        assert.match(
+          err.message,
+          new RegExp(UNCONFIGURED_RESOLVER_MESSAGE.slice(0, 20)),
+        );
         return true;
       },
     );
@@ -119,7 +123,10 @@ describe("worker entry — CORS for browser MCP hosts", () => {
     assert.equal(res.status, 204);
     assert.equal(res.headers.get("access-control-allow-origin"), ORIGIN);
     // Without this the browser hides the 401's challenge and OAuth cannot start.
-    assert.equal(res.headers.get("access-control-expose-headers"), "WWW-Authenticate");
+    assert.equal(
+      res.headers.get("access-control-expose-headers"),
+      "WWW-Authenticate",
+    );
     assert.match(res.headers.get("access-control-allow-methods") ?? "", /POST/);
     assert.match(res.headers.get("vary") ?? "", /Origin/);
   });

--- a/src/client.ts
+++ b/src/client.ts
@@ -138,7 +138,7 @@ export function __resetStdioClientName(): void {
  */
 function attributionHeaders(): Record<string, string> {
   const creds = getCurrentCreds();
-  const src = creds ? creds.src : process.env.SF_SRC ?? null;
+  const src = creds ? creds.src : (process.env.SF_SRC ?? null);
   const client = creds ? creds.client : stdioClientName;
   const out: Record<string, string> = {};
   if (src) out["X-SF-Src"] = src;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -458,7 +458,11 @@ export default {
       }
       if (method === "POST") {
         return withCors(
-          await handleMcpPost(request, getVerifier(), getCredentialResolver(env)),
+          await handleMcpPost(
+            request,
+            getVerifier(),
+            getCredentialResolver(env),
+          ),
           request.headers.get("origin"),
         );
       }


### PR DESCRIPTION
An audit of the live listings found the shop windows in worse shape than anything they advertise. Four fixes and a guard.

## 1. Retired pricing, on three surfaces

mig 173 replaced the daily caps with a monthly meter (200 anon / 500 free / 10,000 Pro), but `smithery.yaml`, `manifest.json` and the Docker entry still said **"100 calls/day"** and **"1,000/day"** — a free tier ~60× larger than reality, so the first wall lands far sooner than the listing promises.

🔴 This is not internal untidiness. A plain web search for the product **still returns the retired numbers**, because directories are what search engines and LLMs read. These files are the public answer to "what does Scholar Feed cost."

Also fixed the README contradicting itself on `ask_library` — line 222 said "Free 1/month", line 257 said "20/month". `metering.FREE_MONTHLY_LIMITS` enforces **20**, so 222 was the wrong one.

## 2. Four manifests, four versions

| file | was | now |
|---|---|---|
| package.json | 3.19.1 | — |
| server.json | 3.9.1 | 3.19.1 |
| manifest.json | 3.8.0 | 3.19.1 |
| .claude-plugin/plugin.json | 3.7.1 | 3.19.1 |

Only `server.json` was ever synced, and only inside `publish.yml` at publish time — so the MCPB bundle and the plugin directories shipped a version **eleven releases stale**. `scripts/sync-manifests.mjs` stamps all four, wired as the npm `version` lifecycle script so the sync lands in the release commit the tag points at.

## 3. Smithery is now attributable — the highest-leverage line in the diff

Our largest listing (**7,974 uses**) was indistinguishable from anonymous traffic: Smithery containerises this config and its calls arrive from their IPs untagged, so we could neither confirm nor refute that number.

Smithery runs the **stdio** binary, which is exactly the path where a server-level `SF_SRC` *is* honoured (the client ignores it only when a per-request credential context is present — never on stdio). One env entry converts the channel from a vendor-reported number into a measured one. Verified by evaluating the `commandFunction` both ways:

```
no key:   {"command":"npx","args":[...],"env":{"SF_SRC":"smithery"}}
with key: {"command":"npx","args":[...],"env":{"SF_SRC":"smithery","SF_API_KEY":"sf_abc"}}
```

## 4. The Codex one-click install was broken

`awesome-ai-plugins` (188★, the largest list we appear in) publishes `install_url: …/HEAD/.codex-plugin/plugin.json`, which **404'd** — we only shipped `.claude-plugin/`. Every Codex user who clicked install from that list failed. Added the manifest in the schema their catalogue documents (`mcpServers` as a path to a sibling `mcp.json`).

## Guard

`distribution_manifests.test.ts` asserts version parity, absence of any retired daily-cap claim, correct monthly numbers, the `SF_SRC` tag, and that the codex install path resolves. **Mutation-tested three ways** — reintroduced the pricing, dropped `SF_SRC`, drifted a version — each fails as intended, then green again on restore. It runs in the tagged `verify` job, so a forgotten sync cannot reach npm.

452 tests pass, lint clean, build succeeds.

## One judgment call to review

`plugin-scan.yml` adds a **third-party action**. Every other input to the HOL trust score is already satisfied in this repo (SECURITY.md, LICENSE, dependabot, CODE_OF_CONDUCT, CONTRIBUTING, CodeQL, all actions SHA-pinned), so the flat 10% no-scanner-CI reduction is the only lever left: **trust 72 → ~80**. It is SHA-pinned, `contents: read` only, no secrets, `persist-credentials: false`, and it never runs on the tag path that publishes to npm. Drop the file if that trade isn't worth ~8 points on one directory's score.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1z5bf9WW6z6mD42hcKreb