### PR TITLE
feat(fulltext): expose the six section names, default to all

### DIFF
--- a/src/__tests__/handlers.test.ts
+++ b/src/__tests__/handlers.test.ts
@@ -295,27 +295,48 @@ describe("untrusted-content fencing", () => {
   });
 
   // The default mode is the one step 5 of the deep-research loop uses, and it was
-  // broken on the wire: with `sections` omitted the tool sent NO sections param, so
-  // the documented default was never actually exercised as a request. Assert the
-  // outgoing query string, not just the parsed result — a green result-shape test
-  // could not catch this class of bug.
-  it("fetch_fulltext sends sections=results explicitly when the arg is omitted", async () => {
+  // broken on the wire twice over: with `sections` omitted the tool once sent NO
+  // sections param at all, and then sent "results" — ~800 chars, about 6% of the
+  // paper. Assert the outgoing query string, not just the parsed result — a green
+  // result-shape test could not catch either bug.
+  it("fetch_fulltext sends sections=all explicitly when the arg is omitted", async () => {
     const { url } = await invoke(
       "fetch_fulltext",
       { arxiv_id: "1706.03762" },
       {
         json: {
           arxiv_id: "1706.03762",
-          results_text: "28.4 BLEU",
-          source: "pdf",
+          sections: { results: "28.4 BLEU" },
+          available_sections: ["results"],
+          source: "latexml_html",
         },
       },
     );
     assert.strictEqual(
       url?.searchParams.get("sections"),
-      "results",
+      "all",
       "default mode must be explicit on the wire, not left to a backend fallback",
     );
+  });
+
+  // A named section must reach the backend verbatim — that projection is the whole
+  // point of section-aware retrieval, and silently widening it to "all" would blow
+  // up the payload an agent deliberately kept small.
+  it("fetch_fulltext forwards a single named section", async () => {
+    const { url } = await invoke(
+      "fetch_fulltext",
+      { arxiv_id: "1706.03762", sections: "method" },
+      {
+        json: {
+          arxiv_id: "1706.03762",
+          requested_section: "method",
+          sections: { method: "The Transformer follows this overall architecture…" },
+          available_sections: ["abstract", "introduction", "method", "results"],
+          source: "latexml_html",
+        },
+      },
+    );
+    assert.strictEqual(url?.searchParams.get("sections"), "method");
   });
 
   it("fetch_fulltext forwards an explicit sections=all", async () => {

--- a/src/tools/_output.ts
+++ b/src/tools/_output.ts
@@ -250,7 +250,25 @@ export const fulltextOutput = looseObject({
     })
     .catchall(z.unknown())
     .optional()
-    .describe("Per-section text (sections='all')."),
+    .describe(
+      "Per-section text. All six canonical keys are present; a null value means the paper has no such section.",
+    ),
+  available_sections: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Which sections this paper actually has. Lets a caller tell 'no related-work section' apart from 'extraction failed'.",
+    ),
+  requested_section: z.string().optional(),
+  requested_section_available: z
+    .boolean()
+    .optional()
+    .describe("False when the requested section does not exist in this paper."),
+  note: z.string().optional(),
+  full_text: z
+    .string()
+    .optional()
+    .describe("Unstructured backup text, present only on the PDF fallback path."),
   table_captions: z.array(z.string()).optional(),
 });
 

--- a/src/tools/fulltext.ts
+++ b/src/tools/fulltext.ts
@@ -1,13 +1,18 @@
 /**
- * fetch_fulltext tool — extract paper content from arXiv LaTeX source (PDF fallback).
+ * fetch_fulltext tool — section-typed paper content from arXiv.
  *
  * Endpoint: GET /public/papers/{arxiv_id}/fulltext
  *
- * The `sections` param is sent EXPLICITLY (default "results") rather than omitted.
- * Relying on the backend's implicit default meant the wire request carried no
- * `sections` at all, so the tool's documented default and the served behavior could
- * drift apart silently — which is exactly what happened when the LaTeX path broke and
- * the default mode 404'd on every paper while `sections=all` kept working.
+ * The `sections` param is sent EXPLICITLY rather than omitted. Relying on the
+ * backend's implicit default meant the wire request carried no `sections` at all,
+ * so the tool's documented default and the served behavior could drift apart
+ * silently — which is exactly what happened when the LaTeX path broke and the
+ * default mode 404'd on every paper while `sections=all` kept working.
+ *
+ * The default is "all". It used to be "results", which served ~800 chars — about
+ * 6% of the available text — and the description then told agents not to ask for
+ * more. Backing the endpoint with arXiv's LaTeXML HTML made the full-section path
+ * as cheap as the lean one, so there is no longer a reason to ration it.
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -24,14 +29,22 @@ export function register(server: McpServer): void {
       annotations: { readOnlyHint: true, destructiveHint: false },
       outputSchema: fulltextOutput,
       description:
-        "Extract paper content from an arXiv paper's LaTeX source, falling back to PDF text. Two modes: 'results' (default) returns ~800 chars of results/experiments + up to 3 table captions — lean, ideal for checking a reported number. 'all' returns full paper sections (abstract, introduction, related work, method, results, conclusion) at up to 3000 chars each + 5 table captions, ~15KB, so prefer 'results' unless you need the whole paper. Content is available for ~95% of arXiv papers; a 404 means neither LaTeX nor PDF extraction yielded text. May take a few seconds.",
+        "Read an arXiv paper's actual text, by section. Default 'all' returns every section it has — abstract, introduction, related_work, method, results, conclusion — at up to 3000 chars each plus figure/table captions. Pass a single section name to read just that one: 'method' for how it works, 'results' for the numbers it reports, 'related_work' for what it positions against. Every response lists `available_sections`, so if a paper has no related-work or results section (common in theory papers) you get that stated explicitly along with the sections it does have, not an empty answer. Sourced from arXiv's section-tagged HTML, falling back to LaTeX source then PDF text; a 404 means all three failed.",
       inputSchema: {
         arxiv_id: z.string().min(1).describe("arXiv ID of the paper"),
         sections: z
-          .enum(["results", "all"])
+          .enum([
+            "all",
+            "abstract",
+            "introduction",
+            "related_work",
+            "method",
+            "results",
+            "conclusion",
+          ])
           .optional()
           .describe(
-            "'results' (default): lean ~800-char results/experiments excerpt + table captions. 'all': full paper (abstract, intro, method, results, conclusion, related work) — much larger payload.",
+            "Which section to return. 'all' (default) returns every section the paper has. Name a single section to read just that one — cheaper, and enough when you only need the method or the reported numbers.",
           ),
       },
     },
@@ -41,7 +54,7 @@ export function register(server: McpServer): void {
         // default instead of depending on the backend's implicit fallback.
         const result = await client.get<unknown>(
           `/public/papers/${encodeURIComponent(arxiv_id)}/fulltext`,
-          { sections: sections ?? "results" },
+          { sections: sections ?? "all" },
         );
         return {
           content: [


### PR DESCRIPTION
Pairs with scholar-feed#194, which backs the endpoint with arXiv's section-tagged LaTeXML HTML (89.2% of the corpus) instead of a regex over the e-print tarball.

- Widens the `sections` enum from `["results","all"]` to the six section names plus `all`, so an agent can ask for the method or the reported numbers without paying for the whole paper.
- **Flips the default from `results` to `all`.** The old default served ~800 chars — about 6% of the available text — and the description then said *"prefer 'results' unless you need the whole paper"*, so a model reading a paper got ~150 words and was steered away from asking for more. The HTML layer made the full-section path as cheap as the lean one, so the rationing no longer bought anything.
- Output schema gains `available_sections`, `requested_section`, `requested_section_available`, `note`, `full_text` — what lets a caller distinguish "this paper has no related-work section" (true for roughly a third of arXiv) from "extraction failed". Previously both looked like an empty payload.

The wire-explicitness test keeps its intent (the default must appear in the query string, not be left to a backend fallback) and only changes the expected value. Adds a test that a single named section is forwarded verbatim rather than silently widened.

⚠️ Merge **after** scholar-feed#194 is deployed — the new response fields come from the backend.

453 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQR5ZFSGvwjpMXsNirxRaZ